### PR TITLE
Annotate BMP and BGP packates for fuzzing

### DIFF
--- a/crates/bgp-pkt/Cargo.toml
+++ b/crates/bgp-pkt/Cargo.toml
@@ -26,12 +26,13 @@ nom = { workspace = true, optional = true }
 byteorder = { workspace = true, optional = true }
 criterion = { workspace = true, optional = true } # Dev dep for bench
 arbitrary = { workspace = true, optional = true }
+arbitrary_ext = { workspace = true, optional = true }
 
 [features]
 default = ["serde"]
 serde = ["nom", "byteorder", "netgauze-locate", "netgauze-parse-utils", "netgauze-serde-macros"]
 bench = ["criterion"]
-fuzz = ["arbitrary"]
+fuzz = ["arbitrary", "arbitrary_ext"]
 
 
 [dev-dependencies]

--- a/crates/bgp-pkt/README.md
+++ b/crates/bgp-pkt/README.md
@@ -147,5 +147,18 @@ pub fn main() {
 
 # Development documentation
 
-*Running Packet Serde benchmarks*
-```cargo bench --features bench```
+* Running Packet Serde benchmarks*
+  ```cargo bench --features bench```
+
+* Using this library to fuzz other code accepting `BgpMessage`
+
+```rust
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use netgauze_bgp_pkt::BgpMessage;
+
+fuzz_target!(|data: BgpMessage| {
+    // Some fuzzing target that accepts BgpMessage as input and need to be fuzzed
+});
+```

--- a/crates/bgp-pkt/src/capabilities.rs
+++ b/crates/bgp-pkt/src/capabilities.rs
@@ -62,6 +62,7 @@ pub(crate) const BGP_ROLE_CAPABILITY_LENGTH: u8 = 1;
 /// +------------------------------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpCapability {
     /// Defined in [RFC4760](https://datatracker.ietf.org/doc/html/rfc4760)
     MultiProtocolExtensions(MultiProtocolExtensionsCapability),
@@ -168,6 +169,7 @@ impl BgpCapability {
 /// Generic struct to carry all the unsupported BGP capabilities
 #[repr(C)]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UnrecognizedCapability {
     code: u8,
     value: Vec<u8>,
@@ -190,6 +192,7 @@ impl UnrecognizedCapability {
 /// Experimental Capabilities Codes as defined by [RFC8810](https://datatracker.ietf.org/doc/html/RFC8810)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum ExperimentalCapabilityCode {
     Experimental239 = 239,
     Experimental240 = 240,
@@ -212,6 +215,7 @@ pub enum ExperimentalCapabilityCode {
 /// Generic struct to carry all capabilities that are designated as experimental
 /// by IANA See [RFC8810](https://datatracker.ietf.org/doc/html/RFC8810)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExperimentalCapability {
     code: ExperimentalCapabilityCode,
     value: Vec<u8>,
@@ -241,6 +245,7 @@ impl ExperimentalCapability {
 /// +-------+-------+-------+-------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct MultiProtocolExtensionsCapability {
     address_type: AddressType,
 }
@@ -257,6 +262,7 @@ impl MultiProtocolExtensionsCapability {
 
 /// Defined in [RFC6793](https://datatracker.ietf.org/doc/html/rfc6793)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct FourOctetAsCapability {
     asn4: u32,
 }
@@ -274,6 +280,7 @@ impl FourOctetAsCapability {
 /// Defined in [RFC4724](https://datatracker.ietf.org/doc/html/rfc4724)
 /// and [RFC8538](https://datatracker.ietf.org/doc/html/rfc8538)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct GracefulRestartCapability {
     restart: bool,
     graceful_notification: bool,
@@ -314,6 +321,7 @@ impl GracefulRestartCapability {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct GracefulRestartAddressFamily {
     forwarding_state: bool,
     address_type: AddressType,
@@ -341,6 +349,7 @@ impl GracefulRestartAddressFamily {
 ///
 /// See [RFC7911](https://datatracker.ietf.org/doc/html/RFC7911)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct AddPathCapability {
     address_families: Vec<AddPathAddressFamily>,
 }
@@ -366,6 +375,7 @@ impl AddPathCapability {
 /// +------------------------------------------------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct AddPathAddressFamily {
     address_type: AddressType,
     send: bool,
@@ -421,6 +431,7 @@ impl AddPathAddressFamily {
 /// +-----------------------------------------------------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExtendedNextHopEncodingCapability {
     encodings: Vec<ExtendedNextHopEncoding>,
 }
@@ -447,6 +458,7 @@ impl ExtendedNextHopEncodingCapability {
 /// +-----------------------------------------------------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExtendedNextHopEncoding {
     address_type: AddressType,
     next_hop_afi: AddressFamily,
@@ -479,6 +491,7 @@ impl ExtendedNextHopEncoding {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct MultipleLabel {
     address_type: AddressType,
     count: u8,
@@ -504,6 +517,7 @@ impl MultipleLabel {
 /// BGP Role used in the route leak prevention and detection procedures
 /// defined by: [RFC9234](https://datatracker.ietf.org/doc/html/rfc9234)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct BgpRoleCapability {
     role: BgpRoleValue,
 }

--- a/crates/bgp-pkt/src/community.rs
+++ b/crates/bgp-pkt/src/community.rs
@@ -15,6 +15,8 @@
 
 //! Representations for normal, extended, and large BGP Communities.
 
+#[cfg(feature = "fuzz")]
+use crate::{arbitrary_ipv4, arbitrary_ipv6};
 use crate::{iana::WellKnownCommunity, nlri::MacAddress};
 use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -23,6 +25,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 ///
 /// See [RFC1997](https://datatracker.ietf.org/doc/html/rfc1997)
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Community(u32);
 
 impl Community {
@@ -68,6 +71,7 @@ impl Community {
 /// Local Data Part 1:  A four-octet operator-defined value.
 /// Local Data Part 2:  A four-octet operator-defined value.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct LargeCommunity {
     global_admin: u32,
     local_data1: u32,
@@ -121,6 +125,7 @@ pub trait ExtendedCommunityProperties {
 ///
 /// See [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum ExtendedCommunity {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     TransitiveTwoOctet(TransitiveTwoOctetExtendedCommunity),
@@ -189,6 +194,7 @@ impl ExtendedCommunityProperties for ExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveTwoOctetExtendedCommunity {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteTarget {
@@ -266,6 +272,7 @@ impl ExtendedCommunityProperties for TransitiveTwoOctetExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum NonTransitiveTwoOctetExtendedCommunity {
     LinkBandwidth {
         global_admin: u16,
@@ -293,6 +300,7 @@ impl ExtendedCommunityProperties for NonTransitiveTwoOctetExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveFourOctetExtendedCommunity {
     /// [RFC5668](https://datatracker.ietf.org/doc/html/rfc5668)
     RouteTarget {
@@ -359,6 +367,7 @@ impl ExtendedCommunityProperties for TransitiveFourOctetExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum NonTransitiveFourOctetExtendedCommunity {
     Unassigned {
         sub_type: u8,
@@ -378,97 +387,114 @@ impl ExtendedCommunityProperties for NonTransitiveFourOctetExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveIpv4ExtendedCommunity {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteTarget {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteOrigin {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [draft-ietf-idr-bgp-ifit-capabilities](https://datatracker.ietf.org/doc/draft-ietf-idr-bgp-ifit-capabilities)
     Ipv4Ifit {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [RFC4577](https://datatracker.ietf.org/doc/html/rfc4577)
     OspfDomainIdentifier {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [RFC4577](https://datatracker.ietf.org/doc/html/rfc4577)
     OspfRouteID {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [draft-dong-idr-node-target-ext-comm](https://datatracker.ietf.org/doc/draft-dong-idr-node-target-ext-comm)
     NodeTarget {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [RFC6074](https://datatracker.ietf.org/doc/html/rfc6074)
     L2VpnIdentifier {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [RFC6514](https://datatracker.ietf.org/doc/html/rfc6514)
     VrfRouteImport {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [draft-ietf-idr-flowspec-redirect](https://datatracker.ietf.org/doc/html/draft-ietf-idr-flowspec-redirect)
     FlowSpecRedirectToIpv4 {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     CiscoVpnDistinguisher {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [RFC7524](https://datatracker.ietf.org/doc/rfc7524)
     InterAreaP2MpSegmentedNextHop {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [draft-ietf-bess-service-chaining](https://datatracker.ietf.org/doc/draft-ietf-bess-service-chaining/)
     RouteTargetRecord {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     VrfRecursiveNextHop {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [draft-zzhang-idr-rt-derived-community](https://datatracker.ietf.org/doc/draft-zzhang-idr-rt-derived-community/)
     RtDerivedEc {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     /// [RFC9081](https://datatracker.ietf.org/doc/rfc9081)
     MulticastVpnRpAddress {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
 
     Unassigned {
         sub_type: u8,
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
@@ -485,9 +511,11 @@ impl ExtendedCommunityProperties for TransitiveIpv4ExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum NonTransitiveIpv4ExtendedCommunity {
     Unassigned {
         sub_type: u8,
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         global_admin: Ipv4Addr,
         local_admin: u16,
     },
@@ -504,6 +532,7 @@ impl ExtendedCommunityProperties for NonTransitiveIpv4ExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveOpaqueExtendedCommunity {
     /// The Default Gateway community  It is a transitive community,
     /// which means that the first octet is 0x03.  The value of the second
@@ -529,6 +558,7 @@ impl ExtendedCommunityProperties for TransitiveOpaqueExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum NonTransitiveOpaqueExtendedCommunity {
     Unassigned { sub_type: u8, value: [u8; 6] },
 }
@@ -544,6 +574,7 @@ impl ExtendedCommunityProperties for NonTransitiveOpaqueExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExperimentalExtendedCommunity {
     code: u8,
     sub_type: u8,
@@ -583,6 +614,7 @@ impl ExtendedCommunityProperties for ExperimentalExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UnknownExtendedCommunity {
     code: u8,
     sub_type: u8,
@@ -640,6 +672,7 @@ impl ExtendedCommunityProperties for UnknownExtendedCommunity {
 ///
 /// See [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum ExtendedCommunityIpv6 {
     /// [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
     TransitiveIpv6(TransitiveIpv6ExtendedCommunity),
@@ -669,21 +702,25 @@ impl ExtendedCommunityProperties for ExtendedCommunityIpv6 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveIpv6ExtendedCommunity {
     /// [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
     RouteTarget {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
 
     /// [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
     RouteOrigin {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
 
     /// [draft-ietf-idr-bgp-ifit-capabilities](https://datatracker.ietf.org/doc/draft-ietf-idr-bgp-ifit-capabilities)
     Ipv6Ifit {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
@@ -691,41 +728,48 @@ pub enum TransitiveIpv6ExtendedCommunity {
     /// [RFC6515](https://datatracker.ietf.org/doc/html/rfc6515) and
     /// [RFC6514](https://datatracker.ietf.org/doc/html/rfc6514)
     VrfRouteImport {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
 
     /// [draft-ietf-idr-flowspec-redirect](https://datatracker.ietf.org/doc/html/draft-ietf-idr-flowspec-redirect)
     FlowSpecRedirectToIpv6 {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
 
     /// [RFC8956](https://datatracker.ietf.org/doc/html/rfc8956)
     FlowSpecRtRedirectToIpv6 {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
 
     CiscoVpnDistinguisher {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
 
     /// [RFC7524](https://datatracker.ietf.org/doc/rfc7524)
     InterAreaP2MpSegmentedNextHop {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
 
     /// [draft-zzhang-idr-rt-derived-community](https://datatracker.ietf.org/doc/draft-zzhang-idr-rt-derived-community/)
     RtDerivedEc {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
 
     Unassigned {
         sub_type: u8,
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
@@ -742,9 +786,11 @@ impl ExtendedCommunityProperties for TransitiveIpv6ExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum NonTransitiveIpv6ExtendedCommunity {
     Unassigned {
         sub_type: u8,
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         global_admin: Ipv6Addr,
         local_admin: u16,
     },
@@ -761,6 +807,7 @@ impl ExtendedCommunityProperties for NonTransitiveIpv6ExtendedCommunity {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UnknownExtendedCommunityIpv6 {
     code: u8,
     sub_type: u8,
@@ -800,6 +847,7 @@ impl ExtendedCommunityProperties for UnknownExtendedCommunityIpv6 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum EvpnExtendedCommunity {
     /// MAC Mobility extended community
     /// ```text

--- a/crates/bgp-pkt/src/iana.rs
+++ b/crates/bgp-pkt/src/iana.rs
@@ -21,6 +21,7 @@ use strum_macros::{Display, FromRepr};
 /// BGP Message types as registered in IANA [BGP Message Types](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-1)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpMessageType {
     Open = 1,
     Update = 2,
@@ -33,6 +34,7 @@ pub enum BgpMessageType {
 /// BGP Message type is not one of [`BgpMessageType`], the carried value is the
 /// undefined code.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedBgpMessageType(pub u8);
 
 impl From<BgpMessageType> for u8 {
@@ -55,6 +57,7 @@ impl TryFrom<u8> for BgpMessageType {
 /// BGP Path Attributes as defined by IANA [BGP Path Attributes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-2)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum PathAttributeType {
     /// [RFC4271](https://datatracker.ietf.org/doc/html/rfc4271)
     Origin = 1,
@@ -157,6 +160,7 @@ impl From<PathAttributeType> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedPathAttributeType(pub u8);
 
 impl TryFrom<u8> for PathAttributeType {
@@ -173,6 +177,7 @@ impl TryFrom<u8> for PathAttributeType {
 /// BGP Error (Notification) Codes as defined by IANA [BGP Error (Notification) Codes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-3)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpErrorNotificationCode {
     /// [RFC4271](https://datatracker.ietf.org/doc/html/rfc4271)
     MessageHeaderError = 1,
@@ -203,6 +208,7 @@ impl From<BgpErrorNotificationCode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedBgpErrorNotificationCode(pub u8);
 
 impl TryFrom<u8> for BgpErrorNotificationCode {
@@ -219,6 +225,7 @@ impl TryFrom<u8> for BgpErrorNotificationCode {
 /// Message Header Error sub-codes for [`BgpErrorNotificationCode::MessageHeaderError`] as defined by IANA [Message Header Error subcodes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-5)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum MessageHeaderErrorSubCode {
     /// [RFC Errata 4493](https://www.rfc-editor.org/errata_search.php?eid=4493)
     Unspecific = 0,
@@ -234,6 +241,7 @@ impl From<MessageHeaderErrorSubCode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedMessageHeaderErrorSubCode(pub u8);
 
 impl TryFrom<u8> for MessageHeaderErrorSubCode {
@@ -250,6 +258,7 @@ impl TryFrom<u8> for MessageHeaderErrorSubCode {
 /// OPEN Message Error sub-codes for [`BgpErrorNotificationCode::OpenMessageError`] as defined by IANA [OPEN Message Error subcodes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-6)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum OpenMessageErrorSubCode {
     /// [RFC Errata 4493](https://www.rfc-editor.org/errata_search.php?eid=4493)
     Unspecific = 0,
@@ -273,6 +282,7 @@ impl From<OpenMessageErrorSubCode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedOpenMessageErrorSubCode(pub u8);
 
 impl TryFrom<u8> for OpenMessageErrorSubCode {
@@ -289,6 +299,7 @@ impl TryFrom<u8> for OpenMessageErrorSubCode {
 /// UPDATE Message Error sub-codes for [`BgpErrorNotificationCode::UpdateMessageError`] as defined by IANA [UPDATE Message Error subcodes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-7)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum UpdateMessageErrorSubCode {
     /// [RFC Errata 4493](https://www.rfc-editor.org/errata_search.php?eid=4493)
     Unspecific = 0,
@@ -311,6 +322,7 @@ impl From<UpdateMessageErrorSubCode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedUpdateMessageErrorSubCode(pub u8);
 
 impl TryFrom<u8> for UpdateMessageErrorSubCode {
@@ -327,6 +339,7 @@ impl TryFrom<u8> for UpdateMessageErrorSubCode {
 /// BGP Finite State Machine Error sub-codes for [`BgpErrorNotificationCode::FiniteStateMachineError`] as defined by IANA [BGP Finite State Machine Error Subcodes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-finite-state-machine-error-subcodes)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum FiniteStateMachineErrorSubCode {
     /// [RFC6608](https://datatracker.ietf.org/doc/html/rfc6608)
     UnspecifiedError = 0,
@@ -348,6 +361,7 @@ impl From<FiniteStateMachineErrorSubCode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedFiniteStateMachineErrorSubCode(pub u8);
 
 impl TryFrom<u8> for FiniteStateMachineErrorSubCode {
@@ -364,6 +378,7 @@ impl TryFrom<u8> for FiniteStateMachineErrorSubCode {
 /// BGP Cease NOTIFICATION message Error sub-codes for [`BgpErrorNotificationCode::Cease]` as defined by IANA [BGP Cease NOTIFICATION message subcodes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-8)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum CeaseErrorSubCode {
     /// [RFC4486](https://datatracker.ietf.org/doc/html/rfc4486)
     MaximumNumberOfPrefixesReached = 1,
@@ -403,6 +418,7 @@ impl From<CeaseErrorSubCode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedCeaseErrorSubCode(pub u8);
 
 impl TryFrom<u8> for CeaseErrorSubCode {
@@ -419,6 +435,7 @@ impl TryFrom<u8> for CeaseErrorSubCode {
 /// BGP ROUTE-REFRESH Message Error subcodes for [`BgpErrorNotificationCode::RouteRefreshMessageError`] as defined by IANA [BGP ROUTE-REFRESH Message Error subcodes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#route-refresh-error-subcodes)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum RouteRefreshMessageErrorSubCode {
     /// [RFC7313](https://datatracker.ietf.org/doc/html/rfc7313)
     InvalidMessageLength = 1,
@@ -431,6 +448,7 @@ impl From<RouteRefreshMessageErrorSubCode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedRouteRefreshMessageError(pub u8);
 
 impl TryFrom<u8> for RouteRefreshMessageErrorSubCode {
@@ -447,6 +465,7 @@ impl TryFrom<u8> for RouteRefreshMessageErrorSubCode {
 /// [BGP OPEN Optional Parameter Types](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-11)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpOpenMessageParameterType {
     /// [RFC5492](https://datatracker.ietf.org/doc/html/rfc5492)
     Capability = 2,
@@ -462,6 +481,7 @@ impl From<BgpOpenMessageParameterType> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedBgpOpenMessageParameterType(pub u8);
 
 impl TryFrom<u8> for BgpOpenMessageParameterType {
@@ -588,6 +608,7 @@ impl From<BgpCapabilityCode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedBgpCapabilityCode(pub u8);
 
 impl TryFrom<u8> for BgpCapabilityCode {
@@ -604,6 +625,7 @@ impl TryFrom<u8> for BgpCapabilityCode {
 /// [BGP Route Refresh Subcodes](https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#route-refresh-subcodes)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum RouteRefreshSubcode {
     NormalRequest = 0,
     BeginningOfRouteRefresh = 1,
@@ -617,6 +639,7 @@ impl From<RouteRefreshSubcode> for u8 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedRouteRefreshSubcode(pub u8);
 
 impl TryFrom<u8> for RouteRefreshSubcode {
@@ -633,6 +656,7 @@ impl TryFrom<u8> for RouteRefreshSubcode {
 /// [Route Distinguisher Type Field](https://www.iana.org/assignments/route-distinguisher-types/route-distinguisher-types.xhtml)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum RouteDistinguisherTypeCode {
     As2Administrator = 0,
     Ipv4Administrator = 1,
@@ -648,6 +672,7 @@ impl From<RouteDistinguisherTypeCode> for u16 {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedRouteDistinguisherTypeCode(pub u16);
 
 impl TryFrom<u16> for RouteDistinguisherTypeCode {
@@ -672,6 +697,7 @@ impl TryFrom<u16> for RouteDistinguisherTypeCode {
 /// the RFC.
 #[repr(u32)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum WellKnownCommunity {
     /// [RFC8326](https://datatracker.ietf.org/doc/html/rfc8326)
     GracefulShutdown = 0xFFFF0000,
@@ -701,6 +727,7 @@ pub enum WellKnownCommunity {
 /// collectors defined by [RFC4384](https://datatracker.ietf.org/doc/html/rfc4384)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpDataCollectionCommunityValueCode {
     CustomerRoutes = 0b0000000000000001,
     PeerRoutes = 0b0000000000000010,
@@ -715,6 +742,7 @@ pub enum BgpDataCollectionCommunityValueCode {
 /// Region Identifiers defined [RFC4384](https://datatracker.ietf.org/doc/html/rfc4384)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpDataCollectionCommunityRegionIdentifierCode {
     Africa = 0b00001,
     Oceania = 0b00010,
@@ -727,6 +755,7 @@ pub enum BgpDataCollectionCommunityRegionIdentifierCode {
 
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpExtendedCommunityType {
     /// [RFC7153](https://datatracker.ietf.org/doc/html/rfc7153)
     TransitiveTwoOctet = 0x00,
@@ -854,6 +883,7 @@ pub enum BgpExtendedCommunityType {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedBgpExtendedCommunityType(pub u8);
 
 impl TryFrom<u8> for BgpExtendedCommunityType {
@@ -869,6 +899,7 @@ impl TryFrom<u8> for BgpExtendedCommunityType {
 
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpExtendedCommunityIpv6Type {
     /// [RFC7153](https://datatracker.ietf.org/doc/html/rfc7153)
     TransitiveIpv6 = 0x00,
@@ -878,6 +909,7 @@ pub enum BgpExtendedCommunityIpv6Type {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedBgpExtendedCommunityIpv6Type(pub u8);
 
 impl TryFrom<u8> for BgpExtendedCommunityIpv6Type {
@@ -893,6 +925,7 @@ impl TryFrom<u8> for BgpExtendedCommunityIpv6Type {
 
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveTwoOctetExtendedCommunitySubType {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteTarget = 0x02,
@@ -923,6 +956,7 @@ pub enum TransitiveTwoOctetExtendedCommunitySubType {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedTransitiveTwoOctetExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveTwoOctetExtendedCommunitySubType {
@@ -938,6 +972,7 @@ impl TryFrom<u8> for TransitiveTwoOctetExtendedCommunitySubType {
 
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum NonTransitiveTwoOctetExtendedCommunitySubType {
     /// [draft-ietf-idr-link-bandwidth](https://datatracker.ietf.org/doc/draft-ietf-idr-link-bandwidth/)
     LinkBandwidth = 0x04,
@@ -947,6 +982,7 @@ pub enum NonTransitiveTwoOctetExtendedCommunitySubType {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedNonTransitiveTwoOctetExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for NonTransitiveTwoOctetExtendedCommunitySubType {
@@ -964,6 +1000,7 @@ impl TryFrom<u8> for NonTransitiveTwoOctetExtendedCommunitySubType {
 
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveFourOctetExtendedCommunitySubType {
     /// [RFC5668](https://datatracker.ietf.org/doc/html/rfc5668)
     RouteTarget = 0x02,
@@ -990,6 +1027,7 @@ pub enum TransitiveFourOctetExtendedCommunitySubType {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedTransitiveFourOctetExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveFourOctetExtendedCommunitySubType {
@@ -1005,6 +1043,7 @@ impl TryFrom<u8> for TransitiveFourOctetExtendedCommunitySubType {
 
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveIpv4ExtendedCommunitySubType {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteTarget = 0x02,
@@ -1050,6 +1089,7 @@ pub enum TransitiveIpv4ExtendedCommunitySubType {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedTransitiveIpv4ExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveIpv4ExtendedCommunitySubType {
@@ -1065,6 +1105,7 @@ impl TryFrom<u8> for TransitiveIpv4ExtendedCommunitySubType {
 
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveIpv6ExtendedCommunitySubType {
     /// [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
     RouteTarget = 0x02,
@@ -1095,6 +1136,7 @@ pub enum TransitiveIpv6ExtendedCommunitySubType {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedTransitiveIpv6ExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveIpv6ExtendedCommunitySubType {
@@ -1111,6 +1153,7 @@ impl TryFrom<u8> for TransitiveIpv6ExtendedCommunitySubType {
 /// EVPN Route Types [RFC7432](https://datatracker.ietf.org/doc/html/rfc7432)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum L2EvpnRouteTypeCode {
     /// [RFC7432](https://datatracker.ietf.org/doc/html/rfc7432)
     EthernetAutoDiscovery = 0x01,
@@ -1138,6 +1181,7 @@ pub enum L2EvpnRouteTypeCode {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedL2EvpnRouteTypeCode(pub u8);
 
 impl TryFrom<u8> for L2EvpnRouteTypeCode {
@@ -1154,6 +1198,7 @@ impl TryFrom<u8> for L2EvpnRouteTypeCode {
 /// EVPN Extended Community Sub-Types [IANA](https://www.iana.org/assignments/bgp-extended-communities/bgp-extended-communities.xhtml#evpn)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum EvpnExtendedCommunitySubType {
     /// [RFC7432](https://datatracker.ietf.org/doc/html/rfc7432)
     MacMobility = 0x00,
@@ -1196,6 +1241,7 @@ pub enum EvpnExtendedCommunitySubType {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedEvpnExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for EvpnExtendedCommunitySubType {
@@ -1212,12 +1258,14 @@ impl TryFrom<u8> for EvpnExtendedCommunitySubType {
 /// Transitive Opaque Extended Community Sub-Types [IANA](https://www.iana.org/assignments/bgp-extended-communities/bgp-extended-communities.xhtml#trans-opaque)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TransitiveOpaqueExtendedCommunitySubType {
     /// [RFC7432](https://datatracker.ietf.org/doc/html/rfc7432)
     DefaultGateway = 0x0d,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedTransitiveOpaqueExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveOpaqueExtendedCommunitySubType {
@@ -1235,6 +1283,7 @@ impl TryFrom<u8> for TransitiveOpaqueExtendedCommunitySubType {
 /// [RFC9234](https://datatracker.ietf.org/doc/html/rfc9234)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpRoleValue {
     /// The local AS is a transit provider of the remote AS
     Provider = 0x00,

--- a/crates/bgp-pkt/src/nlri.rs
+++ b/crates/bgp-pkt/src/nlri.rs
@@ -17,6 +17,8 @@
 //! (`NLRI`)
 
 use crate::iana::{L2EvpnRouteTypeCode, RouteDistinguisherTypeCode};
+#[cfg(feature = "fuzz")]
+use crate::{arbitrary_ip, arbitrary_ipv4, arbitrary_ipv4net, arbitrary_ipv6, arbitrary_ipv6net};
 use ipnet::{Ipv4Net, Ipv6Net};
 use netgauze_iana::address_family::AddressType;
 use serde::{Deserialize, Serialize};
@@ -29,6 +31,7 @@ pub trait NlriAddressType {
 
 /// Temporary representation of MPLS Labels
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct MplsLabel([u8; 3]);
 
 impl MplsLabel {
@@ -62,7 +65,11 @@ pub enum RouteDistinguisher {
     /// The Value field consists of two subfields:
     ///     - Administrator subfield: Ipv4 address
     ///     - Assigned Number subfield: 2 bytes
-    Ipv4Administrator { ip: Ipv4Addr, number: u16 },
+    Ipv4Administrator {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
+        ip: Ipv4Addr,
+        number: u16,
+    },
 
     /// The Value field consists of two subfields:
     ///     - Administrator subfield: ASN4
@@ -86,8 +93,10 @@ impl RouteDistinguisher {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct LabeledIpv4NextHop {
     rd: RouteDistinguisher,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
     next_hop: Ipv4Addr,
 }
 
@@ -106,8 +115,10 @@ impl LabeledIpv4NextHop {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct LabeledIpv6NextHop {
     rd: RouteDistinguisher,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
     next_hop: Ipv6Addr,
 }
 
@@ -126,6 +137,7 @@ impl LabeledIpv6NextHop {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum LabeledNextHop {
     Ipv4(LabeledIpv4NextHop),
     Ipv6(LabeledIpv6NextHop),
@@ -134,11 +146,16 @@ pub enum LabeledNextHop {
 /// A more restricted version of [`Ipv4Net`] that allows only unicast
 /// networks
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Ipv4Unicast(Ipv4Net);
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct Ipv4Unicast(#[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4net))] Ipv4Net);
 
 /// Raised when the network is not a unicast range
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
-pub struct InvalidIpv4UnicastNetwork(pub Ipv4Net);
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+
+pub struct InvalidIpv4UnicastNetwork(
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4net))] pub Ipv4Net,
+);
 
 impl Ipv4Unicast {
     pub fn from_net(net: Ipv4Net) -> Result<Self, InvalidIpv4UnicastNetwork> {
@@ -168,6 +185,7 @@ impl TryFrom<Ipv4Net> for Ipv4Unicast {
 
 /// Ipv4 Network address in NLRI
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ipv4UnicastAddress {
     path_id: Option<u32>,
     network: Ipv4Unicast,
@@ -201,6 +219,7 @@ impl NlriAddressType for Ipv4UnicastAddress {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ipv4MplsVpnUnicastAddress {
     path_id: Option<u32>,
     rd: RouteDistinguisher,
@@ -262,10 +281,16 @@ impl NlriAddressType for Ipv4MplsVpnUnicastAddress {
 /// A more restricted version of [`Ipv4Net`] that allows only multicast
 /// networks
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Ipv4Multicast(Ipv4Net);
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct Ipv4Multicast(
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4net))] Ipv4Net,
+);
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
-pub struct InvalidIpv4MulticastNetwork(pub Ipv4Net);
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct InvalidIpv4MulticastNetwork(
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4net))] pub Ipv4Net,
+);
 
 impl Ipv4Multicast {
     pub fn from_net(net: Ipv4Net) -> Result<Self, InvalidIpv4MulticastNetwork> {
@@ -291,6 +316,7 @@ impl TryFrom<Ipv4Net> for Ipv4Multicast {
 
 /// Ipv4 Multicast Network address in NLRI
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ipv4MulticastAddress {
     path_id: Option<u32>,
     network: Ipv4Multicast,
@@ -326,10 +352,14 @@ impl NlriAddressType for Ipv4MulticastAddress {
 /// A more restricted version of [`Ipv6Net`] that allows only unicast
 /// networks
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Ipv6Unicast(Ipv6Net);
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct Ipv6Unicast(#[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6net))] Ipv6Net);
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
-pub struct InvalidIpv6UnicastNetwork(pub Ipv6Net);
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct InvalidIpv6UnicastNetwork(
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6net))] pub Ipv6Net,
+);
 
 impl Ipv6Unicast {
     pub fn from_net(net: Ipv6Net) -> Result<Self, InvalidIpv6UnicastNetwork> {
@@ -354,6 +384,7 @@ impl TryFrom<Ipv6Net> for Ipv6Unicast {
 
 /// Ipv6 Network address in NLRI
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ipv6UnicastAddress {
     path_id: Option<u32>,
     network: Ipv6Unicast,
@@ -380,6 +411,7 @@ impl NlriAddressType for Ipv6UnicastAddress {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ipv6MplsVpnUnicastAddress {
     path_id: Option<u32>,
     rd: RouteDistinguisher,
@@ -441,10 +473,16 @@ impl NlriAddressType for Ipv6MplsVpnUnicastAddress {
 /// A more restricted version of [`Ipv6Net`] that allows only multicast
 /// networks
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Ipv6Multicast(Ipv6Net);
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct Ipv6Multicast(
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6net))] Ipv6Net,
+);
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
-pub struct InvalidIpv6MulticastNetwork(pub Ipv6Net);
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub struct InvalidIpv6MulticastNetwork(
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6net))] pub Ipv6Net,
+);
 
 impl Ipv6Multicast {
     pub fn from_net(net: Ipv6Net) -> Result<Self, InvalidIpv6MulticastNetwork> {
@@ -474,6 +512,7 @@ impl TryFrom<Ipv6Net> for Ipv6Multicast {
 
 /// Ipv4 Multicast Network address in NLRI
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ipv6MulticastAddress {
     path_id: Option<u32>,
     network: Ipv6Multicast,
@@ -507,15 +546,19 @@ impl NlriAddressType for Ipv6MulticastAddress {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct EthernetSegmentIdentifier(pub [u8; 10]);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct EthernetTag(pub u32);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct MacAddress(pub [u8; 6]);
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct L2EvpnAddress {
     path_id: Option<u32>,
     route: L2EvpnRoute,
@@ -536,6 +579,7 @@ impl L2EvpnAddress {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum L2EvpnRoute {
     EthernetAutoDiscovery(EthernetAutoDiscovery),
     MacIpAdvertisement(MacIpAdvertisement),
@@ -579,6 +623,7 @@ impl NlriAddressType for L2EvpnAddress {
 /// +---------------------------------------+
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct EthernetAutoDiscovery {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
@@ -642,11 +687,13 @@ impl EthernetAutoDiscovery {
 /// +---------------------------------------+
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct MacIpAdvertisement {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
     tag: EthernetTag,
     mac: MacAddress,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ext::arbitrary_option(arbitrary_ip)))]
     ip: Option<IpAddr>,
     mpls_label1: MplsLabel,
     mpls_label2: Option<MplsLabel>,
@@ -718,9 +765,11 @@ impl MacIpAdvertisement {
 /// +---------------------------------------+
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct InclusiveMulticastEthernetTagRoute {
     rd: RouteDistinguisher,
     tag: EthernetTag,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ip))]
     ip: IpAddr,
 }
 
@@ -758,9 +807,11 @@ impl InclusiveMulticastEthernetTagRoute {
 /// +---------------------------------------+
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct EthernetSegmentRoute {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ip))]
     ip: IpAddr,
 }
 
@@ -788,6 +839,7 @@ impl EthernetSegmentRoute {
 
 /// The BGP EVPN IPv4 or IPv6 Prefix Route
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum L2EvpnIpPrefixRoute {
     V4(L2EvpnIpv4PrefixRoute),
     V6(L2EvpnIpv6PrefixRoute),
@@ -813,11 +865,14 @@ pub enum L2EvpnIpPrefixRoute {
 /// +---------------------------------------+
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct L2EvpnIpv4PrefixRoute {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
     tag: EthernetTag,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4net))]
     prefix: Ipv4Net,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
     gateway: Ipv4Addr,
     label: MplsLabel,
 }
@@ -884,11 +939,14 @@ impl L2EvpnIpv4PrefixRoute {
 /// +---------------------------------------+
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct L2EvpnIpv6PrefixRoute {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
     tag: EthernetTag,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6net))]
     prefix: Ipv6Net,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
     gateway: Ipv6Addr,
     label: MplsLabel,
 }
@@ -936,6 +994,7 @@ impl L2EvpnIpv6PrefixRoute {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct RouteTargetMembershipAddress {
     path_id: Option<u32>,
     membership: Option<RouteTargetMembership>,
@@ -970,6 +1029,7 @@ impl RouteTargetMembershipAddress {
 /// +-------------------------------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct RouteTargetMembership {
     origin_as: u32,
     /// Route targets can then be expressed as prefixes, where, for instance,
@@ -1033,9 +1093,11 @@ impl NlriAddressType for RouteTargetMembershipAddress {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ipv4NlriMplsLabelsAddress {
     path_id: Option<u32>,
     labels: Vec<MplsLabel>,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4net))]
     prefix: Ipv4Net,
 }
 
@@ -1107,9 +1169,11 @@ impl NlriAddressType for Ipv4NlriMplsLabelsAddress {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Ipv6NlriMplsLabelsAddress {
     path_id: Option<u32>,
     labels: Vec<MplsLabel>,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6net))]
     prefix: Ipv6Net,
 }
 

--- a/crates/bgp-pkt/src/notification.rs
+++ b/crates/bgp-pkt/src/notification.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 ///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpNotificationMessage {
     MessageHeaderError(MessageHeaderError),
     OpenMessageError(OpenMessageError),
@@ -38,6 +39,7 @@ pub enum BgpNotificationMessage {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum MessageHeaderError {
     Unspecific { value: Vec<u8> },
     ConnectionNotSynchronized { value: Vec<u8> },
@@ -47,6 +49,7 @@ pub enum MessageHeaderError {
 
 /// See [`crate::iana::OpenMessageErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum OpenMessageError {
     Unspecific { value: Vec<u8> },
     UnsupportedVersionNumber { value: Vec<u8> },
@@ -60,6 +63,7 @@ pub enum OpenMessageError {
 
 /// See [`crate::iana::UpdateMessageErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum UpdateMessageError {
     Unspecific { value: Vec<u8> },
     MalformedAttributeList { value: Vec<u8> },
@@ -75,12 +79,14 @@ pub enum UpdateMessageError {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum HoldTimerExpiredError {
     Unspecific { sub_code: u8, value: Vec<u8> },
 }
 
 /// See [`crate::iana::FiniteStateMachineErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum FiniteStateMachineError {
     Unspecific { value: Vec<u8> },
     ReceiveUnexpectedMessageInOpenSentState { value: Vec<u8> },
@@ -90,6 +96,7 @@ pub enum FiniteStateMachineError {
 
 /// See [`crate::iana::CeaseErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum CeaseError {
     MaximumNumberOfPrefixesReached { value: Vec<u8> },
     AdministrativeShutdown { value: Vec<u8> },
@@ -105,6 +112,7 @@ pub enum CeaseError {
 
 /// See [`crate::iana::RouteRefreshMessageErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum RouteRefreshError {
     InvalidMessageLength { value: Vec<u8> },
 }

--- a/crates/bgp-pkt/src/open.rs
+++ b/crates/bgp-pkt/src/open.rs
@@ -15,6 +15,8 @@
 
 //! Representations for BGP Open message
 
+#[cfg(feature = "fuzz")]
+use crate::arbitrary_ipv4;
 use crate::{capabilities::BgpCapability, iana::BgpCapabilityCode, Deserialize, Serialize};
 use std::{collections::HashMap, net::Ipv4Addr};
 
@@ -41,10 +43,12 @@ pub const BGP_VERSION: u8 = 4;
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct BgpOpenMessage {
     version: u8,
     my_as: u16,
     hold_time: u16,
+    #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
     bgp_id: Ipv4Addr,
     params: Vec<BgpOpenMessageParameter>, // TODO (AH): rfc5492
 }
@@ -108,6 +112,7 @@ impl BgpOpenMessage {
 /// |  Parm. Type   | Parm. Length  |  Parameter Value (variable)
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-...
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpOpenMessageParameter {
     /// Capabilities Advertisement
     Capabilities(Vec<BgpCapability>),

--- a/crates/bgp-pkt/src/path_attribute.rs
+++ b/crates/bgp-pkt/src/path_attribute.rs
@@ -16,6 +16,8 @@
 //! Contains the extensible definitions for various [`PathAttribute`] that can
 //! be used in [`crate::update::BgpUpdateMessage`].
 
+#[cfg(feature = "fuzz")]
+use crate::{arbitrary_ip, arbitrary_ipv4, arbitrary_ipv6};
 use crate::{
     community::{Community, ExtendedCommunity, ExtendedCommunityIpv6, LargeCommunity},
     nlri::*,
@@ -50,6 +52,7 @@ pub trait PathAttributeValueProperties {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum InvalidPathAttribute {
     InvalidOptionalFlagValue(bool),
     InvalidTransitiveFlagValue(bool),
@@ -66,6 +69,7 @@ pub enum InvalidPathAttribute {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct PathAttribute {
     /// Optional bit defines whether the attribute is optional (if set to
     /// `true`) or well-known (if set to `false`).
@@ -149,6 +153,7 @@ impl PathAttribute {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum PathAttributeValue {
     Origin(Origin),
     AsPath(AsPath),
@@ -258,6 +263,7 @@ impl PathAttributeValue {
 /// ```
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum Origin {
     IGP = 0,
     EGP = 1,
@@ -287,6 +293,7 @@ impl From<Origin> for u8 {
 /// Error type used in [`TryFrom`] for [`Origin`].
 /// The value carried is the undefined value being parsed
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedOrigin(pub u8);
 
 impl TryFrom<u8> for Origin {
@@ -305,6 +312,7 @@ impl TryFrom<u8> for Origin {
 /// represented by a triple <path segment type, path segment
 /// length, path segment value>.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum AsPath {
     As2PathSegments(Vec<As2PathSegment>),
     As4PathSegments(Vec<As4PathSegment>),
@@ -335,6 +343,7 @@ impl PathAttributeValueProperties for AsPath {
 /// ```
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum AsPathSegmentType {
     AsSet = 1,
     AsSequence = 2,
@@ -349,6 +358,7 @@ impl From<AsPathSegmentType> for u8 {
 /// Error type used in [`TryFrom`] for [`AsPathSegmentType`].
 /// The value carried is the undefined value being parsed
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UndefinedAsPathSegmentType(pub u8);
 
 impl TryFrom<u8> for AsPathSegmentType {
@@ -379,6 +389,7 @@ impl TryFrom<u8> for AsPathSegmentType {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct As2PathSegment {
     segment_type: AsPathSegmentType,
     as_numbers: Vec<u16>,
@@ -404,6 +415,7 @@ impl As2PathSegment {
 ///  Each AS path segment is represented by a triple:
 /// <path segment type, path segment length, path segment value>.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct As4PathSegment {
     segment_type: AsPathSegmentType,
     as_numbers: Vec<u32>,
@@ -427,6 +439,7 @@ impl As4PathSegment {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct As4Path {
     segments: Vec<As4PathSegment>,
 }
@@ -466,6 +479,7 @@ impl PathAttributeValueProperties for As4Path {
 /// the next hop to the destinations listed in the Network Layer
 /// Reachability Information field of the UPDATE message.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct NextHop {
     next_hop: Ipv4Addr,
 }
@@ -499,6 +513,7 @@ impl PathAttributeValueProperties for NextHop {
 /// discriminate among multiple entry points to a neighboring
 /// autonomous system.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct MultiExitDiscriminator {
     metric: u32,
 }
@@ -532,6 +547,7 @@ impl PathAttributeValueProperties for MultiExitDiscriminator {
 /// internal peers of the advertising speaker's degree of
 /// preference for an advertised route.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct LocalPreference {
     metric: u32,
 }
@@ -562,6 +578,7 @@ impl PathAttributeValueProperties for LocalPreference {
 
 /// `ATOMIC_AGGREGATE` is a well-known discretionary attribute of length 0.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct AtomicAggregate;
 
 impl PathAttributeValueProperties for AtomicAggregate {
@@ -584,6 +601,7 @@ impl PathAttributeValueProperties for AtomicAggregate {
 /// (encoded as 4 octets). This SHOULD be the same address as
 /// the one used for the BGP Identifier of the speaker.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct As2Aggregator {
     asn: u16,
     origin: Ipv4Addr,
@@ -603,6 +621,7 @@ impl As2Aggregator {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct As4Aggregator {
     asn: u32,
     origin: Ipv4Addr,
@@ -627,6 +646,7 @@ impl As4Aggregator {
 /// This SHOULD be the same address as the one used for the BGP Identifier of
 /// the speaker.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum Aggregator {
     As2Aggregator(As2Aggregator),
     As4Aggregator(As4Aggregator),
@@ -648,6 +668,7 @@ impl PathAttributeValueProperties for Aggregator {
 
 /// Path attribute can be of size `u8` or `u16` based on `extended_length` bit.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum PathAttributeLength {
     U8(u8),
     U16(u16),
@@ -669,6 +690,7 @@ impl From<PathAttributeLength> for u16 {
 ///
 /// See [RFC1997](https://datatracker.ietf.org/doc/html/rfc1997)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Communities {
     communities: Vec<Community>,
 }
@@ -698,6 +720,7 @@ impl PathAttributeValueProperties for Communities {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExtendedCommunities {
     communities: Vec<ExtendedCommunity>,
 }
@@ -727,6 +750,7 @@ impl PathAttributeValueProperties for ExtendedCommunities {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExtendedCommunitiesIpv6 {
     communities: Vec<ExtendedCommunityIpv6>,
 }
@@ -756,6 +780,7 @@ impl PathAttributeValueProperties for ExtendedCommunitiesIpv6 {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct LargeCommunities {
     communities: Vec<LargeCommunity>,
 }
@@ -794,6 +819,7 @@ impl PathAttributeValueProperties for LargeCommunities {
 ///
 /// [RFC4456](https://datatracker.ietf.org/doc/html/rfc4456) defines this value
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct Originator(Ipv4Addr);
 
 impl Originator {
@@ -826,6 +852,7 @@ impl PathAttributeValueProperties for Originator {
 ///
 /// [RFC4456](https://datatracker.ietf.org/doc/html/rfc4456) defines this value
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ClusterList(Vec<ClusterId>);
 
 impl ClusterList {
@@ -853,6 +880,7 @@ impl PathAttributeValueProperties for ClusterList {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ClusterId(Ipv4Addr);
 
 impl ClusterId {
@@ -892,16 +920,20 @@ impl ClusterId {
 /// +---------------------------------------------------------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum MpReach {
     Ipv4Unicast {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         next_hop: Ipv4Addr,
         nlri: Vec<Ipv4UnicastAddress>,
     },
     Ipv4Multicast {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv4))]
         next_hop: Ipv4Addr,
         nlri: Vec<Ipv4MulticastAddress>,
     },
     Ipv4NlriMplsLabels {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ip))]
         next_hop: IpAddr,
         nlri: Vec<Ipv4NlriMplsLabelsAddress>,
     },
@@ -911,15 +943,19 @@ pub enum MpReach {
     },
     Ipv6Unicast {
         next_hop_global: Ipv6Addr,
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ext::arbitrary_option(arbitrary_ipv6)))]
         next_hop_local: Option<Ipv6Addr>,
         nlri: Vec<Ipv6UnicastAddress>,
     },
     Ipv6Multicast {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ipv6))]
         next_hop_global: Ipv6Addr,
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ext::arbitrary_option(arbitrary_ipv6)))]
         next_hop_local: Option<Ipv6Addr>,
         nlri: Vec<Ipv6MulticastAddress>,
     },
     Ipv6NlriMplsLabels {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ip))]
         next_hop: IpAddr,
         nlri: Vec<Ipv6NlriMplsLabelsAddress>,
     },
@@ -928,10 +964,12 @@ pub enum MpReach {
         nlri: Vec<Ipv6MplsVpnUnicastAddress>,
     },
     L2Evpn {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ip))]
         next_hop: IpAddr,
         nlri: Vec<L2EvpnAddress>,
     },
     RouteTargetMembership {
+        #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ip))]
         next_hop: IpAddr,
         nlri: Vec<RouteTargetMembershipAddress>,
     },
@@ -972,6 +1010,7 @@ impl PathAttributeValueProperties for MpReach {
 /// +---------------------------------------------------------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum MpUnreach {
     Ipv4Unicast {
         nlri: Vec<Ipv4UnicastAddress>,
@@ -1028,6 +1067,7 @@ impl PathAttributeValueProperties for MpUnreach {
 /// BGP Allows parsing unrecognized attributes as is, and then only consider
 /// the transitive and partial bits of the attribute.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UnknownAttribute {
     code: u8,
     value: Vec<u8>,
@@ -1064,6 +1104,7 @@ impl PathAttributeValueProperties for UnknownAttribute {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct OnlyToCustomer(u32);
 
 impl OnlyToCustomer {
@@ -1092,6 +1133,7 @@ impl PathAttributeValueProperties for OnlyToCustomer {
 
 /// Accumulated IGP Metric Attribute [RFC7311](https://datatracker.ietf.org/doc/html/rfc7311)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum Aigp {
     AccumulatedIgpMetric(u64),
 }

--- a/crates/bgp-pkt/src/route_refresh.rs
+++ b/crates/bgp-pkt/src/route_refresh.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize};
 /// +-------+-------+-------+-------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct BgpRouteRefreshMessage {
     address_type: AddressType,
     operation_type: RouteRefreshSubcode,

--- a/crates/bgp-pkt/src/update.rs
+++ b/crates/bgp-pkt/src/update.rs
@@ -37,6 +37,7 @@ use crate::path_attribute::PathAttribute;
 /// +-----------------------------------------------------+
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct BgpUpdateMessage {
     withdrawn_routes: Vec<Ipv4UnicastAddress>,
     path_attributes: Vec<PathAttribute>,

--- a/crates/bmp-pkt/README.md
+++ b/crates/bmp-pkt/README.md
@@ -36,10 +36,10 @@ fn main() {
         ],
     )));
 
-   println!(
-      "JSON representation of BMP packet: {}",
-      serde_json::to_string(&bmp_msg).unwrap()
-   );
+    println!(
+        "JSON representation of BMP packet: {}",
+        serde_json::to_string(&bmp_msg).unwrap()
+    );
 
     // Serialize the message into it's BGP binary format
     let mut buf: Vec<u8> = vec![];
@@ -67,3 +67,18 @@ fn main() {
 2. [RFC 8671](https://datatracker.ietf.org/doc/html/rfc8671) Support for Adj-RIB-Out in the BGP Monitoring Protocol (
    BMP).
 3. [RFC 9069](https://datatracker.ietf.org/doc/html/rfc9069) Support for Local RIB in the BGP Monitoring Protocol (BMP).
+
+# Development documentation
+
+* Using this library to fuzz other code accepting `BmpMessage`
+
+```rust
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use netgauze_bmp_pkt::BmpMessage;
+
+fuzz_target!(|data: BmpMessage| {
+    // Some fuzzing target that accepts BmpMessage as input and need to be fuzzed
+});
+```

--- a/crates/bmp-pkt/src/iana.rs
+++ b/crates/bmp-pkt/src/iana.rs
@@ -41,6 +41,7 @@ pub const PEER_FLAGS_IS_FILTERED: u8 = 0b10000000;
 /// Currently supported BMP versions
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BmpVersion {
     Version3 = 3,
 }
@@ -70,6 +71,7 @@ impl TryFrom<u8> for BmpVersion {
 /// BMP Message types as registered in IANA [BMP Message Types](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#message-types)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BmpMessageType {
     RouteMonitoring = 0,
     StatisticsReport = 1,
@@ -109,6 +111,7 @@ impl TryFrom<u8> for BmpMessageType {
 /// BMP Message types as registered in IANA [BMP Message Types](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#message-types)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BmpPeerTypeCode {
     GlobalInstancePeer = 0,
     RdInstancePeer = 1,
@@ -145,6 +148,7 @@ impl TryFrom<u8> for BmpPeerTypeCode {
 /// BMP `InformationTLV` types as registered in IANA [BMP Initiation and Peer Up Information TLVs](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#initiation-peer-up-tlvs)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum InitiationInformationTlvType {
     String = 0,
     SystemDescription = 1,
@@ -182,6 +186,7 @@ impl TryFrom<u16> for InitiationInformationTlvType {
 /// BMP Termination `InformationTLV` types as registered in IANA [BMP Termination Message TLVs](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#termination-message-tlvs)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum TerminationInformationTlvType {
     String = 0,
     Reason = 1,
@@ -216,6 +221,7 @@ impl TryFrom<u16> for TerminationInformationTlvType {
 /// BMP peer termination Reason codes as registered in IANA [BMP Termination Message Reason Codes](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#termination-message-reason-codes)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum PeerTerminationCode {
     AdministrativelyClosed = 0,
     UnspecifiedReason = 1,
@@ -253,6 +259,7 @@ impl TryFrom<u16> for PeerTerminationCode {
 /// BMP Peer down Reason codes as registered in IANA [BMP Peer Down Reason Codes](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#peer-down-reason-codes)
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum PeerDownReasonCode {
     LocalSystemClosedNotificationPduFollows = 1,
     LocalSystemClosedFsmEventFollows = 2,
@@ -291,6 +298,7 @@ impl TryFrom<u8> for PeerDownReasonCode {
 /// [BMP Route Mirroring TLVs](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#route-mirroring-tlvs)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum RouteMirroringTlvType {
     BgpMessage = 0,
     Information = 1,
@@ -325,6 +333,7 @@ impl TryFrom<u16> for RouteMirroringTlvType {
 /// [BMP Route Mirroring Information Codes](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#route-mirroring-information-codes)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum RouteMirroringInformation {
     ErroredPdu = 0,
     MessagesLost = 1,
@@ -359,6 +368,7 @@ impl TryFrom<u16> for RouteMirroringInformation {
 /// [BMP Statistics Types](https://www.iana.org/assignments/bmp-parameters/bmp-parameters.xhtml#statistics-types)
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BmpStatisticsType {
     NumberOfPrefixesRejectedByInboundPolicy = 0,
     NumberOfDuplicatePrefixAdvertisements = 1,

--- a/crates/iana/src/address_family.rs
+++ b/crates/iana/src/address_family.rs
@@ -57,6 +57,7 @@ use strum_macros::{Display, FromRepr};
 /// ```
 #[repr(u16)]
 #[derive(FromRepr, Display, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum AddressFamily {
     IPv4 = 1,
     IPv6 = 2,
@@ -216,6 +217,7 @@ impl TryFrom<u16> for AddressFamily {
 /// ```
 #[repr(u8)]
 #[derive(FromRepr, Display, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum SubsequentAddressFamily {
     /// Network Layer Reachability Information used for unicast forwarding
     /// [RFC4760](https://datatracker.ietf.org/doc/html/RFC4760)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -27,10 +27,24 @@ test = false
 doc = false
 
 [[bin]]
+name = "fuzz-bgp-pkt-serialize"
+path = "fuzz_targets/fuzz_bgp_pkt_serialize.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "fuzz-bmp-pkt"
 path = "fuzz_targets/fuzz_bmp_pkt.rs"
 test = false
 doc = false
+
+
+[[bin]]
+name = "fuzz-bmp-pkt-serialize"
+path = "fuzz_targets/fuzz_bmp_pkt_serialize.rs"
+test = false
+doc = false
+
 
 [[bin]]
 name = "fuzz-ipfix-pkt"

--- a/fuzz/fuzz_targets/fuzz_bgp_pkt_serialize.rs
+++ b/fuzz/fuzz_targets/fuzz_bgp_pkt_serialize.rs
@@ -1,0 +1,27 @@
+// Copyright (C) 2023-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use netgauze_bgp_pkt::BgpMessage;
+use netgauze_parse_utils::WritablePdu;
+use std::io::Cursor;
+
+fuzz_target!(|data: BgpMessage| {
+    let mut buf: Vec<u8> = vec![];
+    let mut cursor = Cursor::new(&mut buf);
+    data.write(&mut cursor).unwrap();
+});

--- a/fuzz/fuzz_targets/fuzz_bmp_pkt_serialize.rs
+++ b/fuzz/fuzz_targets/fuzz_bmp_pkt_serialize.rs
@@ -1,0 +1,28 @@
+// Copyright (C) 2023-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use netgauze_bmp_pkt::BmpMessage;
+use netgauze_parse_utils::WritablePdu;
+use std::io::Cursor;
+
+fuzz_target!(|data: BmpMessage| {
+    let mut buf: Vec<u8> = vec![];
+    let mut cursor = Cursor::new(&mut buf);
+    data.write(&mut cursor).unwrap();
+});


### PR DESCRIPTION
Annotate BMP and BGP packates with `Arbitrary` trait making them suitable to be used in fuzzing scenarios.