### PR TITLE
Allow BMP Mirror packet to accept raw bgp message

### DIFF
--- a/crates/bmp-pkt/examples/bmp.rs
+++ b/crates/bmp-pkt/examples/bmp.rs
@@ -4,8 +4,8 @@
 use chrono::{TimeZone, Utc};
 use netgauze_bgp_pkt::BgpMessage;
 use netgauze_bmp_pkt::{
-    iana::RouteMirroringInformation, BmpMessage, BmpMessageValue, BmpPeerType, PeerHeader,
-    RouteMirroringMessage, RouteMirroringValue,
+    iana::RouteMirroringInformation, BmpMessage, BmpMessageValue, BmpPeerType, MirroredBgpMessage,
+    PeerHeader, RouteMirroringMessage, RouteMirroringValue,
 };
 use netgauze_parse_utils::{ReadablePduWithTwoInputs, Span, WritablePdu};
 use std::{
@@ -27,7 +27,7 @@ fn main() {
         ),
         vec![
             RouteMirroringValue::Information(RouteMirroringInformation::Experimental65531),
-            RouteMirroringValue::BgpMessage(BgpMessage::KeepAlive),
+            RouteMirroringValue::BgpMessage(MirroredBgpMessage::Parsed(BgpMessage::KeepAlive)),
         ],
     )));
 

--- a/crates/bmp-pkt/src/lib.rs
+++ b/crates/bmp-pkt/src/lib.rs
@@ -521,11 +521,18 @@ impl RouteMirroringMessage {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+pub enum MirroredBgpMessage {
+    Parsed(BgpMessage),
+    Raw(Vec<u8>),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum RouteMirroringValue {
     /// A BGP PDU.  This PDU may or may not be an Update message.
     /// If the BGP Message TLV occurs in the Route Mirroring message,
     /// it MUST occur last in the list of TLVs.
-    BgpMessage(BgpMessage),
+    BgpMessage(MirroredBgpMessage),
 
     /// A 2-byte code that provides information about the mirrored message or
     /// message stream.

--- a/crates/bmp-pkt/src/wire/deserializer/mod.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/mod.rs
@@ -780,7 +780,10 @@ impl<'a>
             RouteMirroringTlvType::BgpMessage => {
                 let (buf, msg) =
                     parse_into_located_three_inputs(buf, asn4, multiple_labels, add_path)?;
-                (buf, RouteMirroringValue::BgpMessage(msg))
+                (
+                    buf,
+                    RouteMirroringValue::BgpMessage(MirroredBgpMessage::Parsed(msg)),
+                )
             }
             RouteMirroringTlvType::Information => {
                 let (buf, information) =

--- a/crates/bmp-pkt/src/wire/serializer/mod.rs
+++ b/crates/bmp-pkt/src/wire/serializer/mod.rs
@@ -273,7 +273,10 @@ impl WritablePdu<RouteMirroringValueWritingError> for RouteMirroringValue {
     fn len(&self) -> usize {
         Self::BASE_LENGTH
             + match self {
-                Self::BgpMessage(msg) => msg.len(),
+                Self::BgpMessage(msg) => match msg {
+                    MirroredBgpMessage::Parsed(msg) => msg.len(),
+                    MirroredBgpMessage::Raw(msg) => msg.len(),
+                },
                 Self::Information(_) => 2, // Information are always 2-octets
                 Self::Experimental65531(value) => value.len(),
                 Self::Experimental65532(value) => value.len(),
@@ -286,7 +289,10 @@ impl WritablePdu<RouteMirroringValueWritingError> for RouteMirroringValue {
         writer.write_u16::<NetworkEndian>(self.get_type().into())?;
         writer.write_u16::<NetworkEndian>((self.len() - Self::BASE_LENGTH) as u16)?;
         match self {
-            Self::BgpMessage(msg) => msg.write(writer)?,
+            Self::BgpMessage(msg) => match msg {
+                MirroredBgpMessage::Parsed(msg) => msg.write(writer)?,
+                MirroredBgpMessage::Raw(raw) => writer.write_all(&raw)?,
+            },
             Self::Information(info) => writer.write_u16::<NetworkEndian>((*info).into())?,
             Self::Experimental65531(value) => writer.write_all(value)?,
             Self::Experimental65532(value) => writer.write_all(value)?,

--- a/crates/bmp-pkt/src/wire/tests/mod.rs
+++ b/crates/bmp-pkt/src/wire/tests/mod.rs
@@ -1244,7 +1244,8 @@ fn test_router_mirroring_value() -> Result<(), RouteMirroringValueWritingError> 
     let good_experimental_65533_wire = [0xff, 0xfd, 0, 2, 1, 2];
     let good_experimental_65534_wire = [0xff, 0xfe, 0, 2, 1, 2];
 
-    let good_bgp = RouteMirroringValue::BgpMessage(BgpMessage::KeepAlive);
+    let good_bgp =
+        RouteMirroringValue::BgpMessage(MirroredBgpMessage::Parsed(BgpMessage::KeepAlive));
     let good_information = RouteMirroringValue::Information(RouteMirroringInformation::ErroredPdu);
     let good_experimental_65531 = RouteMirroringValue::Experimental65531(vec![1, 2]);
     let good_experimental_65532 = RouteMirroringValue::Experimental65532(vec![1, 2]);
@@ -1327,7 +1328,9 @@ fn test_bmp_router_mirroring() -> Result<(), BmpMessageWritingError> {
             Ipv4Addr::new(172, 16, 0, 20),
             Some(Utc.timestamp_opt(1664915595, 285358000).unwrap()),
         ),
-        vec![RouteMirroringValue::BgpMessage(BgpMessage::KeepAlive)],
+        vec![RouteMirroringValue::BgpMessage(MirroredBgpMessage::Parsed(
+            BgpMessage::KeepAlive,
+        ))],
     )));
     test_parsed_completely_with_two_inputs(&good_wire, &HashMap::new(), &HashMap::new(), &good);
 


### PR DESCRIPTION
Allow BMP Mirror packet to accept raw bgp message.

At the moment, it can serialize raw BGP packets, however deserialization will always generate parsed BGP message.