### PR TITLE
add missing path_id getter to Ipv6MplsVpnUnicastAddress

### DIFF
--- a/crates/bgp-pkt/src/nlri.rs
+++ b/crates/bgp-pkt/src/nlri.rs
@@ -423,6 +423,10 @@ impl Ipv6MplsVpnUnicastAddress {
     pub const fn network(&self) -> &Ipv6Unicast {
         &self.network
     }
+
+    pub const fn path_id(&self) -> Option<u32> {
+        self.path_id
+    }
 }
 
 impl NlriAddressType for Ipv6MplsVpnUnicastAddress {


### PR DESCRIPTION
* adds a missing `path_id(&self)` getter method to Ipv6MplsVpnUnicastAddress
* moves the bmp per peer header flags into u8 logic to a `get_flags_value(&self)` getter method of `BmpPeerType`