### PR TITLE
Fix Echo duplicate cap

### DIFF
--- a/crates/bgp-pkt/src/capabilities.rs
+++ b/crates/bgp-pkt/src/capabilities.rs
@@ -37,7 +37,7 @@ use strum_macros::{Display, FromRepr};
 /// ~                              ~
 /// +------------------------------+
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpCapability {
     /// Defined in [RFC4760](https://datatracker.ietf.org/doc/html/rfc4760)
@@ -144,7 +144,7 @@ impl BgpCapability {
 
 /// Generic struct to carry all the unsupported BGP capabilities
 #[repr(C)]
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct UnrecognizedCapability {
     code: u8,
@@ -167,7 +167,7 @@ impl UnrecognizedCapability {
 
 /// Experimental Capabilities Codes as defined by [RFC8810](https://datatracker.ietf.org/doc/html/RFC8810)
 #[repr(u8)]
-#[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Display, FromRepr, Hash, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum ExperimentalCapabilityCode {
     Experimental239 = 239,
@@ -190,7 +190,7 @@ pub enum ExperimentalCapabilityCode {
 
 /// Generic struct to carry all capabilities that are designated as experimental
 /// by IANA See [RFC8810](https://datatracker.ietf.org/doc/html/RFC8810)
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExperimentalCapability {
     code: ExperimentalCapabilityCode,
@@ -220,7 +220,7 @@ impl ExperimentalCapability {
 /// |      AFI      | Res.  | SAFI  |
 /// +-------+-------+-------+-------+
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct MultiProtocolExtensionsCapability {
     address_type: AddressType,
@@ -237,7 +237,7 @@ impl MultiProtocolExtensionsCapability {
 }
 
 /// Defined in [RFC6793](https://datatracker.ietf.org/doc/html/rfc6793)
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct FourOctetAsCapability {
     asn4: u32,
@@ -255,7 +255,7 @@ impl FourOctetAsCapability {
 
 /// Defined in [RFC4724](https://datatracker.ietf.org/doc/html/rfc4724)
 /// and [RFC8538](https://datatracker.ietf.org/doc/html/rfc8538)
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct GracefulRestartCapability {
     restart: bool,
@@ -296,7 +296,7 @@ impl GracefulRestartCapability {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct GracefulRestartAddressFamily {
     forwarding_state: bool,
@@ -324,7 +324,7 @@ impl GracefulRestartAddressFamily {
 /// without replacing any previous ones.
 ///
 /// See [RFC7911](https://datatracker.ietf.org/doc/html/RFC7911)
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct AddPathCapability {
     address_families: Vec<AddPathAddressFamily>,
@@ -350,7 +350,7 @@ impl AddPathCapability {
 /// | Send/Receive (1 octet)                         |
 /// +------------------------------------------------+
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct AddPathAddressFamily {
     address_type: AddressType,
@@ -406,7 +406,7 @@ impl AddPathAddressFamily {
 /// | Nexthop AFI - N (2 octets)                          |
 /// +-----------------------------------------------------+
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExtendedNextHopEncodingCapability {
     encodings: Vec<ExtendedNextHopEncoding>,
@@ -433,7 +433,7 @@ impl ExtendedNextHopEncodingCapability {
 /// | Nexthop AFI - 1 (2 octets)                          |
 /// +-----------------------------------------------------+
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExtendedNextHopEncoding {
     address_type: AddressType,
@@ -466,7 +466,7 @@ impl ExtendedNextHopEncoding {
 /// |              AFI              |    SAFI       |    Count      ~
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct MultipleLabel {
     address_type: AddressType,
@@ -492,7 +492,7 @@ impl MultipleLabel {
 
 /// BGP Role used in the route leak prevention and detection procedures
 /// defined by: [RFC9234](https://datatracker.ietf.org/doc/html/rfc9234)
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct BgpRoleCapability {
     role: BgpRoleValue,

--- a/crates/bgp-pkt/src/iana.rs
+++ b/crates/bgp-pkt/src/iana.rs
@@ -1282,7 +1282,7 @@ impl TryFrom<u8> for TransitiveOpaqueExtendedCommunitySubType {
 /// BGP Role Values used in the route leak prevention and detection procedures
 /// [RFC9234](https://datatracker.ietf.org/doc/html/rfc9234)
 #[repr(u8)]
-#[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Display, FromRepr, Hash, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BgpRoleValue {
     /// The local AS is a transit provider of the remote AS

--- a/crates/bgp-speaker/examples/log_listener.rs
+++ b/crates/bgp-speaker/examples/log_listener.rs
@@ -15,14 +15,12 @@
 
 use clap::Parser;
 use std::{
-    collections::{HashSet},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    vec,
 };
 use tokio::net::TcpStream;
 
-use netgauze_bgp_pkt::{
-    capabilities::{BgpCapability, FourOctetAsCapability},
-};
+use netgauze_bgp_pkt::capabilities::{BgpCapability, FourOctetAsCapability};
 
 use netgauze_bgp_speaker::{
     connection::TcpActiveConnect,
@@ -46,10 +44,9 @@ fn create_peer(
     peer_addr: SocketAddr,
     supervisor: &mut PeersSupervisor<IpAddr, SocketAddr, TcpStream>,
 ) -> PeerHandle<SocketAddr, TcpStream> {
-    let mut caps = HashSet::new();
-    caps.insert(
-        BgpCapability::FourOctetAs(FourOctetAsCapability::new(my_asn)),
-    );
+    let caps = vec![BgpCapability::FourOctetAs(FourOctetAsCapability::new(
+        my_asn,
+    ))];
     let config = PeerConfigBuilder::new()
         .open_delay_timer_duration(1)
         .build();
@@ -58,7 +55,7 @@ fn create_peer(
         my_bgp_id,
         config.hold_timer_duration_large_value().as_secs() as u16,
         caps,
-        HashSet::new(),
+        vec![],
     );
 
     let properties = PeerProperties::new(

--- a/crates/bgp-speaker/examples/log_listener.rs
+++ b/crates/bgp-speaker/examples/log_listener.rs
@@ -15,14 +15,13 @@
 
 use clap::Parser;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashSet},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
 use tokio::net::TcpStream;
 
 use netgauze_bgp_pkt::{
     capabilities::{BgpCapability, FourOctetAsCapability},
-    iana::BgpCapabilityCode,
 };
 
 use netgauze_bgp_speaker::{
@@ -47,9 +46,8 @@ fn create_peer(
     peer_addr: SocketAddr,
     supervisor: &mut PeersSupervisor<IpAddr, SocketAddr, TcpStream>,
 ) -> PeerHandle<SocketAddr, TcpStream> {
-    let mut caps = HashMap::new();
+    let mut caps = HashSet::new();
     caps.insert(
-        BgpCapabilityCode::FourOctetAs,
         BgpCapability::FourOctetAs(FourOctetAsCapability::new(my_asn)),
     );
     let config = PeerConfigBuilder::new()

--- a/crates/bgp-speaker/src/codec.rs
+++ b/crates/bgp-speaker/src/codec.rs
@@ -19,7 +19,7 @@ use nom::Needed;
 use tokio_util::codec::{Decoder, Encoder};
 
 use netgauze_bgp_pkt::{
-    iana::BgpCapabilityCode,
+    capabilities::BgpCapability,
     wire::{
         deserializer::{BgpMessageParsingError, BgpParsingContext, BgpParsingIgnoredErrors},
         serializer::BgpMessageWritingError,
@@ -92,8 +92,8 @@ impl Decoder for BgpCodec {
                         if let BgpMessage::Open(ref open) = msg {
                             let asn4 = open
                                 .capabilities()
-                                .get(&BgpCapabilityCode::FourOctetAs)
-                                .is_some();
+                                .into_iter()
+                                .any(|cap| matches!(cap, BgpCapability::FourOctetAs(_)));
                             log::debug!("Sending ASN4 received to: {asn4}");
                             self.asn4_received = Some(asn4);
                         }
@@ -137,8 +137,8 @@ impl Encoder<BgpMessage> for BgpCodec {
         if let BgpMessage::Open(ref open) = msg {
             let asn4 = open
                 .capabilities()
-                .get(&BgpCapabilityCode::FourOctetAs)
-                .is_some();
+                .into_iter()
+                .any(|cap| matches!(cap, BgpCapability::FourOctetAs(_)));
             log::debug!("Sending ASN4 sent to: {asn4}");
             self.asn4_sent = Some(asn4);
         }

--- a/crates/bgp-speaker/src/connection.rs
+++ b/crates/bgp-speaker/src/connection.rs
@@ -1504,7 +1504,7 @@ pub mod test {
         BgpMessage,
     };
     use std::{
-        collections::{HashMap, HashSet},
+        collections::HashMap,
         io,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         time::Duration,
@@ -1551,13 +1551,8 @@ pub mod test {
 
     #[tokio::test]
     async fn test_connected_delay_open_timer_expires() -> io::Result<()> {
-        let mut policy = EchoCapabilitiesPolicy::new(
-            MY_AS,
-            MY_BGP_ID,
-            HOLD_TIME,
-            HashSet::new(),
-            HashSet::new(),
-        );
+        let mut policy =
+            EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
         let open_delay_duration = Duration::from_secs(1);
         let io = BgpIoMockBuilder::new()
             .wait(open_delay_duration)
@@ -1586,13 +1581,8 @@ pub mod test {
 
     #[tokio::test]
     async fn test_connected_open_with_delay_open_timer() -> io::Result<()> {
-        let mut policy = EchoCapabilitiesPolicy::new(
-            MY_AS,
-            MY_BGP_ID,
-            HOLD_TIME,
-            HashSet::new(),
-            HashSet::new(),
-        );
+        let mut policy =
+            EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
         let open_delay_duration = Duration::from_secs(1);
         let io = BgpIoMockBuilder::new()
             .read(BgpMessage::Open(BgpOpenMessage::new(
@@ -1647,13 +1637,8 @@ pub mod test {
 
     #[tokio::test]
     async fn test_connected_bgp_header_err() -> io::Result<()> {
-        let mut policy = EchoCapabilitiesPolicy::new(
-            MY_AS,
-            MY_BGP_ID,
-            HOLD_TIME,
-            HashSet::new(),
-            HashSet::new(),
-        );
+        let mut policy =
+            EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
         let open_delay_duration = Duration::from_secs(1);
         let io = BgpIoMockBuilder::new()
             .read_u8(&[
@@ -1685,13 +1670,8 @@ pub mod test {
 
     #[tokio::test]
     async fn test_connected_open_sent() -> io::Result<()> {
-        let mut policy = EchoCapabilitiesPolicy::new(
-            MY_AS,
-            MY_BGP_ID,
-            HOLD_TIME,
-            HashSet::new(),
-            HashSet::new(),
-        );
+        let mut policy =
+            EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
         let io = BgpIoMockBuilder::new()
             .write(BgpMessage::Open(BgpOpenMessage::new(
                 MY_AS as u16,
@@ -1714,13 +1694,8 @@ pub mod test {
 
     #[tokio::test]
     async fn test_open_sent_hold_timer_expires() -> io::Result<()> {
-        let mut policy = EchoCapabilitiesPolicy::new(
-            MY_AS,
-            MY_BGP_ID,
-            HOLD_TIME,
-            HashSet::new(),
-            HashSet::new(),
-        );
+        let mut policy =
+            EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
         let hold_time_seconds = 1;
         let io = BgpIoMockBuilder::new()
             .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1763,13 +1738,8 @@ pub mod test {
     async fn test_open_sent_bgp_open() -> io::Result<()> {
         let peer_hold_time = 120;
         let our_hold_time = 240;
-        let mut policy = EchoCapabilitiesPolicy::new(
-            MY_AS,
-            MY_BGP_ID,
-            our_hold_time,
-            HashSet::new(),
-            HashSet::new(),
-        );
+        let mut policy =
+            EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, our_hold_time, Vec::new(), Vec::new());
         let open = BgpOpenMessage::new(
             MY_AS as u16,
             peer_hold_time,
@@ -1818,13 +1788,8 @@ pub mod test {
 
     #[tokio::test]
     async fn test_open_sent_tcp_connection_fails() -> io::Result<()> {
-        let mut policy = EchoCapabilitiesPolicy::new(
-            MY_AS,
-            MY_BGP_ID,
-            HOLD_TIME,
-            HashSet::new(),
-            HashSet::new(),
-        );
+        let mut policy =
+            EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
         let hold_time_seconds = 1;
         let io = BgpIoMockBuilder::new()
             .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1862,8 +1827,8 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             hold_time_seconds as u16,
-            HashSet::new(),
-            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
         );
         let open = BgpOpenMessage::new(
             MY_AS as u16,

--- a/crates/bgp-speaker/src/connection.rs
+++ b/crates/bgp-speaker/src/connection.rs
@@ -1555,7 +1555,7 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             HOLD_TIME,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let open_delay_duration = Duration::from_secs(1);
@@ -1590,7 +1590,7 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             HOLD_TIME,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let open_delay_duration = Duration::from_secs(1);
@@ -1651,7 +1651,7 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             HOLD_TIME,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let open_delay_duration = Duration::from_secs(1);
@@ -1689,7 +1689,7 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             HOLD_TIME,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let io = BgpIoMockBuilder::new()
@@ -1718,7 +1718,7 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             HOLD_TIME,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let hold_time_seconds = 1;
@@ -1767,7 +1767,7 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             our_hold_time,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let open = BgpOpenMessage::new(
@@ -1822,7 +1822,7 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             HOLD_TIME,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let hold_time_seconds = 1;
@@ -1862,7 +1862,7 @@ pub mod test {
             MY_AS,
             MY_BGP_ID,
             hold_time_seconds as u16,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let open = BgpOpenMessage::new(

--- a/crates/bgp-speaker/src/peer_test.rs
+++ b/crates/bgp-speaker/src/peer_test.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::{HashMap, HashSet},
     io,
     io::Cursor,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -15,6 +14,8 @@ use netgauze_bgp_pkt::{
 };
 
 use netgauze_bgp_pkt::{
+    capabilities::{BgpCapability, FourOctetAsCapability, MultiProtocolExtensionsCapability},
+    iana::AS_TRANS,
     notification::{FiniteStateMachineError, *},
     open::{BgpOpenMessage, BgpOpenMessageParameter::Capabilities},
     route_refresh::BgpRouteRefreshMessage,
@@ -46,8 +47,7 @@ const PROPERTIES: PeerProperties<SocketAddr> = PeerProperties::new(
 
 #[test_log::test(tokio::test)]
 async fn test_idle_manual_start() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -70,8 +70,7 @@ async fn test_idle_manual_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_idle_manual_start_with_passive_tcp() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -102,8 +101,7 @@ async fn test_idle_manual_start_with_passive_tcp() {
 
 #[test_log::test(tokio::test)]
 async fn test_idle_automatic_start() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -127,8 +125,7 @@ async fn test_idle_automatic_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_idle_automatic_start_with_passive() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -159,8 +156,7 @@ async fn test_idle_automatic_start_with_passive() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_manual_start() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -187,8 +183,7 @@ async fn test_connect_manual_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_automatic_start() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -215,8 +210,7 @@ async fn test_connect_automatic_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_manual_stop() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -266,8 +260,7 @@ async fn test_connect_manual_stop() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_retry_timer_expires() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -307,8 +300,7 @@ async fn test_connect_retry_timer_expires() {
 #[test_log::test(tokio::test)]
 async fn test_connect_delay_open_timer_expires() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .wait(Duration::from_secs(1))
@@ -357,8 +349,7 @@ async fn test_connect_delay_open_timer_expires() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_confirmed() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -413,8 +404,7 @@ async fn test_connect_tcp_connection_confirmed() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_confirmed_with_open_delay() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
@@ -458,8 +448,7 @@ async fn test_connect_tcp_connection_confirmed_with_open_delay() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_fails() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_connect = MockFailedActiveConnect {
         peer_addr: PEER_ADDR,
         connect_delay: Duration::from_secs(0),
@@ -498,8 +487,7 @@ async fn test_connect_tcp_connection_fails_with_open_delay_timer() {
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_with_delay() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -558,8 +546,7 @@ async fn test_connect_bgp_open_with_delay() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_cr_acked() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -593,8 +580,7 @@ async fn test_connect_tcp_cr_acked() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_header_err() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let bad_header = [0xee; 16];
     io_builder
@@ -640,8 +626,7 @@ async fn test_connect_bgp_header_err() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_err_unsupported_version() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let bgp_version = 0x03;
     io_builder
@@ -688,8 +673,7 @@ async fn test_connect_bgp_open_err_unsupported_version() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_err_unacceptable_hold_time() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let hold_time = 1;
     let peer_open = BgpOpenMessage::new(
@@ -747,8 +731,7 @@ async fn test_connect_notif_version_err() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_notif_version_err_with_open_delay() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.read(BgpMessage::Notification(
         BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
@@ -783,8 +766,7 @@ async fn test_connect_notif_version_err_with_open_delay() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_automatic_stop() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -826,8 +808,7 @@ async fn test_connect_hold_timer_expires() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_notif_msg() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
@@ -861,8 +842,7 @@ async fn test_connect_notif_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_keepalive_msg() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.read(BgpMessage::KeepAlive);
 
@@ -894,8 +874,7 @@ async fn test_connect_keepalive_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_update_msg() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
     io_builder.read(BgpMessage::Update(update.clone()));
@@ -931,8 +910,7 @@ async fn test_connect_update_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_update_err_msg() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let update = [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -973,8 +951,7 @@ async fn test_connect_update_err_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_route_refresh_msg() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let route_refresh = BgpRouteRefreshMessage::new(
         AddressType::Ipv4Unicast,
@@ -1010,8 +987,7 @@ async fn test_connect_route_refresh_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_manual_start() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -1042,8 +1018,7 @@ async fn test_active_manual_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_automatic_start() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -1074,8 +1049,7 @@ async fn test_active_automatic_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_connect_retry_timer_expires() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
 
     let active_connect = MockActiveConnect {
@@ -1115,8 +1089,7 @@ async fn test_active_connect_retry_timer_expires() {
 #[test_log::test(tokio::test)]
 async fn test_active_delay_open_timer_expires() {
     let open_delay = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1171,8 +1144,7 @@ async fn test_active_delay_open_timer_expires() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_confirmed() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1221,8 +1193,7 @@ async fn test_active_tcp_connection_confirmed() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_confirmed_with_open_delay() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
 
@@ -1261,8 +1232,7 @@ async fn test_active_tcp_connection_confirmed_with_open_delay() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_fails() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let passive_io = tokio_test::io::Builder::new()
         .read_error(io::Error::from(io::ErrorKind::ConnectionAborted))
@@ -1312,8 +1282,7 @@ async fn test_active_tcp_connection_fails() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_active_bgp_open_with_open_delay() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -1390,8 +1359,7 @@ async fn test_active_bgp_open_with_open_delay() {
 #[test_log::test(tokio::test)]
 async fn test_active_bgp_header_err() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     let bad_header = [0xee; 16];
@@ -1451,8 +1419,7 @@ async fn test_active_bgp_header_err() {
 #[test_log::test(tokio::test)]
 async fn test_active_bgp_open_err() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1520,8 +1487,7 @@ async fn test_active_notif_version_err() {
 #[test_log::test(tokio::test)]
 async fn test_active_notif_version_err_with_open_delay() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1569,8 +1535,7 @@ async fn test_active_notif_version_err_with_open_delay() {
 #[test_log::test(tokio::test)]
 async fn test_active_automatic_stop() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1618,8 +1583,7 @@ async fn test_active_automatic_stop() {
 #[test_log::test(tokio::test)]
 async fn test_active_notif_msg() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let notif =
@@ -1667,8 +1631,7 @@ async fn test_active_notif_msg() {
 #[test_log::test(tokio::test)]
 async fn test_active_keepalive_msg() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1713,8 +1676,7 @@ async fn test_active_keepalive_msg() {
 #[test_log::test(tokio::test)]
 async fn test_active_update_msg() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
@@ -1762,8 +1724,7 @@ async fn test_active_update_msg() {
 #[test_log::test(tokio::test)]
 async fn test_active_update_err_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let update = [
@@ -1817,8 +1778,7 @@ async fn test_active_update_err_msg() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_active_route_refresh_msg() {
     let delay_open_duration = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let route_refresh = BgpRouteRefreshMessage::new(
@@ -1866,8 +1826,7 @@ async fn test_active_route_refresh_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_manual_stop() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1914,8 +1873,7 @@ async fn test_open_sent_manual_stop() {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_automatic_stop() {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1963,8 +1921,7 @@ async fn test_open_sent_automatic_stop() {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_hold_timer_expires() {
     let hold_time = 1;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -2009,8 +1966,7 @@ async fn test_open_sent_hold_timer_expires() {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_tcp_connection_confirmed() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
     let mut active_io_builder = BgpIoMockBuilder::new();
@@ -2072,8 +2028,7 @@ async fn test_open_sent_tcp_cr_acked() {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_tcp_connections_fails() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
 
     let msg = BgpMessage::Open(BgpOpenMessage::new(
@@ -2129,8 +2084,7 @@ async fn test_open_sent_tcp_connections_fails() -> Result<(), FsmStateError<Sock
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_open() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2185,8 +2139,7 @@ async fn test_open_sent_bgp_open() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let bad_header = [0xee; 16];
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2248,8 +2201,7 @@ async fn test_open_sent_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let bgp_version = 0x03;
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2310,8 +2262,7 @@ async fn test_open_sent_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> 
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -2411,8 +2362,7 @@ async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateE
 #[test_log::test(tokio::test)]
 async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -2511,8 +2461,7 @@ async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmSta
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_notif_version_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -2563,8 +2512,7 @@ async fn test_open_sent_notif_version_err() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
     let mut io_builder = BgpIoMockBuilder::new();
@@ -2618,8 +2566,7 @@ async fn test_open_sent_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -2671,8 +2618,7 @@ async fn test_open_sent_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2725,8 +2671,7 @@ async fn test_open_sent_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_update_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let update = [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0x00, 0x1b, 0x02, 0x00, 0x04, 0x19, 0xac, 0x10, 0x01, 0x00, 0x00,
@@ -2785,8 +2730,7 @@ async fn test_open_sent_update_err() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_route_refresh_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let route_refresh = BgpRouteRefreshMessage::new(
         AddressType::Ipv4Unicast,
         RouteRefreshSubcode::BeginningOfRouteRefresh,
@@ -2842,8 +2786,7 @@ async fn test_open_sent_route_refresh_msg() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_starts() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2908,8 +2851,7 @@ async fn test_open_confirm_starts() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_manual_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2973,8 +2915,7 @@ async fn test_open_confirm_manual_stop() -> Result<(), FsmStateError<SocketAddr>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_automatic_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3039,8 +2980,7 @@ async fn test_open_confirm_automatic_stop() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3117,8 +3057,7 @@ async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<Sock
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_keep_alive_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3176,8 +3115,7 @@ async fn test_open_confirm_keep_alive_timer_expires() -> Result<(), FsmStateErro
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
     let peer_open = BgpOpenMessage::new(
@@ -3240,8 +3178,7 @@ async fn test_open_confirm_notif_msg() -> Result<(), FsmStateError<SocketAddr>> 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_notif_version_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3306,8 +3243,7 @@ async fn test_open_confirm_notif_version_err() -> Result<(), FsmStateError<Socke
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -3413,8 +3349,7 @@ async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmSta
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_collision_dump_tracked_connection(
 ) -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -3520,8 +3455,7 @@ async fn test_open_confirm_collision_dump_tracked_connection(
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_open_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let notif = BgpNotificationMessage::FiniteStateMachineError(
         FiniteStateMachineError::ReceiveUnexpectedMessageInOpenConfirmState { value: vec![] },
     );
@@ -3586,8 +3520,7 @@ async fn test_open_confirm_open_msg() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let bgp_version = 0x03;
     let notif =
         BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
@@ -3662,8 +3595,7 @@ async fn test_open_confirm_bgp_open_err() -> Result<(), FsmStateError<SocketAddr
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let bad_header = [0xee; 16];
     let notif =
         BgpNotificationMessage::MessageHeaderError(MessageHeaderError::ConnectionNotSynchronized {
@@ -3735,8 +3667,7 @@ async fn test_open_confirm_bgp_header_err() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3793,8 +3724,7 @@ async fn test_open_confirm_keep_alive_msg() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3861,8 +3791,7 @@ async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3935,8 +3864,7 @@ async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4006,8 +3934,7 @@ async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<Socke
 
 #[test_log::test(tokio::test)]
 async fn test_established_starts() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4077,8 +4004,7 @@ async fn test_established_starts() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_established_manual_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4147,8 +4073,7 @@ async fn test_established_manual_stop() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_established_automatic_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4218,8 +4143,7 @@ async fn test_established_automatic_stop() -> Result<(), FsmStateError<SocketAdd
 #[test_log::test(tokio::test)]
 async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4299,8 +4223,7 @@ async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<Socke
 #[test_log::test(tokio::test)]
 async fn test_established_keep_alive_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4368,8 +4291,7 @@ async fn test_established_keep_alive_timer_expires() -> Result<(), FsmStateError
 #[test_log::test(tokio::test)]
 async fn test_established_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4481,8 +4403,7 @@ async fn test_established_collision_dump_main_connection() -> Result<(), FsmStat
 #[test_log::test(tokio::test)]
 async fn test_established_collision_dump_tracked_connection(
 ) -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4593,8 +4514,7 @@ async fn test_established_collision_dump_tracked_connection(
 #[test_log::test(tokio::test)]
 async fn test_established_reject_connection_tracking_disabled(
 ) -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4680,8 +4600,7 @@ async fn test_established_reject_connection_tracking_disabled(
 #[test_log::test(tokio::test)]
 async fn test_established_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4748,8 +4667,7 @@ async fn test_established_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_established_notif_version_error() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4817,8 +4735,7 @@ async fn test_established_notif_version_error() -> Result<(), FsmStateError<Sock
 
 #[test_log::test(tokio::test)]
 async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let my_open = BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
         HOLD_TIME,
@@ -4898,8 +4815,7 @@ async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<Soc
 
 #[test_log::test(tokio::test)]
 async fn test_established_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4959,8 +4875,7 @@ async fn test_established_keep_alive_msg() -> Result<(), FsmStateError<SocketAdd
 
 #[test_log::test(tokio::test)]
 async fn test_established_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -5016,5 +4931,106 @@ async fn test_established_update_msg() -> Result<(), FsmStateError<SocketAddr>> 
     let event = peer.run().await?;
     assert_eq!(event, BgpEvent::UpdateMsg(update, UpdateTreatment::Normal));
     assert_eq!(peer.fsm_state(), FsmState::Established);
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_connect_echo_policy() -> Result<(), FsmStateError<SocketAddr>> {
+    let my_asn = 66_000; // must be encoded as ASN4
+    let extended_msg_cap = BgpCapability::ExtendedMessage;
+    let route_refresh_cap = BgpCapability::RouteRefresh;
+    let enhanced_route_refresh_cap = BgpCapability::EnhancedRouteRefresh;
+    let ipv4_unicast_cap = BgpCapability::MultiProtocolExtensions(
+        MultiProtocolExtensionsCapability::new(AddressType::Ipv4Unicast),
+    );
+    let ipv4_multicast_cap = BgpCapability::MultiProtocolExtensions(
+        MultiProtocolExtensionsCapability::new(AddressType::Ipv4Multicast),
+    );
+    let ipv6_unicast_cap = BgpCapability::MultiProtocolExtensions(
+        MultiProtocolExtensionsCapability::new(AddressType::Ipv6Unicast),
+    );
+    let ipv6_multicast_cap = BgpCapability::MultiProtocolExtensions(
+        MultiProtocolExtensionsCapability::new(AddressType::Ipv6Multicast),
+    );
+
+    let pushed_caps = vec![
+        route_refresh_cap.clone(),
+        extended_msg_cap.clone(),
+        ipv6_unicast_cap.clone(),
+    ];
+    let rejected_caps = vec![
+        enhanced_route_refresh_cap.clone(),
+        ipv6_multicast_cap.clone(),
+    ];
+    let policy = EchoCapabilitiesPolicy::new(
+        my_asn,
+        MY_BGP_ID,
+        HOLD_TIME,
+        pushed_caps.clone(),
+        rejected_caps.clone(),
+    );
+
+    let peer_open = BgpOpenMessage::new(
+        PEER_AS as u16,
+        HOLD_TIME,
+        PEER_BGP_ID,
+        vec![Capabilities(vec![
+            route_refresh_cap.clone(),
+            enhanced_route_refresh_cap.clone(),
+            ipv4_unicast_cap.clone(),
+            ipv4_multicast_cap.clone(),
+            ipv6_multicast_cap.clone(),
+        ])],
+    );
+
+    let my_open = BgpOpenMessage::new(
+        AS_TRANS,
+        HOLD_TIME,
+        MY_BGP_ID,
+        vec![Capabilities(vec![
+            // ASN 4 should be added automatically since my_asn > u16::MAX
+            BgpCapability::FourOctetAs(FourOctetAsCapability::new(my_asn)),
+            // in pushed_caps and learned from peer
+            route_refresh_cap.clone(),
+            // Should be added since it's in pushed_caps
+            extended_msg_cap.clone(),
+            // In pushed_caps
+            ipv6_unicast_cap.clone(),
+            // Learned from peer
+            ipv4_unicast_cap.clone(),
+            // Learned from peer
+            ipv4_multicast_cap.clone(),
+        ])],
+    );
+
+    let mut io_builder = BgpIoMockBuilder::new();
+    io_builder
+        .read(BgpMessage::Open(peer_open.clone()))
+        .write(BgpMessage::Open(my_open))
+        .write(BgpMessage::KeepAlive);
+
+    let active_connect = MockActiveConnect {
+        peer_addr: PEER_ADDR,
+        io_builder,
+        connect_delay: Duration::from_secs(0),
+    };
+    let config = PeerConfigBuilder::new()
+        .open_delay_timer_duration(1)
+        .build();
+
+    let mut peer = Peer::new(PEER_KEY, PROPERTIES, config, policy, active_connect);
+
+    peer.add_admin_event(PeerAdminEvents::ManualStart);
+    let event = peer.run().await?;
+    assert_eq!(event, BgpEvent::ManualStart);
+
+    let event = peer.run().await?;
+    assert_eq!(event, BgpEvent::TcpConnectionRequestAcked(PEER_ADDR));
+    assert_eq!(peer.fsm_state(), FsmState::Connect);
+
+    let event = peer.run().await?;
+    assert_eq!(event, BgpEvent::BGPOpenWithDelayOpenTimer(peer_open));
+    assert_eq!(peer.fsm_state(), FsmState::OpenConfirm);
+
     Ok(())
 }

--- a/crates/bgp-speaker/src/peer_test.rs
+++ b/crates/bgp-speaker/src/peer_test.rs
@@ -47,7 +47,7 @@ const PROPERTIES: PeerProperties<SocketAddr> = PeerProperties::new(
 #[test_log::test(tokio::test)]
 async fn test_idle_manual_start() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -71,7 +71,7 @@ async fn test_idle_manual_start() {
 #[test_log::test(tokio::test)]
 async fn test_idle_manual_start_with_passive_tcp() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -103,7 +103,7 @@ async fn test_idle_manual_start_with_passive_tcp() {
 #[test_log::test(tokio::test)]
 async fn test_idle_automatic_start() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -128,7 +128,7 @@ async fn test_idle_automatic_start() {
 #[test_log::test(tokio::test)]
 async fn test_idle_automatic_start_with_passive() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -160,7 +160,7 @@ async fn test_idle_automatic_start_with_passive() {
 #[test_log::test(tokio::test)]
 async fn test_connect_manual_start() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -188,7 +188,7 @@ async fn test_connect_manual_start() {
 #[test_log::test(tokio::test)]
 async fn test_connect_automatic_start() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -216,7 +216,7 @@ async fn test_connect_automatic_start() {
 #[test_log::test(tokio::test)]
 async fn test_connect_manual_stop() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -267,7 +267,7 @@ async fn test_connect_manual_stop() {
 #[test_log::test(tokio::test)]
 async fn test_connect_retry_timer_expires() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -308,7 +308,7 @@ async fn test_connect_retry_timer_expires() {
 async fn test_connect_delay_open_timer_expires() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .wait(Duration::from_secs(1))
@@ -358,7 +358,7 @@ async fn test_connect_delay_open_timer_expires() {
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_confirmed() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -414,7 +414,7 @@ async fn test_connect_tcp_connection_confirmed() {
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_confirmed_with_open_delay() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
@@ -459,7 +459,7 @@ async fn test_connect_tcp_connection_confirmed_with_open_delay() {
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_fails() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_connect = MockFailedActiveConnect {
         peer_addr: PEER_ADDR,
         connect_delay: Duration::from_secs(0),
@@ -499,7 +499,7 @@ async fn test_connect_tcp_connection_fails_with_open_delay_timer() {
 async fn test_connect_bgp_open_with_delay() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -559,7 +559,7 @@ async fn test_connect_bgp_open_with_delay() {
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_cr_acked() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -594,7 +594,7 @@ async fn test_connect_tcp_cr_acked() {
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_header_err() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let bad_header = [0xee; 16];
     io_builder
@@ -641,7 +641,7 @@ async fn test_connect_bgp_header_err() {
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_err_unsupported_version() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let bgp_version = 0x03;
     io_builder
@@ -689,7 +689,7 @@ async fn test_connect_bgp_open_err_unsupported_version() {
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_err_unacceptable_hold_time() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let hold_time = 1;
     let peer_open = BgpOpenMessage::new(
@@ -748,7 +748,7 @@ async fn test_connect_notif_version_err() {
 #[test_log::test(tokio::test)]
 async fn test_connect_notif_version_err_with_open_delay() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.read(BgpMessage::Notification(
         BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
@@ -784,7 +784,7 @@ async fn test_connect_notif_version_err_with_open_delay() {
 #[test_log::test(tokio::test)]
 async fn test_connect_automatic_stop() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -827,7 +827,7 @@ async fn test_connect_hold_timer_expires() {
 #[test_log::test(tokio::test)]
 async fn test_connect_notif_msg() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
@@ -862,7 +862,7 @@ async fn test_connect_notif_msg() {
 #[test_log::test(tokio::test)]
 async fn test_connect_keepalive_msg() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.read(BgpMessage::KeepAlive);
 
@@ -895,7 +895,7 @@ async fn test_connect_keepalive_msg() {
 #[test_log::test(tokio::test)]
 async fn test_connect_update_msg() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
     io_builder.read(BgpMessage::Update(update.clone()));
@@ -932,7 +932,7 @@ async fn test_connect_update_msg() {
 #[test_log::test(tokio::test)]
 async fn test_connect_update_err_msg() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let update = [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -974,7 +974,7 @@ async fn test_connect_update_err_msg() {
 #[test_log::test(tokio::test)]
 async fn test_connect_route_refresh_msg() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let route_refresh = BgpRouteRefreshMessage::new(
         AddressType::Ipv4Unicast,
@@ -1011,7 +1011,7 @@ async fn test_connect_route_refresh_msg() {
 #[test_log::test(tokio::test)]
 async fn test_active_manual_start() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -1043,7 +1043,7 @@ async fn test_active_manual_start() {
 #[test_log::test(tokio::test)]
 async fn test_active_automatic_start() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -1075,7 +1075,7 @@ async fn test_active_automatic_start() {
 #[test_log::test(tokio::test)]
 async fn test_active_connect_retry_timer_expires() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let io_builder = BgpIoMockBuilder::new();
 
     let active_connect = MockActiveConnect {
@@ -1116,7 +1116,7 @@ async fn test_active_connect_retry_timer_expires() {
 async fn test_active_delay_open_timer_expires() {
     let open_delay = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1172,7 +1172,7 @@ async fn test_active_delay_open_timer_expires() {
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_confirmed() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1222,7 +1222,7 @@ async fn test_active_tcp_connection_confirmed() {
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_confirmed_with_open_delay() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
 
@@ -1262,7 +1262,7 @@ async fn test_active_tcp_connection_confirmed_with_open_delay() {
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_fails() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let passive_io = tokio_test::io::Builder::new()
         .read_error(io::Error::from(io::ErrorKind::ConnectionAborted))
@@ -1313,7 +1313,7 @@ async fn test_active_tcp_connection_fails() -> Result<(), FsmStateError<SocketAd
 async fn test_active_bgp_open_with_open_delay() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -1391,7 +1391,7 @@ async fn test_active_bgp_open_with_open_delay() {
 async fn test_active_bgp_header_err() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     let bad_header = [0xee; 16];
@@ -1452,7 +1452,7 @@ async fn test_active_bgp_header_err() {
 async fn test_active_bgp_open_err() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1521,7 +1521,7 @@ async fn test_active_notif_version_err() {
 async fn test_active_notif_version_err_with_open_delay() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1570,7 +1570,7 @@ async fn test_active_notif_version_err_with_open_delay() {
 async fn test_active_automatic_stop() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1619,7 +1619,7 @@ async fn test_active_automatic_stop() {
 async fn test_active_notif_msg() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let notif =
@@ -1668,7 +1668,7 @@ async fn test_active_notif_msg() {
 async fn test_active_keepalive_msg() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1714,7 +1714,7 @@ async fn test_active_keepalive_msg() {
 async fn test_active_update_msg() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
@@ -1763,7 +1763,7 @@ async fn test_active_update_msg() {
 async fn test_active_update_err_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let update = [
@@ -1818,7 +1818,7 @@ async fn test_active_update_err_msg() -> Result<(), FsmStateError<SocketAddr>> {
 async fn test_active_route_refresh_msg() {
     let delay_open_duration = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let route_refresh = BgpRouteRefreshMessage::new(
@@ -1867,7 +1867,7 @@ async fn test_active_route_refresh_msg() {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_manual_stop() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1915,7 +1915,7 @@ async fn test_open_sent_manual_stop() {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_automatic_stop() {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1964,7 +1964,7 @@ async fn test_open_sent_automatic_stop() {
 async fn test_open_sent_hold_timer_expires() {
     let hold_time = 1;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -2010,7 +2010,7 @@ async fn test_open_sent_hold_timer_expires() {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_tcp_connection_confirmed() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
     let mut active_io_builder = BgpIoMockBuilder::new();
@@ -2073,7 +2073,7 @@ async fn test_open_sent_tcp_cr_acked() {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_tcp_connections_fails() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let active_io_builder = BgpIoMockBuilder::new();
 
     let msg = BgpMessage::Open(BgpOpenMessage::new(
@@ -2130,7 +2130,7 @@ async fn test_open_sent_tcp_connections_fails() -> Result<(), FsmStateError<Sock
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_open() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2186,7 +2186,7 @@ async fn test_open_sent_bgp_open() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let bad_header = [0xee; 16];
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2249,7 +2249,7 @@ async fn test_open_sent_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let bgp_version = 0x03;
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2311,7 +2311,7 @@ async fn test_open_sent_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -2412,7 +2412,7 @@ async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateE
 async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -2512,7 +2512,7 @@ async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmSta
 #[test_log::test(tokio::test)]
 async fn test_open_sent_notif_version_err() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -2564,7 +2564,7 @@ async fn test_open_sent_notif_version_err() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_open_sent_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
     let mut io_builder = BgpIoMockBuilder::new();
@@ -2619,7 +2619,7 @@ async fn test_open_sent_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -2672,7 +2672,7 @@ async fn test_open_sent_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>
 #[test_log::test(tokio::test)]
 async fn test_open_sent_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2726,7 +2726,7 @@ async fn test_open_sent_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_update_err() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let update = [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0x00, 0x1b, 0x02, 0x00, 0x04, 0x19, 0xac, 0x10, 0x01, 0x00, 0x00,
@@ -2786,7 +2786,7 @@ async fn test_open_sent_update_err() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_route_refresh_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let route_refresh = BgpRouteRefreshMessage::new(
         AddressType::Ipv4Unicast,
         RouteRefreshSubcode::BeginningOfRouteRefresh,
@@ -2843,7 +2843,7 @@ async fn test_open_sent_route_refresh_msg() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_starts() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2909,7 +2909,7 @@ async fn test_open_confirm_starts() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_manual_stop() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2974,7 +2974,7 @@ async fn test_open_confirm_manual_stop() -> Result<(), FsmStateError<SocketAddr>
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_automatic_stop() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3040,7 +3040,7 @@ async fn test_open_confirm_automatic_stop() -> Result<(), FsmStateError<SocketAd
 async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3118,7 +3118,7 @@ async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<Sock
 async fn test_open_confirm_keep_alive_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3177,7 +3177,7 @@ async fn test_open_confirm_keep_alive_timer_expires() -> Result<(), FsmStateErro
 async fn test_open_confirm_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
     let peer_open = BgpOpenMessage::new(
@@ -3241,7 +3241,7 @@ async fn test_open_confirm_notif_msg() -> Result<(), FsmStateError<SocketAddr>> 
 async fn test_open_confirm_notif_version_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3307,7 +3307,7 @@ async fn test_open_confirm_notif_version_err() -> Result<(), FsmStateError<Socke
 async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -3414,7 +3414,7 @@ async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmSta
 async fn test_open_confirm_collision_dump_tracked_connection(
 ) -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -3521,7 +3521,7 @@ async fn test_open_confirm_collision_dump_tracked_connection(
 async fn test_open_confirm_open_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let notif = BgpNotificationMessage::FiniteStateMachineError(
         FiniteStateMachineError::ReceiveUnexpectedMessageInOpenConfirmState { value: vec![] },
     );
@@ -3587,7 +3587,7 @@ async fn test_open_confirm_open_msg() -> Result<(), FsmStateError<SocketAddr>> {
 async fn test_open_confirm_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let bgp_version = 0x03;
     let notif =
         BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
@@ -3663,7 +3663,7 @@ async fn test_open_confirm_bgp_open_err() -> Result<(), FsmStateError<SocketAddr
 async fn test_open_confirm_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let bad_header = [0xee; 16];
     let notif =
         BgpNotificationMessage::MessageHeaderError(MessageHeaderError::ConnectionNotSynchronized {
@@ -3736,7 +3736,7 @@ async fn test_open_confirm_bgp_header_err() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3794,7 +3794,7 @@ async fn test_open_confirm_keep_alive_msg() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3862,7 +3862,7 @@ async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>>
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3936,7 +3936,7 @@ async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>>
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4007,7 +4007,7 @@ async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<Socke
 #[test_log::test(tokio::test)]
 async fn test_established_starts() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4078,7 +4078,7 @@ async fn test_established_starts() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_established_manual_stop() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4148,7 +4148,7 @@ async fn test_established_manual_stop() -> Result<(), FsmStateError<SocketAddr>>
 #[test_log::test(tokio::test)]
 async fn test_established_automatic_stop() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4219,7 +4219,7 @@ async fn test_established_automatic_stop() -> Result<(), FsmStateError<SocketAdd
 async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4300,7 +4300,7 @@ async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<Socke
 async fn test_established_keep_alive_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4369,7 +4369,7 @@ async fn test_established_keep_alive_timer_expires() -> Result<(), FsmStateError
 async fn test_established_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4482,7 +4482,7 @@ async fn test_established_collision_dump_main_connection() -> Result<(), FsmStat
 async fn test_established_collision_dump_tracked_connection(
 ) -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4594,7 +4594,7 @@ async fn test_established_collision_dump_tracked_connection(
 async fn test_established_reject_connection_tracking_disabled(
 ) -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4681,7 +4681,7 @@ async fn test_established_reject_connection_tracking_disabled(
 async fn test_established_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4749,7 +4749,7 @@ async fn test_established_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
 async fn test_established_notif_version_error() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4818,7 +4818,7 @@ async fn test_established_notif_version_error() -> Result<(), FsmStateError<Sock
 #[test_log::test(tokio::test)]
 async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let my_open = BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
         HOLD_TIME,
@@ -4899,7 +4899,7 @@ async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<Soc
 #[test_log::test(tokio::test)]
 async fn test_established_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4960,7 +4960,7 @@ async fn test_established_keep_alive_msg() -> Result<(), FsmStateError<SocketAdd
 #[test_log::test(tokio::test)]
 async fn test_established_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let policy =
-        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, HashSet::new(), HashSet::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,

--- a/crates/bgp-speaker/src/supervisor.rs
+++ b/crates/bgp-speaker/src/supervisor.rs
@@ -26,7 +26,7 @@ use netgauze_bgp_pkt::{
     BgpMessage,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt::{Debug, Display},
     hash::Hash,
     net::Ipv4Addr,
@@ -151,8 +151,8 @@ impl<
             self.my_asn,
             self.my_bgp_id,
             peer_config.hold_timer_duration_large_value,
-            HashSet::new(),
-            HashSet::new(),
+            Vec::new(),
+            Vec::new(),
         );
         let (rx, peer_handle) = self.create_peer(
             peer_key,
@@ -194,14 +194,14 @@ mod tests {
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashSet::new(), HashSet::new()),
+            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, Vec::new(), Vec::new()),
         )?;
         let second_create = supervisor.create_peer(
             peer_addr.ip(),
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashSet::new(), HashSet::new()),
+            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, Vec::new(), Vec::new()),
         );
         let removed_peer = supervisor.remove_peer(&peer_addr.ip());
         let non_existing_peer = supervisor.remove_peer(&peer_addr.ip());
@@ -237,7 +237,7 @@ mod tests {
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashSet::new(), HashSet::new()),
+            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, Vec::new(), Vec::new()),
         );
 
         let removed_peer = supervisor.remove_peer(&peer_addr.ip());

--- a/crates/bgp-speaker/src/supervisor.rs
+++ b/crates/bgp-speaker/src/supervisor.rs
@@ -151,7 +151,7 @@ impl<
             self.my_asn,
             self.my_bgp_id,
             peer_config.hold_timer_duration_large_value,
-            HashMap::new(),
+            HashSet::new(),
             HashSet::new(),
         );
         let (rx, peer_handle) = self.create_peer(
@@ -194,14 +194,14 @@ mod tests {
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashMap::new(), HashSet::new()),
+            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashSet::new(), HashSet::new()),
         )?;
         let second_create = supervisor.create_peer(
             peer_addr.ip(),
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashMap::new(), HashSet::new()),
+            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashSet::new(), HashSet::new()),
         );
         let removed_peer = supervisor.remove_peer(&peer_addr.ip());
         let non_existing_peer = supervisor.remove_peer(&peer_addr.ip());
@@ -237,7 +237,7 @@ mod tests {
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashMap::new(), HashSet::new()),
+            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashSet::new(), HashSet::new()),
         );
 
         let removed_peer = supervisor.remove_peer(&peer_addr.ip());

--- a/crates/iana/src/address_family.rs
+++ b/crates/iana/src/address_family.rs
@@ -56,7 +56,7 @@ use strum_macros::{Display, FromRepr};
 /// assert_eq!(undefined, Err(UndefinedAddressFamily(65000)));
 /// ```
 #[repr(u16)]
-#[derive(FromRepr, Display, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(FromRepr, Display, Hash, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum AddressFamily {
     IPv4 = 1,

--- a/fuzz/fuzz_targets/fuzz_bgp_peer.rs
+++ b/fuzz/fuzz_targets/fuzz_bgp_peer.rs
@@ -16,10 +16,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use std::{
-    collections::HashMap,
-    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
-};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use netgauze_bgp_speaker::peer::{
     EchoCapabilitiesPolicy, Peer, PeerAdminEvents, PeerConfig, PeerProperties,
@@ -416,7 +413,7 @@ fuzz_target!(|data: (
         IpAddr::V6(v6) => SocketAddr::V6(SocketAddrV6::new(v6, 179, 0, 0)),
     };
     let policy =
-        EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashMap::new(), HashSet::new());
+        EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashSet::new(), HashSet::new());
 
     tokio_test::block_on(async {
         let mut io_builder = IoBuilder::new();

--- a/fuzz/fuzz_targets/fuzz_bgp_peer.rs
+++ b/fuzz/fuzz_targets/fuzz_bgp_peer.rs
@@ -35,7 +35,7 @@ use netgauze_bgp_speaker::{
 };
 use std::{
     cmp,
-    collections::{HashSet, VecDeque},
+    collections::VecDeque,
     fmt,
     future::Future,
     io,
@@ -412,8 +412,7 @@ fuzz_target!(|data: (
         IpAddr::V4(v4) => SocketAddr::V4(SocketAddrV4::new(v4, 179)),
         IpAddr::V6(v6) => SocketAddr::V6(SocketAddrV6::new(v6, 179, 0, 0)),
     };
-    let policy =
-        EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, HashSet::new(), HashSet::new());
+    let policy = EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, vec![], vec![]);
 
     tokio_test::block_on(async {
         let mut io_builder = IoBuilder::new();


### PR DESCRIPTION
Use Vec to hold BGP capabilities, since the same BGP Capability code could repeat (e.g., multiple address families).