### PR TITLE
Error handling according RFC7606

### DIFF
--- a/crates/bgp-pkt/benches/serde_benchmark.rs
+++ b/crates/bgp-pkt/benches/serde_benchmark.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use netgauze_bgp_pkt::BgpMessage;
-use netgauze_parse_utils::{ReadablePduWithThreeInputs, Span};
-use std::collections::HashMap;
+use netgauze_bgp_pkt::{wire::deserializer::BgpParsingContext, BgpMessage};
+use netgauze_parse_utils::{ReadablePduWithOneInput, Span};
 
 const OPEN_COMPLEX_NO_PARAMS: [u8; 29] = [
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -41,11 +40,11 @@ const OPEN_COMPLEX_RAW: [u8; 123] = [
 ];
 
 pub fn test_open_message_no_params(span: Span<'_>) {
-    let x = BgpMessage::from_wire(span, true, &HashMap::new(), &HashMap::new());
+    let x = BgpMessage::from_wire(span, &mut BgpParsingContext::default());
     x.unwrap();
 }
 pub fn test_complex_open_message(span: Span<'_>) {
-    let x = BgpMessage::from_wire(span, true, &HashMap::new(), &HashMap::new());
+    let x = BgpMessage::from_wire(span, &mut BgpParsingContext::default());
     x.unwrap();
 }
 

--- a/crates/bgp-pkt/benches/serde_benchmark.rs
+++ b/crates/bgp-pkt/benches/serde_benchmark.rs
@@ -41,11 +41,11 @@ const OPEN_COMPLEX_RAW: [u8; 123] = [
 ];
 
 pub fn test_open_message_no_params(span: Span<'_>) {
-    let x = BgpMessage::from_wire(span, true, false, &HashMap::new());
+    let x = BgpMessage::from_wire(span, true, &HashMap::new(), &HashMap::new());
     x.unwrap();
 }
 pub fn test_complex_open_message(span: Span<'_>) {
-    let x = BgpMessage::from_wire(span, true, false, &HashMap::new());
+    let x = BgpMessage::from_wire(span, true, &HashMap::new(), &HashMap::new());
     x.unwrap();
 }
 

--- a/crates/bgp-pkt/examples/bgp.rs
+++ b/crates/bgp-pkt/examples/bgp.rs
@@ -1,11 +1,11 @@
 //! Simple example of constructing BGP packet
 //! in addition to serializing and deserializing BGP packet from wire format.
 
-use std::{collections::HashMap, io::Cursor, net::Ipv4Addr};
+use std::{io::Cursor, net::Ipv4Addr};
 
-use netgauze_bgp_pkt::{capabilities::*, open::*, *};
+use netgauze_bgp_pkt::{capabilities::*, open::*, wire::deserializer::BgpParsingContext, *};
 use netgauze_iana::address_family::*;
-use netgauze_parse_utils::{ReadablePduWithThreeInputs, Span, WritablePdu};
+use netgauze_parse_utils::{ReadablePduWithOneInput, Span, WritablePdu};
 
 pub fn main() {
     // Construct a new BGP message
@@ -59,6 +59,6 @@ pub fn main() {
 
     // Deserialize the message from binary format
     let (_, msg_back) =
-        BgpMessage::from_wire(Span::new(&buf), true, &HashMap::new(), &HashMap::new()).unwrap();
+        BgpMessage::from_wire(Span::new(&buf), &mut BgpParsingContext::default()).unwrap();
     assert_eq!(msg, msg_back);
 }

--- a/crates/bgp-pkt/src/path_attribute.rs
+++ b/crates/bgp-pkt/src/path_attribute.rs
@@ -91,27 +91,36 @@ impl PathAttribute {
         partial: bool,
         extended_length: bool,
         value: PathAttributeValue,
-    ) -> Result<PathAttribute, InvalidPathAttribute> {
+    ) -> Result<PathAttribute, (PathAttributeValue, InvalidPathAttribute)> {
         if value
             .can_be_optional()
             .map(|x| x != optional)
             .unwrap_or(false)
         {
-            return Err(InvalidPathAttribute::InvalidOptionalFlagValue(optional));
+            return Err((
+                value,
+                InvalidPathAttribute::InvalidOptionalFlagValue(optional),
+            ));
         }
         if value
             .can_be_transitive()
             .map(|x| x != transitive)
             .unwrap_or(false)
         {
-            return Err(InvalidPathAttribute::InvalidTransitiveFlagValue(transitive));
+            return Err((
+                value,
+                InvalidPathAttribute::InvalidTransitiveFlagValue(transitive),
+            ));
         }
         if value
             .can_be_partial()
             .map(|x| x != partial)
             .unwrap_or(false)
         {
-            return Err(InvalidPathAttribute::InvalidPartialFlagValue(partial));
+            return Err((
+                value,
+                InvalidPathAttribute::InvalidPartialFlagValue(partial),
+            ));
         }
 
         Ok(PathAttribute {

--- a/crates/bgp-pkt/src/wire/deserializer/open.rs
+++ b/crates/bgp-pkt/src/wire/deserializer/open.rs
@@ -14,12 +14,17 @@
 // limitations under the License.
 
 use crate::{
+    capabilities::BgpCapability,
     iana::{BgpOpenMessageParameterType, UndefinedBgpOpenMessageParameterType},
-    open::BgpOpenMessageParameter,
-    wire::deserializer::capabilities::BgpCapabilityParsingError,
+    notification::OpenMessageError,
+    open::{BgpOpenMessageParameter, BGP_VERSION},
+    wire::deserializer::{capabilities::BgpCapabilityParsingError, BgpParsingContext},
     BgpOpenMessage,
 };
-use netgauze_parse_utils::{parse_till_empty_into_located, ErrorKindSerdeDeref, ReadablePdu, Span};
+use netgauze_parse_utils::{
+    parse_into_located_one_input, ErrorKindSerdeDeref, LocatedParsingError, ReadablePdu,
+    ReadablePduWithOneInput, Span,
+};
 use netgauze_serde_macros::LocatedError;
 use nom::{
     error::ErrorKind,
@@ -37,6 +42,9 @@ pub enum BgpOpenMessageParsingError {
     #[serde(with = "ErrorKindSerdeDeref")]
     NomError(#[from_nom] ErrorKind),
     UnsupportedVersionNumber(u8),
+    UnacceptableHoldTime(u16),
+    /// RFC 4271 specifies that BGP ID must be a valid unicast IP host address.
+    InvalidBgpId(u32),
     ParameterError(#[from_located(module = "self")] BgpParameterParsingError),
 }
 
@@ -54,8 +62,13 @@ pub enum BgpParameterParsingError {
     ),
 }
 
-impl<'a> ReadablePdu<'a, LocatedBgpOpenMessageParsingError<'a>> for BgpOpenMessage {
-    fn from_wire(buf: Span<'a>) -> IResult<Span<'a>, Self, LocatedBgpOpenMessageParsingError<'a>> {
+impl<'a> ReadablePduWithOneInput<'a, &mut BgpParsingContext, LocatedBgpOpenMessageParsingError<'a>>
+    for BgpOpenMessage
+{
+    fn from_wire(
+        buf: Span<'a>,
+        ctx: &mut BgpParsingContext,
+    ) -> IResult<Span<'a>, Self, LocatedBgpOpenMessageParsingError<'a>> {
         let (buf, _) = nom::combinator::map_res(be_u8, |x| {
             if x == 4 {
                 Ok(x)
@@ -64,26 +77,55 @@ impl<'a> ReadablePdu<'a, LocatedBgpOpenMessageParsingError<'a>> for BgpOpenMessa
             }
         })(buf)?;
         let (buf, my_as) = be_u16(buf)?;
+        let begin_buf = buf;
         let (buf, hold_time) = be_u16(buf)?;
+        // RFC 4271: If the Hold Time field of the OPEN message is unacceptable, then
+        // the Error Subcode MUST be set to Unacceptable Hold Time. An implementation
+        // MUST reject Hold Time values of one or two seconds. An implementation MAY
+        // reject any proposed Hold Time.
+        if hold_time == 1 || hold_time == 2 {
+            return Err(nom::Err::Error(LocatedBgpOpenMessageParsingError::new(
+                begin_buf,
+                BgpOpenMessageParsingError::UnacceptableHoldTime(hold_time),
+            )));
+        }
         let (buf, bgp_id) = be_u32(buf)?;
+        let begin_buf = buf;
         let bgp_id = Ipv4Addr::from(bgp_id);
-        let (buf, params_buf) = nom::multi::length_data(be_u8)(buf)?;
-        let (_, params) = parse_till_empty_into_located(params_buf)?;
+        // RFC 4271: If the BGP Identifier field of the OPEN message is syntactically
+        // incorrect, then the Error Subcode MUST be set to Bad BGP Identifier.
+        // Syntactic correctness means that the BGP Identifier field represents
+        // a valid unicast IP host address. NOTE: not all BGP implementation
+        // check for syntactic correctness
+        if bgp_id.is_broadcast() || bgp_id.is_multicast() || bgp_id.is_unspecified() {
+            return Err(nom::Err::Error(LocatedBgpOpenMessageParsingError::new(
+                begin_buf,
+                BgpOpenMessageParsingError::InvalidBgpId(bgp_id.into()),
+            )));
+        }
+        let (buf, mut params_buf) = nom::multi::length_data(be_u8)(buf)?;
+        let mut params = Vec::new();
+        while !params_buf.is_empty() {
+            let (tmp, element) = parse_into_located_one_input(params_buf, &mut *ctx)?;
+            params.push(element);
+            params_buf = tmp;
+        }
         Ok((buf, BgpOpenMessage::new(my_as, hold_time, bgp_id, params)))
     }
 }
 
-impl<'a> ReadablePdu<'a, LocatedBgpParameterParsingError<'a>> for BgpOpenMessageParameter {
-    fn from_wire(buf: Span<'a>) -> IResult<Span<'a>, Self, LocatedBgpParameterParsingError<'a>> {
+impl<'a> ReadablePduWithOneInput<'a, &mut BgpParsingContext, LocatedBgpParameterParsingError<'a>>
+    for BgpOpenMessageParameter
+{
+    fn from_wire(
+        buf: Span<'a>,
+        ctx: &mut BgpParsingContext,
+    ) -> IResult<Span<'a>, Self, LocatedBgpParameterParsingError<'a>> {
         let begin_buf = buf;
         let (buf, param_type) =
             nom::combinator::map_res(be_u8, BgpOpenMessageParameterType::try_from)(buf)?;
         match param_type {
-            BgpOpenMessageParameterType::Capability => {
-                let (buf, capabilities_buf) = nom::multi::length_data(be_u8)(buf)?;
-                let (_, capabilities) = parse_till_empty_into_located(capabilities_buf)?;
-                Ok((buf, BgpOpenMessageParameter::Capabilities(capabilities)))
-            }
+            BgpOpenMessageParameterType::Capability => parse_capability_param(buf, ctx),
             BgpOpenMessageParameterType::ExtendedLength => {
                 return Err(nom::Err::Error(LocatedBgpParameterParsingError::new(
                     begin_buf,
@@ -94,6 +136,125 @@ impl<'a> ReadablePdu<'a, LocatedBgpParameterParsingError<'a>> for BgpOpenMessage
                     ),
                 )))
             }
+        }
+    }
+}
+
+#[inline]
+fn parse_capability_param<'a>(
+    buf: Span<'a>,
+    ctx: &mut BgpParsingContext,
+) -> IResult<Span<'a>, BgpOpenMessageParameter, LocatedBgpParameterParsingError<'a>> {
+    let (buf, mut capabilities_buf) = nom::multi::length_data(be_u8)(buf)?;
+    let mut capabilities = Vec::new();
+    while !capabilities_buf.is_empty() {
+        match BgpCapability::from_wire(capabilities_buf) {
+            Ok((tmp, capability)) => {
+                capabilities.push(capability);
+                capabilities_buf = tmp;
+            }
+            Err(err) => {
+                match err {
+                    nom::Err::Incomplete(needed) => Err(nom::Err::Incomplete(needed))?,
+                    nom::Err::Error(err) => {
+                        if !ctx.fail_on_capability_error {
+                            // Advance the parser and ignore malformed capability
+                            // RFC 5492 defines that a BGP speaker should ignore capabilities it
+                            // does not understand and not report any error.
+                            // It will only report a notification if the capability is
+                            // understood but not supported by the speaker
+                            let (tmp, _code) = be_u8(capabilities_buf)?;
+                            let (tmp, _value) = nom::multi::length_count(be_u8, be_u8)(tmp)?;
+                            capabilities_buf = tmp;
+                            ctx.parsing_errors
+                                .capability_errors
+                                .push(err.error().clone());
+                        } else {
+                            Err(nom::Err::Error(err.into()))?
+                        }
+                    }
+                    nom::Err::Failure(failure) => {
+                        if !ctx.fail_on_capability_error {
+                            // Advance the parser and ignore malformed capability
+                            // RFC 5492 defines that a BGP speaker should ignore capabilities it
+                            // does not understand and not report any error.
+                            // It will only report a notification if the capability is
+                            // understood but not supported by the speaker
+                            let (tmp, _code) = be_u8(capabilities_buf)?;
+                            let (tmp, _value) = nom::multi::length_count(be_u8, be_u8)(tmp)?;
+                            capabilities_buf = tmp;
+                            ctx.parsing_errors
+                                .capability_errors
+                                .push(failure.error().clone());
+                        } else {
+                            Err(nom::Err::Failure(failure.into()))?
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok((buf, BgpOpenMessageParameter::Capabilities(capabilities)))
+}
+
+impl From<BgpParameterParsingError> for OpenMessageError {
+    fn from(param_err: BgpParameterParsingError) -> Self {
+        match param_err {
+            // RFC 4271: If one of the Optional Parameters in the OPEN message is recognized, but is
+            // malformed, then the Error Subcode MUST be set to 0 (Unspecific)
+            BgpParameterParsingError::NomError(_) => OpenMessageError::Unspecific { value: vec![] },
+            // RFC 4271: If one of the Optional Parameters in the OPEN message is not recognized,
+            // then the Error Subcode MUST be set to Unsupported Optional Parameters.
+            BgpParameterParsingError::UndefinedParameterType(param_type) => {
+                OpenMessageError::UnsupportedOptionalParameter {
+                    value: vec![param_type.0],
+                }
+            }
+            // RFC 5492 defines that a BGP speaker should ignore capabilities it
+            // does not understand and not report any error.
+            // It will only report a notification if the capability is
+            // understood but not supported by the speaker. If an error is reported anyways by the
+            // parser we set the notif to Unspecific
+            BgpParameterParsingError::CapabilityError(_) => {
+                OpenMessageError::Unspecific { value: vec![] }
+            }
+        }
+    }
+}
+
+impl From<BgpOpenMessageParsingError> for OpenMessageError {
+    fn from(error: BgpOpenMessageParsingError) -> Self {
+        match error {
+            BgpOpenMessageParsingError::NomError(_) => {
+                OpenMessageError::Unspecific { value: vec![] }
+            }
+            // RFC 4271: If the version number in the Version field of the received OPEN message is
+            // not supported, then the Error Subcode MUST be set to Unsupported Version Number.
+            // The Data field is a 2-octet unsigned integer, which indicates the largest,
+            // locally-supported version number less than the version the remote BGP peer bid (as
+            // indicated in the received OPEN message), or if the smallest, locally-supported
+            // version number is greater than the version the remote BGP peer bid, then the
+            // smallest, locally-supported version number.
+            BgpOpenMessageParsingError::UnsupportedVersionNumber(_) => {
+                OpenMessageError::UnsupportedVersionNumber {
+                    value: (BGP_VERSION as u16).to_be_bytes().to_vec(),
+                }
+            }
+            BgpOpenMessageParsingError::UnacceptableHoldTime(hold_time) => {
+                OpenMessageError::UnacceptableHoldTime {
+                    value: hold_time.to_be_bytes().to_vec(),
+                }
+            }
+            // RFC 4271: If the BGP Identifier field of the OPEN message is syntactically incorrect,
+            // then the Error Subcode MUST be set to Bad BGP Identifier. Syntactic correctness means
+            // that the BGP Identifier field represents a valid unicast IP host address.
+            // NOTE: not all BGP implementation check for syntactic correctness
+            BgpOpenMessageParsingError::InvalidBgpId(bgp_id) => {
+                OpenMessageError::BadBgpIdentifier {
+                    value: bgp_id.to_be_bytes().to_vec(),
+                }
+            }
+            BgpOpenMessageParsingError::ParameterError(param_error) => param_error.into(),
         }
     }
 }

--- a/crates/bgp-pkt/src/wire/deserializer/route_refresh.rs
+++ b/crates/bgp-pkt/src/wire/deserializer/route_refresh.rs
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 
 use netgauze_serde_macros::LocatedError;
 
+use crate::notification::RouteRefreshError;
 use netgauze_parse_utils::ErrorKindSerdeDeref;
 
 /// BGP Route Refresh Message Parsing errors
@@ -66,5 +67,18 @@ impl<'a> ReadablePdu<'a, LocatedBgpRouteRefreshMessageParsingError<'a>> for BgpR
             }
         };
         Ok((buf, BgpRouteRefreshMessage::new(address_type, op)))
+    }
+}
+
+impl From<BgpRouteRefreshMessageParsingError> for RouteRefreshError {
+    fn from(_value: BgpRouteRefreshMessageParsingError) -> Self {
+        // Mapping all RouteRefresh errors to invalid length
+        // TODO implement RFC 7313 error handling: If the length, excluding the
+        // fixed-size message header, of the received ROUTE-REFRESH message with Message
+        // Subtype 1 and 2 is not 4, then the BGP speaker MUST send a NOTIFICATION
+        // message with the Error Code of "ROUTE-REFRESH Message Error" and the subcode
+        // of "Invalid Message Length". The Data field of the NOTIFICATION message MUST
+        // ontain the complete ROUTE-REFRESH message.
+        RouteRefreshError::InvalidMessageLength { value: vec![] }
     }
 }

--- a/crates/bgp-pkt/src/wire/deserializer/update.rs
+++ b/crates/bgp-pkt/src/wire/deserializer/update.rs
@@ -15,17 +15,32 @@
 
 //! Deserializer for BGP Update message
 
-use crate::{wire::deserializer::path_attribute::PathAttributeParsingError, BgpUpdateMessage};
+use crate::{
+    wire::deserializer::path_attribute::{
+        LocatedPathAttributeParsingError, PathAttributeParsingError,
+    },
+    BgpUpdateMessage,
+};
+use ipnet::Ipv4Net;
 use netgauze_iana::address_family::AddressType;
 use netgauze_parse_utils::{
-    parse_till_empty_into_with_one_input_located, parse_till_empty_into_with_three_inputs_located,
-    ReadablePduWithThreeInputs, Span,
+    parse_into_located, LocatedParsingError, ReadablePduWithOneInput, Span,
 };
-use nom::{error::ErrorKind, number::complete::be_u16, IResult};
+use nom::{
+    number::complete::{be_u16, be_u32, be_u8},
+    IResult,
+};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
-use crate::wire::deserializer::nlri::{Ipv4UnicastAddressParsingError, Ipv4UnicastParsingError};
+use crate::{
+    nlri::{InvalidIpv4UnicastNetwork, Ipv4Unicast, Ipv4UnicastAddress},
+    notification::UpdateMessageError,
+    path_attribute::PathAttribute,
+    wire::deserializer::{
+        path_attribute::{OriginParsingError, EXTENDED_LENGTH_PATH_ATTRIBUTE_MASK},
+        BgpParsingContext, Ipv4PrefixParsingError,
+    },
+};
 use netgauze_parse_utils::ErrorKindSerdeDeref;
 use netgauze_serde_macros::LocatedError;
 
@@ -35,51 +50,350 @@ pub enum BgpUpdateMessageParsingError {
     /// Errors triggered by the nom parser, see [nom::error::ErrorKind] for
     /// additional information.
     #[serde(with = "ErrorKindSerdeDeref")]
-    NomError(#[from_nom] ErrorKind),
+    NomError(#[from_nom] nom::error::ErrorKind),
     PathAttributeError(
         #[from_located(module = "crate::wire::deserializer::path_attribute")]
         PathAttributeParsingError,
     ),
-    Ipv4UnicastError(
-        #[from_located(module = "crate::wire::deserializer::nlri")] Ipv4UnicastParsingError,
-    ),
-    Ipv4UnicastAddressError(
-        #[from_located(module = "crate::wire::deserializer::nlri")] Ipv4UnicastAddressParsingError,
-    ),
+    Ipv4PrefixError(#[from_located(module = "crate::wire::deserializer")] Ipv4PrefixParsingError),
+    InvalidIpv4UnicastNetwork(InvalidIpv4UnicastNetwork),
+}
+
+#[inline]
+fn parse_nlri<'a>(
+    buf: Span<'a>,
+    add_path: bool,
+    is_update: bool,
+    ctx: &mut BgpParsingContext,
+) -> IResult<Span<'a>, Vec<Ipv4UnicastAddress>, LocatedBgpUpdateMessageParsingError<'a>> {
+    let mut buf = buf;
+    let mut nlri_vec = Vec::new();
+    while !buf.is_empty() {
+        let (tmp, path_id) = if add_path {
+            let (tmp, add_path) = be_u32(buf)?;
+            (tmp, Some(add_path))
+        } else {
+            (buf, None)
+        };
+        let buf_begin = tmp;
+        let (tmp, ipv4_net): (Span<'a>, Ipv4Net) = parse_into_located(tmp)?;
+        match Ipv4Unicast::from_net(ipv4_net) {
+            Ok(unicast) => {
+                let address = Ipv4UnicastAddress::new(path_id, unicast);
+                nlri_vec.push(address);
+            }
+            Err(err) => {
+                // RFC 4271: If a prefix in the NLRI field is semantically incorrect (e.g., an
+                // unexpected multicast IP address), an error SHOULD be logged locally, and the
+                // prefix SHOULD be ignored.
+                if is_update && ctx.fail_on_non_unicast_update_nlri {
+                    ctx.parsing_errors.non_unicast_update_nlri.push(ipv4_net);
+                }
+                if !is_update && !ctx.fail_on_non_unicast_withdraw_nlri {
+                    ctx.parsing_errors.non_unicast_withdraw_nlri.push(ipv4_net);
+                } else if is_update && !ctx.fail_on_non_unicast_update_nlri {
+                    ctx.parsing_errors.non_unicast_update_nlri.push(ipv4_net);
+                } else {
+                    return Err(nom::Err::Error(LocatedBgpUpdateMessageParsingError::new(
+                        buf_begin,
+                        BgpUpdateMessageParsingError::InvalidIpv4UnicastNetwork(err),
+                    )));
+                }
+            }
+        };
+        buf = tmp;
+    }
+    Ok((buf, nlri_vec))
+}
+
+#[inline]
+fn advance_attr_buffer(
+    path_attributes_buf: Span<'_>,
+) -> IResult<Span<'_>, Span<'_>, LocatedBgpUpdateMessageParsingError<'_>> {
+    let (buf, attributes) = be_u8(path_attributes_buf)?;
+    let (buf, _code) = be_u8(buf)?;
+    let extended_length =
+        attributes & EXTENDED_LENGTH_PATH_ATTRIBUTE_MASK == EXTENDED_LENGTH_PATH_ATTRIBUTE_MASK;
+    let (buf, length) = if extended_length {
+        let (buf, length) = be_u16(buf)?;
+        (buf, length as usize)
+    } else {
+        let (buf, length) = be_u8(buf)?;
+        (buf, length as usize)
+    };
+    nom::bytes::complete::take(length)(buf)
+}
+
+/// Length is for value length only (not counting attribute type and extra byte
+/// for extended length)
+#[inline]
+fn advance_attr_buffer_fixed(
+    length: usize,
+    path_attributes_buf: Span<'_>,
+) -> IResult<Span<'_>, Span<'_>, LocatedBgpUpdateMessageParsingError<'_>> {
+    let (buf, attributes) = be_u8(path_attributes_buf)?;
+    let extended_length =
+        attributes & EXTENDED_LENGTH_PATH_ATTRIBUTE_MASK == EXTENDED_LENGTH_PATH_ATTRIBUTE_MASK;
+    if extended_length {
+        // extra one for path attribute type
+        // extra two for extended length
+        nom::bytes::complete::take(length + 3)(buf)
+    } else {
+        // extra one for path attribute type
+        // extra one for length
+        nom::bytes::complete::take(length + 2)(buf)
+    }
 }
 
 impl<'a>
-    ReadablePduWithThreeInputs<
-        'a,
-        bool,
-        &HashMap<AddressType, u8>,
-        &HashMap<AddressType, bool>,
-        LocatedBgpUpdateMessageParsingError<'a>,
-    > for BgpUpdateMessage
+    ReadablePduWithOneInput<'a, &mut BgpParsingContext, LocatedBgpUpdateMessageParsingError<'a>>
+    for BgpUpdateMessage
 {
     fn from_wire(
         buf: Span<'a>,
-        asn4: bool,
-        multiple_labels: &HashMap<AddressType, u8>,
-        add_path_map: &HashMap<AddressType, bool>,
+        ctx: &mut BgpParsingContext,
     ) -> IResult<Span<'a>, Self, LocatedBgpUpdateMessageParsingError<'a>> {
-        let (buf, withdrawn_buf) = nom::multi::length_data(be_u16)(buf)?;
-        let add_path = add_path_map
+        let add_path = ctx
+            .add_path
             .get(&AddressType::Ipv4Unicast)
             .map_or(false, |x| *x);
-        let (_, withdrawn_routes) =
-            parse_till_empty_into_with_one_input_located(withdrawn_buf, add_path)?;
-        let (buf, path_attributes_buf) = nom::multi::length_data(be_u16)(buf)?;
-        let (_, path_attributes) = parse_till_empty_into_with_three_inputs_located(
-            path_attributes_buf,
-            asn4,
-            multiple_labels,
-            add_path_map,
-        )?;
-        let (buf, nlri_vec) = parse_till_empty_into_with_one_input_located(buf, add_path)?;
+        let (buf, withdrawn_buf) = nom::multi::length_data(be_u16)(buf)?;
+        let (_, withdrawn_routes) = parse_nlri(withdrawn_buf, add_path, false, ctx)?;
+        let (buf, mut path_attributes_buf) = nom::multi::length_data(be_u16)(buf)?;
+        let mut path_attributes = Vec::new();
+        while !path_attributes_buf.is_empty() {
+            match PathAttribute::from_wire(path_attributes_buf, &mut *ctx) {
+                Ok((tmp, element)) => {
+                    path_attributes.push(element);
+                    path_attributes_buf = tmp;
+                }
+                Err(nom_err) => match nom_err {
+                    nom::Err::Incomplete(needed) => Err(nom::Err::Incomplete(needed))?,
+                    nom::Err::Error(located_path_attr_error) => {
+                        if ctx.fail_on_malformed_path_attr {
+                            return Err(nom::Err::Error(located_path_attr_error.into()));
+                        }
+                        let (tmp, _) =
+                            handle_path_error(path_attributes_buf, ctx, &located_path_attr_error)?;
+                        path_attributes_buf = tmp;
+                        ctx.parsing_errors
+                            .path_attr_errors
+                            .push(located_path_attr_error.error().clone());
+                    }
+                    nom::Err::Failure(located_path_attr_error) => {
+                        if ctx.fail_on_malformed_path_attr {
+                            return Err(nom::Err::Error(located_path_attr_error.into()));
+                        }
+                        let (tmp, _) =
+                            handle_path_error(path_attributes_buf, ctx, &located_path_attr_error)?;
+                        path_attributes_buf = tmp;
+                        ctx.parsing_errors
+                            .path_attr_errors
+                            .push(located_path_attr_error.error().clone());
+                    }
+                },
+            };
+        }
+        let (buf, nlri_vec) = parse_nlri(buf, add_path, true, ctx)?;
         Ok((
             buf,
             BgpUpdateMessage::new(withdrawn_routes, path_attributes, nlri_vec),
         ))
+    }
+}
+
+fn handle_path_error<'a>(
+    path_attributes_buf: Span<'a>,
+    ctx: &mut BgpParsingContext,
+    located_path_attr_error: &LocatedPathAttributeParsingError<'a>,
+) -> IResult<Span<'a>, (), LocatedBgpUpdateMessageParsingError<'a>> {
+    let buf = match located_path_attr_error.error() {
+        PathAttributeParsingError::NomError(_) => {
+            return Err(nom::Err::Error(located_path_attr_error.clone().into()));
+        }
+        PathAttributeParsingError::OriginError(_) => {
+            let (buf, _) = advance_attr_buffer_fixed(1usize, path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::AsPathError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::NextHopError(_) => {
+            let (buf, _) = advance_attr_buffer_fixed(4usize, path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::MultiExitDiscriminatorError(_) => {
+            let (buf, _) = advance_attr_buffer_fixed(4usize, path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::LocalPreferenceError(_) => {
+            let (buf, _) = advance_attr_buffer_fixed(4usize, path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::AtomicAggregateError(_) => {
+            let (buf, _) = advance_attr_buffer_fixed(0usize, path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::AggregatorError(_) => {
+            let size = if ctx.asn4 { 8usize } else { 6usize };
+            let (buf, _) = advance_attr_buffer_fixed(size, path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::CommunitiesError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::ExtendedCommunitiesError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::ExtendedCommunitiesErrorIpv6(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::LargeCommunitiesError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::OriginatorError(_) => {
+            let (buf, _) = advance_attr_buffer_fixed(4usize, path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::ClusterListError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::MpReachErrorError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::MpUnreachErrorError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::OnlyToCustomerError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::AigpError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::UnknownAttributeError(_) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+        PathAttributeParsingError::InvalidPathAttribute(_, _) => {
+            let (buf, _) = advance_attr_buffer(path_attributes_buf)?;
+            buf
+        }
+    };
+    Ok((buf, ()))
+}
+
+impl From<BgpUpdateMessageParsingError> for UpdateMessageError {
+    fn from(value: BgpUpdateMessageParsingError) -> Self {
+        // For EoF errors we follow: RFC 4271 Error checking of an UPDATE message begins
+        // by examining the path attributes. If the Withdrawn Routes Length or
+        // Total Attribute Length is too large (i.e., if Withdrawn Routes Length
+        // + Total Attribute Length + 23 exceeds the message Length), then the
+        // Error Subcode MUST be set to Malformed Attribute List.
+        match value {
+            BgpUpdateMessageParsingError::NomError(err) => {
+                if err == nom::error::ErrorKind::Eof {
+                    UpdateMessageError::MalformedAttributeList { value: vec![] }
+                } else {
+                    UpdateMessageError::Unspecific { value: vec![] }
+                }
+            }
+            BgpUpdateMessageParsingError::PathAttributeError(attr_err) => {
+                // TODO need to be refined in accordance with RFC 7606
+                match attr_err {
+                    PathAttributeParsingError::NomError(_) => {
+                        UpdateMessageError::MalformedAttributeList { value: vec![] }
+                    }
+                    PathAttributeParsingError::OriginError(err) => match err {
+                        OriginParsingError::NomError(_) => {
+                            UpdateMessageError::InvalidOriginAttribute { value: vec![] }
+                        }
+                        OriginParsingError::InvalidOriginLength(_) => {
+                            UpdateMessageError::InvalidOriginAttribute { value: vec![] }
+                        }
+                        OriginParsingError::UndefinedOrigin(_) => {
+                            UpdateMessageError::InvalidOriginAttribute { value: vec![] }
+                        }
+                    },
+                    PathAttributeParsingError::AsPathError(_) => {
+                        UpdateMessageError::MalformedAsPath { value: vec![] }
+                    }
+                    PathAttributeParsingError::NextHopError(_) => {
+                        UpdateMessageError::InvalidNextHopAttribute { value: vec![] }
+                    }
+                    PathAttributeParsingError::MultiExitDiscriminatorError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::LocalPreferenceError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::AtomicAggregateError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::AggregatorError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::CommunitiesError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::ExtendedCommunitiesError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::ExtendedCommunitiesErrorIpv6(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::LargeCommunitiesError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::OriginatorError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::ClusterListError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::MpReachErrorError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::MpUnreachErrorError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::OnlyToCustomerError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::AigpError(_) => {
+                        UpdateMessageError::OptionalAttributeError { value: vec![] }
+                    }
+                    PathAttributeParsingError::UnknownAttributeError(_) => {
+                        UpdateMessageError::Unspecific { value: vec![] }
+                    }
+                    PathAttributeParsingError::InvalidPathAttribute(_, _) => {
+                        UpdateMessageError::AttributeFlagsError { value: vec![] }
+                    }
+                }
+            }
+            BgpUpdateMessageParsingError::Ipv4PrefixError(prefix_err) => {
+                if Ipv4PrefixParsingError::NomError(nom::error::ErrorKind::Eof) == prefix_err {
+                    return UpdateMessageError::MalformedAttributeList { value: vec![] };
+                }
+                UpdateMessageError::InvalidNetworkField { value: vec![] }
+            }
+            BgpUpdateMessageParsingError::InvalidIpv4UnicastNetwork(_) => {
+                // RFC 4271: If a prefix in the NLRI field is semantically incorrect (e.g., an
+                // unexpected multicast IP address), an error SHOULD be logged locally, and the
+                // prefix SHOULD be ignored.
+                // If parser is configured to be strict and this error triggered, then report
+                // Unspecific error
+                UpdateMessageError::Unspecific { value: vec![] }
+            }
+        }
     }
 }

--- a/crates/bgp-pkt/src/wire/tests/keepalive.rs
+++ b/crates/bgp-pkt/src/wire/tests/keepalive.rs
@@ -14,13 +14,14 @@
 // limitations under the License.
 
 use crate::{
-    wire::{serializer::BgpMessageWritingError, tests::BGP_MARKER},
+    wire::{
+        deserializer::BgpParsingContext, serializer::BgpMessageWritingError, tests::BGP_MARKER,
+    },
     BgpMessage,
 };
 use netgauze_parse_utils::test_helpers::{
-    combine, test_parsed_completely_with_three_inputs, test_write,
+    combine, test_parsed_completely_with_one_input, test_write,
 };
-use std::collections::HashMap;
 
 #[test]
 fn test_keep_alive() -> Result<(), BgpMessageWritingError> {
@@ -28,20 +29,12 @@ fn test_keep_alive() -> Result<(), BgpMessageWritingError> {
 
     let good = BgpMessage::KeepAlive;
 
-    test_parsed_completely_with_three_inputs(
+    test_parsed_completely_with_one_input(
         &good_wire[..],
-        false,
-        &HashMap::new(),
-        &HashMap::new(),
+        &mut BgpParsingContext::asn2_default(),
         &good,
     );
-    test_parsed_completely_with_three_inputs(
-        &good_wire[..],
-        true,
-        &HashMap::new(),
-        &HashMap::new(),
-        &good,
-    );
+    test_parsed_completely_with_one_input(&good_wire[..], &mut BgpParsingContext::default(), &good);
 
     test_write(&good, &good_wire[..])?;
     Ok(())

--- a/crates/bgp-pkt/src/wire/tests/update.rs
+++ b/crates/bgp-pkt/src/wire/tests/update.rs
@@ -14,14 +14,20 @@
 // limitations under the License.
 
 use crate::{
-    nlri::{Ipv4Unicast, Ipv4UnicastAddress},
+    nlri::{InvalidIpv4UnicastNetwork, Ipv4Unicast, Ipv4UnicastAddress},
+    path_attribute::{
+        As4PathSegment, AsPath, AsPathSegmentType, NextHop, Origin, PathAttribute,
+        PathAttributeValue,
+    },
     wire::{
         deserializer::{
             nlri::{
                 Ipv4UnicastAddressParsingError, Ipv4UnicastParsingError,
                 LocatedIpv4UnicastAddressParsingError,
             },
-            Ipv4PrefixParsingError,
+            update::BgpUpdateMessageParsingError,
+            BgpMessageParsingError, BgpParsingContext, Ipv4PrefixParsingError,
+            LocatedBgpMessageParsingError,
         },
         serializer::{nlri::Ipv4UnicastAddressWritingError, BgpMessageWritingError},
     },
@@ -31,8 +37,7 @@ use ipnet::Ipv4Net;
 use netgauze_parse_utils::{
     test_helpers::{
         test_parse_error_with_one_input, test_parsed_completely,
-        test_parsed_completely_with_one_input, test_parsed_completely_with_three_inputs,
-        test_write,
+        test_parsed_completely_with_one_input, test_write,
     },
     Span,
 };
@@ -105,11 +110,9 @@ fn test_empty_update() -> Result<(), BgpMessageWritingError> {
         0xff, 0x00, 0x17, 0x02, 0x00, 0x00, 0x00, 0x00,
     ];
     let good = BgpMessage::Update(BgpUpdateMessage::new(vec![], vec![], vec![]));
-    test_parsed_completely_with_three_inputs(
+    test_parsed_completely_with_one_input(
         &good_wire,
-        false,
-        &HashMap::new(),
-        &HashMap::new(),
+        &mut BgpParsingContext::asn2_default(),
         &good,
     );
     test_write(&good, &good_wire)?;
@@ -130,13 +133,199 @@ fn test_withdraw_update() -> Result<(), BgpMessageWritingError> {
         vec![],
     ));
 
-    test_parsed_completely_with_three_inputs(
+    test_parsed_completely_with_one_input(
         &good_withdraw_wire,
-        false,
-        &HashMap::new(),
-        &HashMap::new(),
+        &mut BgpParsingContext::asn2_default(),
         &good_withdraw,
     );
     test_write(&good_withdraw, &good_withdraw_wire)?;
+    Ok(())
+}
+
+#[test]
+fn test_update_non_unicast_nlri() -> Result<(), BgpMessageWritingError> {
+    let good_update_wire = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0x00, 0x40, 0x02, 0x00, 0x08, 0x18, 0xac, 0x10, 0x03, 0x18, 0xac, 0x10, 0x04, 0x00,
+        0x19, 0x40, 0x01, 0x01, 0x00, 0x50, 0x02, 0x00, 0x0a, 0x02, 0x02, 0x00, 0x00, 0x00, 0xc8,
+        0x00, 0x00, 0x00, 0x64, 0x40, 0x03, 0x04, 0xac, 0x10, 0x00, 0x14, 0x18, 0xac, 0x10, 0x01,
+        0x18, 0xac, 0x10, 0x02,
+    ];
+
+    let bad_multicast_nlri_wire = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0x00, 0x40, 0x02, 0x00, 0x08, 0x18, 0xe0, 0x01, 0x01, 0x18, 0xac, 0x10, 0x04, 0x00,
+        0x19, 0x40, 0x01, 0x01, 0x00, 0x50, 0x02, 0x00, 0x0a, 0x02, 0x02, 0x00, 0x00, 0x00, 0xc8,
+        0x00, 0x00, 0x00, 0x64, 0x40, 0x03, 0x04, 0xac, 0x10, 0x00, 0x14, 0x18, 0xe0, 0x10, 0x01,
+        0x18, 0xac, 0x10, 0x02,
+    ];
+    let good_update = BgpMessage::Update(BgpUpdateMessage::new(
+        vec![
+            Ipv4UnicastAddress::new_no_path_id(
+                Ipv4Unicast::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 3, 0), 24).unwrap())
+                    .unwrap(),
+            ),
+            Ipv4UnicastAddress::new_no_path_id(
+                Ipv4Unicast::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 4, 0), 24).unwrap())
+                    .unwrap(),
+            ),
+        ],
+        vec![
+            PathAttribute::from(
+                false,
+                true,
+                false,
+                false,
+                PathAttributeValue::Origin(Origin::IGP),
+            )
+            .unwrap(),
+            PathAttribute::from(
+                false,
+                true,
+                false,
+                true,
+                PathAttributeValue::AsPath(AsPath::As4PathSegments(vec![As4PathSegment::new(
+                    AsPathSegmentType::AsSequence,
+                    vec![200, 100],
+                )])),
+            )
+            .unwrap(),
+            PathAttribute::from(
+                false,
+                true,
+                false,
+                false,
+                PathAttributeValue::NextHop(NextHop::new(Ipv4Addr::new(172, 16, 0, 20))),
+            )
+            .unwrap(),
+        ],
+        vec![
+            Ipv4UnicastAddress::new_no_path_id(
+                Ipv4Unicast::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 1, 0), 24).unwrap())
+                    .unwrap(),
+            ),
+            Ipv4UnicastAddress::new_no_path_id(
+                Ipv4Unicast::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 2, 0), 24).unwrap())
+                    .unwrap(),
+            ),
+        ],
+    ));
+
+    let good_update_without_multicast = BgpMessage::Update(BgpUpdateMessage::new(
+        vec![Ipv4UnicastAddress::new_no_path_id(
+            Ipv4Unicast::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 4, 0), 24).unwrap()).unwrap(),
+        )],
+        vec![
+            PathAttribute::from(
+                false,
+                true,
+                false,
+                false,
+                PathAttributeValue::Origin(Origin::IGP),
+            )
+            .unwrap(),
+            PathAttribute::from(
+                false,
+                true,
+                false,
+                true,
+                PathAttributeValue::AsPath(AsPath::As4PathSegments(vec![As4PathSegment::new(
+                    AsPathSegmentType::AsSequence,
+                    vec![200, 100],
+                )])),
+            )
+            .unwrap(),
+            PathAttribute::from(
+                false,
+                true,
+                false,
+                false,
+                PathAttributeValue::NextHop(NextHop::new(Ipv4Addr::new(172, 16, 0, 20))),
+            )
+            .unwrap(),
+        ],
+        vec![Ipv4UnicastAddress::new_no_path_id(
+            Ipv4Unicast::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 2, 0), 24).unwrap()).unwrap(),
+        )],
+    ));
+    let invalid_nlri_address = LocatedBgpMessageParsingError::new(
+        unsafe { Span::new_from_raw_offset(21, &bad_multicast_nlri_wire[21..21 + 8]) },
+        BgpMessageParsingError::BgpUpdateMessageParsingError(
+            BgpUpdateMessageParsingError::InvalidIpv4UnicastNetwork(InvalidIpv4UnicastNetwork(
+                Ipv4Net::from_str("224.1.1.0/24").unwrap(),
+            )),
+        ),
+    );
+
+    test_parsed_completely_with_one_input(
+        &good_update_wire,
+        &mut BgpParsingContext::default(),
+        &good_update,
+    );
+
+    test_write(&good_update, &good_update_wire)?;
+
+    test_parse_error_with_one_input::<
+        BgpMessage,
+        &mut BgpParsingContext,
+        LocatedBgpMessageParsingError<'_>,
+    >(
+        &bad_multicast_nlri_wire,
+        &mut BgpParsingContext::new(
+            true,
+            HashMap::new(),
+            HashMap::new(),
+            true,
+            false,
+            false,
+            false,
+        ),
+        &invalid_nlri_address,
+    );
+
+    test_parsed_completely_with_one_input(
+        &bad_multicast_nlri_wire,
+        &mut BgpParsingContext::new(
+            true,
+            HashMap::new(),
+            HashMap::new(),
+            false,
+            false,
+            false,
+            false,
+        ),
+        &good_update_without_multicast,
+    );
+    Ok(())
+}
+
+#[test]
+fn test_update_bad_length() -> Result<(), BgpMessageWritingError> {
+    let bad_withdraw_length_short_wire = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0x00, 0x40, 0x02, 0x00, 0x07, 0x18, 0xac, 0x10, 0x03, 0x18, 0xac, 0x10, 0x04, 0x00,
+        0x19, 0x40, 0x01, 0x01, 0x00, 0x50, 0x02, 0x00, 0x0a, 0x02, 0x02, 0x00, 0x00, 0x00, 0xc8,
+        0x00, 0x00, 0x00, 0x64, 0x40, 0x03, 0x04, 0xac, 0x10, 0x00, 0x14, 0x18, 0xac, 0x10, 0x01,
+        0x18, 0xac, 0x10, 0x02,
+    ];
+
+    let bad_withdraw_length_short = LocatedBgpMessageParsingError::new(
+        unsafe { Span::new_from_raw_offset(26, &bad_withdraw_length_short_wire[26..26 + 2]) },
+        BgpMessageParsingError::BgpUpdateMessageParsingError(
+            BgpUpdateMessageParsingError::Ipv4PrefixError(Ipv4PrefixParsingError::NomError(
+                ErrorKind::Eof,
+            )),
+        ),
+    );
+
+    test_parse_error_with_one_input::<
+        BgpMessage,
+        &mut BgpParsingContext,
+        LocatedBgpMessageParsingError<'_>,
+    >(
+        &bad_withdraw_length_short_wire,
+        &mut BgpParsingContext::default(),
+        &bad_withdraw_length_short,
+    );
     Ok(())
 }

--- a/crates/bgp-speaker/src/supervisor.rs
+++ b/crates/bgp-speaker/src/supervisor.rs
@@ -21,7 +21,10 @@ use crate::{
         PeerPolicy, PeerProperties, PeerStateResult,
     },
 };
-use netgauze_bgp_pkt::{wire::serializer::BgpMessageWritingError, BgpMessage};
+use netgauze_bgp_pkt::{
+    wire::{deserializer::BgpParsingIgnoredErrors, serializer::BgpMessageWritingError},
+    BgpMessage,
+};
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Debug, Display},
@@ -62,7 +65,7 @@ impl<
 
     pub fn add_peer<
         D: BgpCodecInitializer<Peer<A, I, D, C, P>>
-            + Decoder<Item = BgpMessage, Error = BgpCodecDecoderError>
+            + Decoder<Item = (BgpMessage, BgpParsingIgnoredErrors), Error = BgpCodecDecoderError>
             + Encoder<BgpMessage, Error = BgpMessageWritingError>
             + Send
             + Sync,
@@ -107,7 +110,7 @@ impl<
     #[allow(clippy::type_complexity)]
     pub fn dynamic_peer<
         D: BgpCodecInitializer<Peer<A, I, D, C, EchoCapabilitiesPolicy<A, I, D>>>
-            + Decoder<Item = BgpMessage, Error = BgpCodecDecoderError>
+            + Decoder<Item = (BgpMessage, BgpParsingIgnoredErrors), Error = BgpCodecDecoderError>
             + Encoder<BgpMessage, Error = BgpMessageWritingError>
             + Send
             + Sync

--- a/crates/bmp-pkt/examples/bmp.rs
+++ b/crates/bmp-pkt/examples/bmp.rs
@@ -7,7 +7,7 @@ use netgauze_bmp_pkt::{
     iana::RouteMirroringInformation, BmpMessage, BmpMessageValue, BmpPeerType, MirroredBgpMessage,
     PeerHeader, RouteMirroringMessage, RouteMirroringValue,
 };
-use netgauze_parse_utils::{ReadablePduWithTwoInputs, Span, WritablePdu};
+use netgauze_parse_utils::{ReadablePduWithOneInput, Span, WritablePdu};
 use std::{
     collections::HashMap,
     io::Cursor,
@@ -51,7 +51,6 @@ fn main() {
     );
 
     // Deserialize the message from binary format
-    let (_, bmp_msg_back) =
-        BmpMessage::from_wire(Span::new(&buf), &HashMap::new(), &HashMap::new()).unwrap();
+    let (_, bmp_msg_back) = BmpMessage::from_wire(Span::new(&buf), &mut HashMap::new()).unwrap();
     assert_eq!(bmp_msg, bmp_msg_back);
 }

--- a/crates/bmp-pkt/src/wire/deserializer/mod.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/mod.rs
@@ -24,7 +24,9 @@ use std::{
 
 use netgauze_bgp_pkt::{
     iana::BgpMessageType,
-    wire::deserializer::{nlri::RouteDistinguisherParsingError, BgpMessageParsingError},
+    wire::deserializer::{
+        nlri::RouteDistinguisherParsingError, BgpMessageParsingError, BgpParsingContext,
+    },
     BgpMessage,
 };
 use netgauze_iana::address_family::{
@@ -38,9 +40,8 @@ use nom::{
 };
 
 use netgauze_parse_utils::{
-    parse_into_located, parse_into_located_three_inputs, parse_into_located_two_inputs,
-    parse_till_empty_into_located, parse_till_empty_into_with_three_inputs_located,
-    ErrorKindSerdeDeref, ReadablePdu, ReadablePduWithThreeInputs, ReadablePduWithTwoInputs, Span,
+    parse_into_located, parse_into_located_one_input, parse_till_empty_into_located,
+    ErrorKindSerdeDeref, ReadablePdu, ReadablePduWithOneInput, Span,
 };
 use netgauze_serde_macros::LocatedError;
 
@@ -56,17 +57,15 @@ pub enum BmpMessageParsingError {
 }
 
 impl<'a>
-    ReadablePduWithTwoInputs<
+    ReadablePduWithOneInput<
         'a,
-        &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        &mut HashMap<PeerKey, BgpParsingContext>,
         LocatedBmpMessageParsingError<'a>,
     > for BmpMessage
 {
     fn from_wire(
         buf: Span<'a>,
-        multiple_labels: &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        add_path: &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        ctx: &mut HashMap<PeerKey, BgpParsingContext>,
     ) -> IResult<Span<'a>, Self, LocatedBmpMessageParsingError<'a>> {
         let (buf, version) = nom::combinator::map_res(be_u8, BmpVersion::try_from)(buf)?;
         let input = buf;
@@ -82,7 +81,7 @@ impl<'a>
 
         let (buf, msg) = match version {
             BmpVersion::Version3 => {
-                let (buf, value) = parse_into_located_two_inputs(buf, multiple_labels, add_path)?;
+                let (buf, value) = parse_into_located_one_input(buf, ctx)?;
                 (buf, BmpMessage::V3(value))
             }
         };
@@ -120,22 +119,20 @@ pub enum BmpMessageValueParsingError {
 }
 
 impl<'a>
-    ReadablePduWithTwoInputs<
+    ReadablePduWithOneInput<
         'a,
-        &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        &mut HashMap<PeerKey, BgpParsingContext>,
         LocatedBmpMessageValueParsingError<'a>,
     > for BmpMessageValue
 {
     fn from_wire(
         buf: Span<'a>,
-        multiple_labels: &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        add_path: &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        ctx: &mut HashMap<PeerKey, BgpParsingContext>,
     ) -> IResult<Span<'a>, Self, LocatedBmpMessageValueParsingError<'a>> {
         let (buf, msg_type) = nom::combinator::map_res(be_u8, BmpMessageType::try_from)(buf)?;
         let (buf, msg) = match msg_type {
             BmpMessageType::RouteMonitoring => {
-                let (buf, value) = parse_into_located_two_inputs(buf, multiple_labels, add_path)?;
+                let (buf, value) = parse_into_located_one_input(buf, ctx)?;
                 (buf, BmpMessageValue::RouteMonitoring(value))
             }
             BmpMessageType::StatisticsReport => {
@@ -143,11 +140,11 @@ impl<'a>
                 (buf, BmpMessageValue::StatisticsReport(value))
             }
             BmpMessageType::PeerDownNotification => {
-                let (buf, value) = parse_into_located_two_inputs(buf, multiple_labels, add_path)?;
+                let (buf, value) = parse_into_located_one_input(buf, ctx)?;
                 (buf, BmpMessageValue::PeerDownNotification(value))
             }
             BmpMessageType::PeerUpNotification => {
-                let (buf, value) = parse_into_located_two_inputs(buf, multiple_labels, add_path)?;
+                let (buf, value) = parse_into_located_one_input(buf, ctx)?;
                 (buf, BmpMessageValue::PeerUpNotification(value))
             }
             BmpMessageType::Initiation => {
@@ -159,7 +156,7 @@ impl<'a>
                 (buf, BmpMessageValue::Termination(init))
             }
             BmpMessageType::RouteMirroring => {
-                let (buf, init) = parse_into_located_two_inputs(buf, multiple_labels, add_path)?;
+                let (buf, init) = parse_into_located_one_input(buf, ctx)?;
                 (buf, BmpMessageValue::RouteMirroring(init))
             }
             BmpMessageType::Experimental251 => {
@@ -286,33 +283,23 @@ pub enum RouteMonitoringMessageParsingError {
 }
 
 impl<'a>
-    ReadablePduWithTwoInputs<
+    ReadablePduWithOneInput<
         'a,
-        &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        &mut HashMap<PeerKey, BgpParsingContext>,
         LocatedRouteMonitoringMessageParsingError<'a>,
     > for RouteMonitoringMessage
 {
     fn from_wire(
         buf: Span<'a>,
-        multiple_labels: &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        add_path: &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        ctx: &mut HashMap<PeerKey, BgpParsingContext>,
     ) -> IResult<Span<'a>, Self, LocatedRouteMonitoringMessageParsingError<'a>> {
         let (buf, peer_header): (Span<'_>, PeerHeader) = parse_into_located(buf)?;
         let peer_key = PeerKey::from_peer_header(&peer_header);
-        let empty_add_path = HashMap::new();
-        let empty_multiple_labels = HashMap::new();
-        let add_path_support = add_path.get(&peer_key).unwrap_or(&empty_add_path);
-        let multiple_labels_support = multiple_labels
-            .get(&peer_key)
-            .unwrap_or(&empty_multiple_labels);
+        let bgp_ctx = ctx.entry(peer_key).or_default();
+        bgp_ctx.set_asn4(peer_header.is_asn4());
         let input = buf;
-        let (buf, update_message): (Span<'_>, BgpMessage) = parse_into_located_three_inputs(
-            buf,
-            peer_header.is_asn4(),
-            multiple_labels_support,
-            add_path_support,
-        )?;
+        let (buf, update_message): (Span<'_>, BgpMessage) =
+            parse_into_located_one_input(buf, bgp_ctx)?;
         if update_message.get_type() != BgpMessageType::Update {
             return Err(nom::Err::Error(
                 LocatedRouteMonitoringMessageParsingError::new(
@@ -472,27 +459,19 @@ const fn check_is_ipv6(peer_type: &BmpPeerType) -> Result<bool, BmpPeerTypeCode>
 }
 
 impl<'a>
-    ReadablePduWithTwoInputs<
+    ReadablePduWithOneInput<
         'a,
-        &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        &mut HashMap<PeerKey, BgpParsingContext>,
         LocatedPeerUpNotificationMessageParsingError<'a>,
     > for PeerUpNotificationMessage
 {
     fn from_wire(
         buf: Span<'a>,
-        multiple_labels: &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        add_path: &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        ctx: &mut HashMap<PeerKey, BgpParsingContext>,
     ) -> IResult<Span<'a>, Self, LocatedPeerUpNotificationMessageParsingError<'a>> {
         let input = buf;
         let (buf, peer_header): (Span<'_>, PeerHeader) = parse_into_located(buf)?;
         let peer_key = PeerKey::from_peer_header(&peer_header);
-        let empty_add_path = HashMap::new();
-        let empty_multiple_labels = HashMap::new();
-        let add_path_support = add_path.get(&peer_key).unwrap_or(&empty_add_path);
-        let multiple_labels_support = multiple_labels
-            .get(&peer_key)
-            .unwrap_or(&empty_multiple_labels);
         let ipv6 = match check_is_ipv6(&peer_header.peer_type) {
             Ok(ipv6) => ipv6,
             Err(code) => {
@@ -525,18 +504,12 @@ impl<'a>
         } else {
             Some(remote_port)
         };
-        let (buf, sent_message) = parse_into_located_three_inputs(
-            buf,
-            peer_header.is_asn4(),
-            multiple_labels_support,
-            add_path_support,
-        )?;
-        let (buf, received_message) = parse_into_located_three_inputs(
-            buf,
-            peer_header.is_asn4(),
-            multiple_labels_support,
-            add_path_support,
-        )?;
+        let bgp_ctx = ctx.entry(peer_key).or_default();
+        bgp_ctx.set_asn4(peer_header.is_asn4());
+        let (buf, sent_message) = parse_into_located_one_input(buf, bgp_ctx)?;
+        let bgp_ctx = ctx.entry(peer_key).or_default();
+        bgp_ctx.set_asn4(peer_header.is_asn4());
+        let (buf, received_message) = parse_into_located_one_input(buf, bgp_ctx)?;
         let (buf, information) = parse_till_empty_into_located(buf)?;
         let peer_up_msg = PeerUpNotificationMessage::build(
             peer_header,
@@ -571,33 +544,22 @@ pub enum PeerDownNotificationMessageParsingError {
 }
 
 impl<'a>
-    ReadablePduWithTwoInputs<
+    ReadablePduWithOneInput<
         'a,
-        &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        &mut HashMap<PeerKey, BgpParsingContext>,
         LocatedPeerDownNotificationMessageParsingError<'a>,
     > for PeerDownNotificationMessage
 {
     fn from_wire(
         buf: Span<'a>,
-        multiple_labels: &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        add_path: &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        ctx: &mut HashMap<PeerKey, BgpParsingContext>,
     ) -> IResult<Span<'a>, Self, LocatedPeerDownNotificationMessageParsingError<'a>> {
         let input = buf;
         let (buf, peer_header): (Span<'_>, PeerHeader) = parse_into_located(buf)?;
         let peer_key = PeerKey::from_peer_header(&peer_header);
-        let empty_add_path = HashMap::new();
-        let empty_multiple_labels = HashMap::new();
-        let add_path_support = add_path.get(&peer_key).unwrap_or(&empty_add_path);
-        let multiple_labels_support = multiple_labels
-            .get(&peer_key)
-            .unwrap_or(&empty_multiple_labels);
-        let (buf, reason) = parse_into_located_three_inputs(
-            buf,
-            peer_header.is_asn4(),
-            multiple_labels_support,
-            add_path_support,
-        )?;
+        let bgp_ctx = ctx.entry(peer_key).or_default();
+        bgp_ctx.set_asn4(peer_header.is_asn4());
+        let (buf, reason) = parse_into_located_one_input(buf, bgp_ctx)?;
         let msg = PeerDownNotificationMessage::build(peer_header, reason);
         match msg {
             Ok(msg) => Ok((buf, msg)),
@@ -625,26 +587,21 @@ pub enum PeerDownNotificationReasonParsingError {
 }
 
 impl<'a>
-    ReadablePduWithThreeInputs<
+    ReadablePduWithOneInput<
         'a,
-        bool,
-        &HashMap<AddressType, u8>,
-        &HashMap<AddressType, bool>,
+        &mut BgpParsingContext,
         LocatedPeerDownNotificationReasonParsingError<'a>,
     > for PeerDownNotificationReason
 {
     fn from_wire(
         buf: Span<'a>,
-        asn4: bool,
-        multiple_labels: &HashMap<AddressType, u8>,
-        add_path: &HashMap<AddressType, bool>,
+        bgp_ctx: &mut BgpParsingContext,
     ) -> IResult<Span<'a>, Self, LocatedPeerDownNotificationReasonParsingError<'a>> {
         let (buf, reason_code) =
             nom::combinator::map_res(be_u8, PeerDownReasonCode::try_from)(buf)?;
         match reason_code {
             PeerDownReasonCode::LocalSystemClosedNotificationPduFollows => {
-                let (buf, msg) =
-                    parse_into_located_three_inputs(buf, asn4, multiple_labels, add_path)?;
+                let (buf, msg) = parse_into_located_one_input(buf, bgp_ctx)?;
                 Ok((
                     buf,
                     PeerDownNotificationReason::LocalSystemClosedNotificationPduFollows(msg),
@@ -658,8 +615,7 @@ impl<'a>
                 ))
             }
             PeerDownReasonCode::RemoteSystemClosedNotificationPduFollows => {
-                let (buf, msg) =
-                    parse_into_located_three_inputs(buf, asn4, multiple_labels, add_path)?;
+                let (buf, msg) = parse_into_located_one_input(buf, bgp_ctx)?;
                 Ok((
                     buf,
                     PeerDownNotificationReason::RemoteSystemClosedNotificationPduFollows(msg),
@@ -717,32 +673,26 @@ pub enum RouteMirroringMessageParsingError {
 }
 
 impl<'a>
-    ReadablePduWithTwoInputs<
+    ReadablePduWithOneInput<
         'a,
-        &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        &mut HashMap<PeerKey, BgpParsingContext>,
         LocatedRouteMirroringMessageParsingError<'a>,
     > for RouteMirroringMessage
 {
     fn from_wire(
         buf: Span<'a>,
-        multiple_labels: &HashMap<PeerKey, HashMap<AddressType, u8>>,
-        add_path: &HashMap<PeerKey, HashMap<AddressType, bool>>,
+        ctx: &mut HashMap<PeerKey, BgpParsingContext>,
     ) -> IResult<Span<'a>, Self, LocatedRouteMirroringMessageParsingError<'a>> {
-        let (buf, peer_header): (Span<'_>, PeerHeader) = parse_into_located(buf)?;
+        let (mut buf, peer_header): (Span<'_>, PeerHeader) = parse_into_located(buf)?;
         let peer_key = PeerKey::from_peer_header(&peer_header);
-        let empty_add_path = HashMap::new();
-        let empty_multiple_labels = HashMap::new();
-        let add_path_support = add_path.get(&peer_key).unwrap_or(&empty_add_path);
-        let multiple_labels_support = multiple_labels
-            .get(&peer_key)
-            .unwrap_or(&empty_multiple_labels);
-        let (buf, mirrored) = parse_till_empty_into_with_three_inputs_located(
-            buf,
-            peer_header.is_asn4(),
-            multiple_labels_support,
-            add_path_support,
-        )?;
+        let bgp_ctx = ctx.entry(peer_key).or_default();
+        bgp_ctx.set_asn4(peer_header.is_asn4());
+        let mut mirrored = Vec::new();
+        while !buf.is_empty() {
+            let (tmp, element) = parse_into_located_one_input(buf, &mut *bgp_ctx)?;
+            mirrored.push(element);
+            buf = tmp;
+        }
         Ok((buf, RouteMirroringMessage::new(peer_header, mirrored)))
     }
 }
@@ -759,27 +709,19 @@ pub enum RouteMirroringValueParsingError {
 }
 
 impl<'a>
-    ReadablePduWithThreeInputs<
-        'a,
-        bool,
-        &HashMap<AddressType, u8>,
-        &HashMap<AddressType, bool>,
-        LocatedRouteMirroringValueParsingError<'a>,
-    > for RouteMirroringValue
+    ReadablePduWithOneInput<'a, &mut BgpParsingContext, LocatedRouteMirroringValueParsingError<'a>>
+    for RouteMirroringValue
 {
     fn from_wire(
         buf: Span<'a>,
-        asn4: bool,
-        multiple_labels: &HashMap<AddressType, u8>,
-        add_path: &HashMap<AddressType, bool>,
+        bgp_ctx: &mut BgpParsingContext,
     ) -> IResult<Span<'a>, Self, LocatedRouteMirroringValueParsingError<'a>> {
         let (buf, code) = nom::combinator::map_res(be_u16, RouteMirroringTlvType::try_from)(buf)?;
         let (_, length): (_, u16) = nom::combinator::peek(be_u16)(buf)?;
         let (reminder, buf) = nom::multi::length_data(be_u16)(buf)?;
         let (buf, value) = match code {
             RouteMirroringTlvType::BgpMessage => {
-                let (buf, msg) =
-                    parse_into_located_three_inputs(buf, asn4, multiple_labels, add_path)?;
+                let (buf, msg) = parse_into_located_one_input(buf, bgp_ctx)?;
                 (
                     buf,
                     RouteMirroringValue::BgpMessage(MirroredBgpMessage::Parsed(msg)),

--- a/fuzz/fuzz_targets/fuzz_bmp_pkt.rs
+++ b/fuzz/fuzz_targets/fuzz_bmp_pkt.rs
@@ -20,18 +20,59 @@ use std::collections::HashMap;
 
 use libfuzzer_sys::fuzz_target;
 
+use netgauze_bgp_pkt::wire::deserializer::BgpParsingContext;
 use netgauze_bmp_pkt::{BmpMessage, PeerKey};
 use netgauze_iana::address_family::AddressType;
-use netgauze_parse_utils::{ReadablePduWithTwoInputs, Span};
+use netgauze_parse_utils::{ReadablePduWithOneInput, Span};
 
+// We don't pass BgpParsingContext as fuzzed input since we don't want to generate BgpParsingContext::parsing_errors.
 fuzz_target!(|data: (
     &[u8],
-    HashMap<PeerKey, HashMap<AddressType, u8>>,
-    HashMap<PeerKey, HashMap<AddressType, bool>>
+    HashMap<
+        PeerKey,
+        (
+            bool,
+            HashMap<AddressType, u8>,
+            HashMap<AddressType, bool>,
+            bool,
+            bool,
+            bool,
+            bool
+        ),
+    >,
 )| {
-    let (mut buf, multiple_labels, addpath) = data;
-    while let Ok((retbuf, _msg)) = BmpMessage::from_wire(Span::new(buf), &multiple_labels, &addpath)
-    {
+    let (mut buf, ctx_params) = data;
+    let mut ctx = ctx_params
+        .iter()
+        .map(
+            |(
+                k,
+                (
+                    asn4,
+                    multiple_labels,
+                    add_path,
+                    fail_on_non_unicast_withdraw_nlri,
+                    fail_on_non_unicast_update_nlri,
+                    fail_on_capability_error,
+                    fail_on_malformed_path_attr,
+                ),
+            )| {
+                (
+                    *k,
+                    BgpParsingContext::new(
+                        *asn4,
+                        multiple_labels.clone(),
+                        add_path.clone(),
+                        *fail_on_non_unicast_withdraw_nlri,
+                        *fail_on_non_unicast_update_nlri,
+                        *fail_on_capability_error,
+                        *fail_on_malformed_path_attr,
+                    ),
+                )
+            },
+        )
+        .collect();
+    while let Ok((retbuf, _msg)) = BmpMessage::from_wire(Span::new(buf), &mut ctx) {
         buf = retbuf.fragment();
     }
 });


### PR DESCRIPTION
Update bgp-pkt parser and bgp-service to handle errors according to RFC7606.

BGP parser API changes to pass one big context struct.  BMP packages got updated accordingly.