### PR TITLE
derive Copy on Community(u32)

### DIFF
--- a/crates/bgp-pkt/src/community.rs
+++ b/crates/bgp-pkt/src/community.rs
@@ -22,7 +22,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 /// Four octet values to specify a community.
 ///
 /// See [RFC1997](https://datatracker.ietf.org/doc/html/rfc1997)
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Community(u32);
 
 impl Community {


### PR DESCRIPTION
Community is just a u32 an is missing the Copy derive
LargeCommunity is larger in size and still has it for example