### PR TITLE
Improve AS4 capabilities handling in EchoCapabilitiesPolicy

### DIFF
--- a/crates/bgp-speaker/examples/log_listener.rs
+++ b/crates/bgp-speaker/examples/log_listener.rs
@@ -20,8 +20,6 @@ use std::{
 };
 use tokio::net::TcpStream;
 
-use netgauze_bgp_pkt::capabilities::{BgpCapability, FourOctetAsCapability};
-
 use netgauze_bgp_speaker::{
     connection::TcpActiveConnect,
     listener::BgpListener,
@@ -44,17 +42,15 @@ fn create_peer(
     peer_addr: SocketAddr,
     supervisor: &mut PeersSupervisor<IpAddr, SocketAddr, TcpStream>,
 ) -> PeerHandle<SocketAddr, TcpStream> {
-    let caps = vec![BgpCapability::FourOctetAs(FourOctetAsCapability::new(
-        my_asn,
-    ))];
     let config = PeerConfigBuilder::new()
         .open_delay_timer_duration(1)
         .build();
     let policy = EchoCapabilitiesPolicy::new(
         my_asn,
+        true,
         my_bgp_id,
         config.hold_timer_duration_large_value().as_secs() as u16,
-        caps,
+        vec![],
         vec![],
     );
 

--- a/crates/bgp-speaker/src/connection.rs
+++ b/crates/bgp-speaker/src/connection.rs
@@ -1515,7 +1515,7 @@ pub mod test {
         connection::ConnectionConfig, events::ConnectionEvent, fsm::FsmStateError,
         peer::PeerProperties, test::BgpIoMockBuilder,
     };
-    use netgauze_bgp_pkt::open::{BgpOpenMessage, BgpOpenMessageParameter::Capabilities};
+    use netgauze_bgp_pkt::open::BgpOpenMessage;
 
     const MY_AS: u32 = 100;
     const HOLD_TIME: u16 = 180;
@@ -1558,7 +1558,7 @@ pub mod test {
                 MY_AS as u16,
                 HOLD_TIME,
                 MY_BGP_ID,
-                vec![Capabilities(vec![])],
+                vec![],
             )))
             .build();
         let config = ConnectionConfigBuilder::new()
@@ -1587,13 +1587,13 @@ pub mod test {
                 MY_AS as u16,
                 HOLD_TIME,
                 MY_BGP_ID,
-                vec![Capabilities(vec![])],
+                vec![],
             )))
             .write(BgpMessage::Open(BgpOpenMessage::new(
                 MY_AS as u16,
                 HOLD_TIME,
                 MY_BGP_ID,
-                vec![Capabilities(vec![])],
+                vec![],
             )))
             .write(BgpMessage::KeepAlive)
             .build();
@@ -1675,7 +1675,7 @@ pub mod test {
                 MY_AS as u16,
                 HOLD_TIME,
                 MY_BGP_ID,
-                vec![Capabilities(vec![])],
+                vec![],
             )))
             .build();
 
@@ -1700,7 +1700,7 @@ pub mod test {
                 MY_AS as u16,
                 HOLD_TIME,
                 MY_BGP_ID,
-                vec![Capabilities(vec![])],
+                vec![],
             )))
             .wait(Duration::from_secs(hold_time_seconds * 2))
             .write(BgpMessage::Notification(
@@ -1744,18 +1744,13 @@ pub mod test {
             Vec::new(),
             Vec::new(),
         );
-        let open = BgpOpenMessage::new(
-            MY_AS as u16,
-            peer_hold_time,
-            MY_BGP_ID,
-            vec![Capabilities(vec![])],
-        );
+        let open = BgpOpenMessage::new(MY_AS as u16, peer_hold_time, MY_BGP_ID, vec![]);
         let io = BgpIoMockBuilder::new()
             .write(BgpMessage::Open(BgpOpenMessage::new(
                 MY_AS as u16,
                 our_hold_time,
                 MY_BGP_ID,
-                vec![Capabilities(vec![])],
+                vec![],
             )))
             .read(BgpMessage::Open(open.clone()))
             .write(BgpMessage::KeepAlive)
@@ -1800,7 +1795,7 @@ pub mod test {
                 MY_AS as u16,
                 HOLD_TIME,
                 MY_BGP_ID,
-                vec![Capabilities(vec![])],
+                vec![],
             )))
             .build();
 
@@ -1835,18 +1830,13 @@ pub mod test {
             Vec::new(),
             Vec::new(),
         );
-        let open = BgpOpenMessage::new(
-            MY_AS as u16,
-            hold_time_seconds as u16,
-            MY_BGP_ID,
-            vec![Capabilities(vec![])],
-        );
+        let open = BgpOpenMessage::new(MY_AS as u16, hold_time_seconds as u16, MY_BGP_ID, vec![]);
         let io = BgpIoMockBuilder::new()
             .write(BgpMessage::Open(BgpOpenMessage::new(
                 MY_AS as u16,
                 hold_time_seconds as u16,
                 MY_BGP_ID,
-                vec![Capabilities(vec![])],
+                vec![],
             )))
             .read(BgpMessage::Open(open.clone()))
             .write(BgpMessage::KeepAlive)

--- a/crates/bgp-speaker/src/peer.rs
+++ b/crates/bgp-speaker/src/peer.rs
@@ -108,7 +108,7 @@ pub struct EchoCapabilitiesPolicy<A, I, D> {
 }
 
 impl<A, I, D> EchoCapabilitiesPolicy<A, I, D> {
-    pub fn new(
+    pub const fn new(
         my_asn: u32,
         send_asn4_cap_by_default: bool,
         my_bgp_id: Ipv4Addr,

--- a/crates/bgp-speaker/src/peer.rs
+++ b/crates/bgp-speaker/src/peer.rs
@@ -181,12 +181,15 @@ impl<
             }
         }
 
-        BgpOpenMessage::new(
-            my_asn,
-            self.hold_timer_duration,
-            self.my_bgp_id,
-            vec![BgpOpenMessageParameter::Capabilities(capabilities)],
-        )
+        let params = if capabilities.is_empty() {
+            vec![]
+        } else {
+            // TODO check for param size and spread capabilities across multiple params or
+            // use extended params RFC 9072
+            vec![BgpOpenMessageParameter::Capabilities(capabilities)]
+        };
+
+        BgpOpenMessage::new(my_asn, self.hold_timer_duration, self.my_bgp_id, params)
     }
 
     async fn pre_handle_connection_event_hook(

--- a/crates/bgp-speaker/src/peer_test.rs
+++ b/crates/bgp-speaker/src/peer_test.rs
@@ -77,7 +77,7 @@ async fn test_idle_manual_start_with_passive_tcp() {
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     )));
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -130,7 +130,7 @@ async fn test_idle_automatic_start_with_passive() {
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     )));
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -302,7 +302,7 @@ async fn test_connect_delay_open_timer_expires() {
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )));
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -349,7 +349,7 @@ async fn test_connect_tcp_connection_confirmed() {
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     )));
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -478,12 +478,7 @@ async fn test_connect_tcp_connection_fails_with_open_delay_timer() {
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_with_delay() {
     let delay_open_duration = 1;
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
 
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -493,7 +488,7 @@ async fn test_connect_bgp_open_with_delay() {
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .write(BgpMessage::KeepAlive);
     let active_connect = MockActiveConnect {
@@ -541,7 +536,7 @@ async fn test_connect_tcp_cr_acked() {
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     )));
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -662,12 +657,7 @@ async fn test_connect_bgp_open_err_unsupported_version() {
 async fn test_connect_bgp_open_err_unacceptable_hold_time() {
     let mut io_builder = BgpIoMockBuilder::new();
     let hold_time = 1;
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
 
     io_builder
         .read(BgpMessage::Open(peer_open.clone()))
@@ -1071,7 +1061,7 @@ async fn test_active_delay_open_timer_expires() {
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     )));
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -1125,7 +1115,7 @@ async fn test_active_tcp_connection_confirmed() {
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     )));
 
     let active_connect = MockActiveConnect {
@@ -1254,12 +1244,7 @@ async fn test_active_tcp_connection_fails() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_active_bgp_open_with_open_delay() {
     let delay_open_duration = 1;
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1270,7 +1255,7 @@ async fn test_active_bgp_open_with_open_delay() {
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .write(BgpMessage::KeepAlive);
 
@@ -1788,7 +1773,7 @@ async fn test_open_sent_manual_stop() {
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .write(BgpMessage::Notification(
             BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown {
@@ -1834,7 +1819,7 @@ async fn test_open_sent_automatic_stop() {
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .write(BgpMessage::Notification(
             BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown {
@@ -1883,7 +1868,7 @@ async fn test_open_sent_hold_timer_expires() {
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .write(BgpMessage::Notification(
             BgpNotificationMessage::HoldTimerExpiredError(HoldTimerExpiredError::Unspecific {
@@ -1928,7 +1913,7 @@ async fn test_open_sent_tcp_connection_confirmed() -> Result<(), FsmStateError<S
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     )));
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -1940,7 +1925,7 @@ async fn test_open_sent_tcp_connection_confirmed() -> Result<(), FsmStateError<S
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     )));
 
     let mut peer = Peer::new(
@@ -1988,7 +1973,7 @@ async fn test_open_sent_tcp_connections_fails() -> Result<(), FsmStateError<Sock
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     ));
     let buf = vec![];
     let mut cursor = Cursor::new(buf);
@@ -2037,19 +2022,14 @@ async fn test_open_sent_tcp_connections_fails() -> Result<(), FsmStateError<Sock
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_open() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive);
@@ -2098,7 +2078,7 @@ async fn test_open_sent_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read_u8(&bad_header) // Malformed header
         .read_u8(&[0x00, 0x13, 0x04]) // Keep alive message body
@@ -2159,7 +2139,7 @@ async fn test_open_sent_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> 
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read_u8(&[0xff; 16]) // BGP Standard header
         .read_u8(&[0x00, 0x14]) // Length
@@ -2224,12 +2204,7 @@ async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateE
     );
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        peer_bgp_id,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, peer_bgp_id, vec![]);
 
     let mut active_io_builder = BgpIoMockBuilder::new();
     active_io_builder
@@ -2237,7 +2212,7 @@ async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateE
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .write(BgpMessage::Notification(
             BgpNotificationMessage::CeaseError(CeaseError::ConnectionCollisionResolution {
@@ -2257,7 +2232,7 @@ async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateE
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -2323,12 +2298,7 @@ async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmSta
     );
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        peer_bgp_id,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, peer_bgp_id, vec![]);
 
     let mut active_io_builder = BgpIoMockBuilder::new();
     active_io_builder
@@ -2336,7 +2306,7 @@ async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmSta
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .wait(Duration::from_millis(10))
         .read(BgpMessage::Open(peer_open.clone()))
@@ -2354,7 +2324,7 @@ async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmSta
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -2415,7 +2385,7 @@ async fn test_open_sent_notif_version_err() -> Result<(), FsmStateError<SocketAd
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Notification(
             BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
@@ -2467,7 +2437,7 @@ async fn test_open_sent_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Notification(notif.clone()))
         .write(BgpMessage::Notification(
@@ -2518,7 +2488,7 @@ async fn test_open_sent_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::KeepAlive)
         .write(BgpMessage::Notification(
@@ -2570,7 +2540,7 @@ async fn test_open_sent_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Update(update.clone()))
         .write(BgpMessage::Notification(
@@ -2625,7 +2595,7 @@ async fn test_open_sent_update_err() -> Result<(), FsmStateError<SocketAddr>> {
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read_u8(&update)
         .write(BgpMessage::Notification(
@@ -2683,7 +2653,7 @@ async fn test_open_sent_route_refresh_msg() -> Result<(), FsmStateError<SocketAd
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::RouteRefresh(route_refresh.clone()))
         .write(BgpMessage::Notification(
@@ -2728,19 +2698,14 @@ async fn test_open_sent_route_refresh_msg() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_starts() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -2792,19 +2757,14 @@ async fn test_open_confirm_starts() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_manual_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -2855,19 +2815,14 @@ async fn test_open_confirm_manual_stop() -> Result<(), FsmStateError<SocketAddr>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_automatic_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -2921,19 +2876,14 @@ async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<Sock
     let hold_time = 3;
     let policy =
         EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -2999,19 +2949,14 @@ async fn test_open_confirm_keep_alive_timer_expires() -> Result<(), FsmStateErro
     let hold_time = 3;
     let policy =
         EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3060,19 +3005,14 @@ async fn test_open_confirm_notif_msg() -> Result<(), FsmStateError<SocketAddr>> 
         EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3122,19 +3062,14 @@ async fn test_open_confirm_notif_version_err() -> Result<(), FsmStateError<Socke
     let hold_time = 3;
     let policy =
         EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3198,12 +3133,7 @@ async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmSta
     );
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        peer_bgp_id,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, peer_bgp_id, vec![]);
 
     let mut active_io_builder = BgpIoMockBuilder::new();
     active_io_builder
@@ -3211,7 +3141,7 @@ async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmSta
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3233,7 +3163,7 @@ async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmSta
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3303,12 +3233,7 @@ async fn test_open_confirm_collision_dump_tracked_connection(
     );
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        peer_bgp_id,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, peer_bgp_id, vec![]);
 
     let mut active_io_builder = BgpIoMockBuilder::new();
     active_io_builder
@@ -3316,7 +3241,7 @@ async fn test_open_confirm_collision_dump_tracked_connection(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3335,7 +3260,7 @@ async fn test_open_confirm_collision_dump_tracked_connection(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3401,19 +3326,14 @@ async fn test_open_confirm_open_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let notif = BgpNotificationMessage::FiniteStateMachineError(
         FiniteStateMachineError::ReceiveUnexpectedMessageInOpenConfirmState { value: vec![] },
     );
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3469,19 +3389,14 @@ async fn test_open_confirm_bgp_open_err() -> Result<(), FsmStateError<SocketAddr
         BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
             value: vec![0x00, 0x04],
         });
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3545,19 +3460,14 @@ async fn test_open_confirm_bgp_header_err() -> Result<(), FsmStateError<SocketAd
         BgpNotificationMessage::MessageHeaderError(MessageHeaderError::ConnectionNotSynchronized {
             value: Vec::from(&bad_header),
         });
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3611,19 +3521,14 @@ async fn test_open_confirm_bgp_header_err() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3667,12 +3572,7 @@ async fn test_open_confirm_keep_alive_msg() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -3680,7 +3580,7 @@ async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>>
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3733,12 +3633,7 @@ async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let update = [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0x00, 0x1b, 0x02, 0x00, 0x04, 0x19, 0xac, 0x10, 0x01, 0x00, 0x00,
@@ -3749,7 +3644,7 @@ async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>>
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3805,12 +3700,7 @@ async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let route_refresh = BgpRouteRefreshMessage::new(
         AddressType::Ipv4Unicast,
         RouteRefreshSubcode::BeginningOfRouteRefresh,
@@ -3821,7 +3711,7 @@ async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<Socke
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3874,19 +3764,14 @@ async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<Socke
 
 #[test_log::test(tokio::test)]
 async fn test_established_starts() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -3943,19 +3828,14 @@ async fn test_established_starts() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_established_manual_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4011,19 +3891,14 @@ async fn test_established_manual_stop() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_established_automatic_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4082,19 +3957,14 @@ async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<Socke
     let hold_time = 3;
     let policy =
         EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4163,19 +4033,14 @@ async fn test_established_keep_alive_timer_expires() -> Result<(), FsmStateError
     let hold_time = 3;
     let policy =
         EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4242,12 +4107,7 @@ async fn test_established_collision_dump_main_connection() -> Result<(), FsmStat
     );
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        peer_bgp_id,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, peer_bgp_id, vec![]);
 
     let mut active_io_builder = BgpIoMockBuilder::new();
     active_io_builder
@@ -4255,7 +4115,7 @@ async fn test_established_collision_dump_main_connection() -> Result<(), FsmStat
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4278,7 +4138,7 @@ async fn test_established_collision_dump_main_connection() -> Result<(), FsmStat
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4353,12 +4213,7 @@ async fn test_established_collision_dump_tracked_connection(
     );
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        peer_bgp_id,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, peer_bgp_id, vec![]);
 
     let mut active_io_builder = BgpIoMockBuilder::new();
     active_io_builder
@@ -4366,7 +4221,7 @@ async fn test_established_collision_dump_tracked_connection(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4386,7 +4241,7 @@ async fn test_established_collision_dump_tracked_connection(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4463,12 +4318,7 @@ async fn test_established_reject_connection_tracking_disabled(
     );
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        peer_bgp_id,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, peer_bgp_id, vec![]);
 
     let mut active_io_builder = BgpIoMockBuilder::new();
     active_io_builder
@@ -4476,7 +4326,7 @@ async fn test_established_reject_connection_tracking_disabled(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4538,12 +4388,7 @@ async fn test_established_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
     let policy =
         EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
     let mut io_builder = BgpIoMockBuilder::new();
@@ -4552,7 +4397,7 @@ async fn test_established_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4606,12 +4451,7 @@ async fn test_established_notif_version_error() -> Result<(), FsmStateError<Sock
     let hold_time = 3;
     let policy =
         EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        hold_time,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, hold_time, PEER_BGP_ID, vec![]);
     let notif =
         BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
             value: vec![0x00, 0x04],
@@ -4622,7 +4462,7 @@ async fn test_established_notif_version_error() -> Result<(), FsmStateError<Sock
             MY_AS as u16,
             hold_time,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4677,7 +4517,7 @@ async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<Soc
         MY_AS as u16,
         HOLD_TIME,
         MY_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     ));
     let buf = vec![];
     let mut cursor = Cursor::new(buf);
@@ -4688,7 +4528,7 @@ async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<Soc
         PEER_AS as u16,
         HOLD_TIME,
         PEER_BGP_ID,
-        vec![Capabilities(vec![])],
+        vec![],
     ));
     let buf = vec![];
     let mut cursor = Cursor::new(buf);
@@ -4752,19 +4592,14 @@ async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<Soc
 
 #[test_log::test(tokio::test)]
 async fn test_established_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)
@@ -4811,12 +4646,7 @@ async fn test_established_keep_alive_msg() -> Result<(), FsmStateError<SocketAdd
 
 #[test_log::test(tokio::test)]
 async fn test_established_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let peer_open = BgpOpenMessage::new(
-        PEER_AS as u16,
-        HOLD_TIME,
-        PEER_BGP_ID,
-        vec![Capabilities(vec![])],
-    );
+    let peer_open = BgpOpenMessage::new(PEER_AS as u16, HOLD_TIME, PEER_BGP_ID, vec![]);
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -4824,7 +4654,7 @@ async fn test_established_update_msg() -> Result<(), FsmStateError<SocketAddr>> 
             MY_AS as u16,
             HOLD_TIME,
             MY_BGP_ID,
-            vec![Capabilities(vec![])],
+            vec![],
         )))
         .read(BgpMessage::Open(peer_open.clone()))
         .write(BgpMessage::KeepAlive)

--- a/crates/bgp-speaker/src/peer_test.rs
+++ b/crates/bgp-speaker/src/peer_test.rs
@@ -47,7 +47,8 @@ const PROPERTIES: PeerProperties<SocketAddr> = PeerProperties::new(
 
 #[test_log::test(tokio::test)]
 async fn test_idle_manual_start() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -70,7 +71,8 @@ async fn test_idle_manual_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_idle_manual_start_with_passive_tcp() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -101,7 +103,8 @@ async fn test_idle_manual_start_with_passive_tcp() {
 
 #[test_log::test(tokio::test)]
 async fn test_idle_automatic_start() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -125,7 +128,8 @@ async fn test_idle_automatic_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_idle_automatic_start_with_passive() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -156,7 +160,8 @@ async fn test_idle_automatic_start_with_passive() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_manual_start() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -183,7 +188,8 @@ async fn test_connect_manual_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_automatic_start() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -210,7 +216,8 @@ async fn test_connect_automatic_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_manual_stop() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -260,7 +267,8 @@ async fn test_connect_manual_stop() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_retry_timer_expires() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -300,7 +308,8 @@ async fn test_connect_retry_timer_expires() {
 #[test_log::test(tokio::test)]
 async fn test_connect_delay_open_timer_expires() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .wait(Duration::from_secs(1))
@@ -349,7 +358,8 @@ async fn test_connect_delay_open_timer_expires() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_confirmed() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -404,7 +414,8 @@ async fn test_connect_tcp_connection_confirmed() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_confirmed_with_open_delay() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
@@ -448,7 +459,8 @@ async fn test_connect_tcp_connection_confirmed_with_open_delay() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_connection_fails() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_connect = MockFailedActiveConnect {
         peer_addr: PEER_ADDR,
         connect_delay: Duration::from_secs(0),
@@ -487,7 +499,8 @@ async fn test_connect_tcp_connection_fails_with_open_delay_timer() {
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_with_delay() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -546,7 +559,8 @@ async fn test_connect_bgp_open_with_delay() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_tcp_cr_acked() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
@@ -580,7 +594,8 @@ async fn test_connect_tcp_cr_acked() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_header_err() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let bad_header = [0xee; 16];
     io_builder
@@ -626,7 +641,8 @@ async fn test_connect_bgp_header_err() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_err_unsupported_version() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let bgp_version = 0x03;
     io_builder
@@ -673,7 +689,8 @@ async fn test_connect_bgp_open_err_unsupported_version() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_bgp_open_err_unacceptable_hold_time() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let hold_time = 1;
     let peer_open = BgpOpenMessage::new(
@@ -731,7 +748,8 @@ async fn test_connect_notif_version_err() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_notif_version_err_with_open_delay() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.read(BgpMessage::Notification(
         BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
@@ -766,7 +784,8 @@ async fn test_connect_notif_version_err_with_open_delay() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_automatic_stop() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.write(BgpMessage::Notification(
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] }),
@@ -808,7 +827,8 @@ async fn test_connect_hold_timer_expires() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_notif_msg() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
@@ -842,7 +862,8 @@ async fn test_connect_notif_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_keepalive_msg() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder.read(BgpMessage::KeepAlive);
 
@@ -874,7 +895,8 @@ async fn test_connect_keepalive_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_update_msg() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
     io_builder.read(BgpMessage::Update(update.clone()));
@@ -910,7 +932,8 @@ async fn test_connect_update_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_update_err_msg() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let update = [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -951,7 +974,8 @@ async fn test_connect_update_err_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_connect_route_refresh_msg() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     let route_refresh = BgpRouteRefreshMessage::new(
         AddressType::Ipv4Unicast,
@@ -987,7 +1011,8 @@ async fn test_connect_route_refresh_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_manual_start() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -1018,7 +1043,8 @@ async fn test_active_manual_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_automatic_start() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
     let active_connect = MockActiveConnect {
         peer_addr: PEER_ADDR,
@@ -1049,7 +1075,8 @@ async fn test_active_automatic_start() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_connect_retry_timer_expires() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let io_builder = BgpIoMockBuilder::new();
 
     let active_connect = MockActiveConnect {
@@ -1089,7 +1116,8 @@ async fn test_active_connect_retry_timer_expires() {
 #[test_log::test(tokio::test)]
 async fn test_active_delay_open_timer_expires() {
     let open_delay = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1144,7 +1172,8 @@ async fn test_active_delay_open_timer_expires() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_confirmed() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     passive_io_builder.write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1193,7 +1222,8 @@ async fn test_active_tcp_connection_confirmed() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_confirmed_with_open_delay() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
 
@@ -1232,7 +1262,8 @@ async fn test_active_tcp_connection_confirmed_with_open_delay() {
 
 #[test_log::test(tokio::test)]
 async fn test_active_tcp_connection_fails() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let passive_io = tokio_test::io::Builder::new()
         .read_error(io::Error::from(io::ErrorKind::ConnectionAborted))
@@ -1282,7 +1313,8 @@ async fn test_active_tcp_connection_fails() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_active_bgp_open_with_open_delay() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -1359,7 +1391,8 @@ async fn test_active_bgp_open_with_open_delay() {
 #[test_log::test(tokio::test)]
 async fn test_active_bgp_header_err() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
     let bad_header = [0xee; 16];
@@ -1419,7 +1452,8 @@ async fn test_active_bgp_header_err() {
 #[test_log::test(tokio::test)]
 async fn test_active_bgp_open_err() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1487,7 +1521,8 @@ async fn test_active_notif_version_err() {
 #[test_log::test(tokio::test)]
 async fn test_active_notif_version_err_with_open_delay() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1535,7 +1570,8 @@ async fn test_active_notif_version_err_with_open_delay() {
 #[test_log::test(tokio::test)]
 async fn test_active_automatic_stop() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1583,7 +1619,8 @@ async fn test_active_automatic_stop() {
 #[test_log::test(tokio::test)]
 async fn test_active_notif_msg() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let notif =
@@ -1631,7 +1668,8 @@ async fn test_active_notif_msg() {
 #[test_log::test(tokio::test)]
 async fn test_active_keepalive_msg() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let mut passive_io_builder = BgpIoMockBuilder::new();
@@ -1676,7 +1714,8 @@ async fn test_active_keepalive_msg() {
 #[test_log::test(tokio::test)]
 async fn test_active_update_msg() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
@@ -1724,7 +1763,8 @@ async fn test_active_update_msg() {
 #[test_log::test(tokio::test)]
 async fn test_active_update_err_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let update = [
@@ -1778,7 +1818,8 @@ async fn test_active_update_err_msg() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_active_route_refresh_msg() {
     let delay_open_duration = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
 
     let active_io_builder = BgpIoMockBuilder::new();
     let route_refresh = BgpRouteRefreshMessage::new(
@@ -1826,7 +1867,8 @@ async fn test_active_route_refresh_msg() {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_manual_stop() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1873,7 +1915,8 @@ async fn test_open_sent_manual_stop() {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_automatic_stop() {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1921,7 +1964,8 @@ async fn test_open_sent_automatic_stop() {
 #[test_log::test(tokio::test)]
 async fn test_open_sent_hold_timer_expires() {
     let hold_time = 1;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -1966,7 +2010,8 @@ async fn test_open_sent_hold_timer_expires() {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_tcp_connection_confirmed() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut passive_addr = PEER_ADDR;
     passive_addr.set_port(5000);
     let mut active_io_builder = BgpIoMockBuilder::new();
@@ -2028,7 +2073,8 @@ async fn test_open_sent_tcp_cr_acked() {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_tcp_connections_fails() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let active_io_builder = BgpIoMockBuilder::new();
 
     let msg = BgpMessage::Open(BgpOpenMessage::new(
@@ -2084,7 +2130,8 @@ async fn test_open_sent_tcp_connections_fails() -> Result<(), FsmStateError<Sock
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_open() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2139,7 +2186,8 @@ async fn test_open_sent_bgp_open() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let bad_header = [0xee; 16];
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2201,7 +2249,8 @@ async fn test_open_sent_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let bgp_version = 0x03;
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2262,7 +2311,8 @@ async fn test_open_sent_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> 
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -2362,7 +2412,8 @@ async fn test_open_sent_collision_dump_main_connection() -> Result<(), FsmStateE
 #[test_log::test(tokio::test)]
 async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -2461,7 +2512,8 @@ async fn test_open_sent_collision_dump_tracked_connection() -> Result<(), FsmSta
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_notif_version_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -2512,7 +2564,8 @@ async fn test_open_sent_notif_version_err() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
     let mut io_builder = BgpIoMockBuilder::new();
@@ -2566,7 +2619,8 @@ async fn test_open_sent_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
         .write(BgpMessage::Open(BgpOpenMessage::new(
@@ -2618,7 +2672,8 @@ async fn test_open_sent_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let update = BgpUpdateMessage::new(vec![], vec![], vec![]);
     let mut io_builder = BgpIoMockBuilder::new();
     io_builder
@@ -2671,7 +2726,8 @@ async fn test_open_sent_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_update_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let update = [
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         0xff, 0x00, 0x1b, 0x02, 0x00, 0x04, 0x19, 0xac, 0x10, 0x01, 0x00, 0x00,
@@ -2730,7 +2786,8 @@ async fn test_open_sent_update_err() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_sent_route_refresh_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let route_refresh = BgpRouteRefreshMessage::new(
         AddressType::Ipv4Unicast,
         RouteRefreshSubcode::BeginningOfRouteRefresh,
@@ -2786,7 +2843,8 @@ async fn test_open_sent_route_refresh_msg() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_starts() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2851,7 +2909,8 @@ async fn test_open_confirm_starts() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_manual_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2915,7 +2974,8 @@ async fn test_open_confirm_manual_stop() -> Result<(), FsmStateError<SocketAddr>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_automatic_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -2980,7 +3040,8 @@ async fn test_open_confirm_automatic_stop() -> Result<(), FsmStateError<SocketAd
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3057,7 +3118,8 @@ async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<Sock
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_keep_alive_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3115,7 +3177,8 @@ async fn test_open_confirm_keep_alive_timer_expires() -> Result<(), FsmStateErro
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let notif =
         BgpNotificationMessage::CeaseError(CeaseError::AdministrativeShutdown { value: vec![] });
     let peer_open = BgpOpenMessage::new(
@@ -3178,7 +3241,8 @@ async fn test_open_confirm_notif_msg() -> Result<(), FsmStateError<SocketAddr>> 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_notif_version_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -3243,7 +3307,8 @@ async fn test_open_confirm_notif_version_err() -> Result<(), FsmStateError<Socke
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -3349,7 +3414,8 @@ async fn test_open_confirm_collision_dump_main_connection() -> Result<(), FsmSta
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_collision_dump_tracked_connection(
 ) -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -3455,7 +3521,8 @@ async fn test_open_confirm_collision_dump_tracked_connection(
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_open_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let notif = BgpNotificationMessage::FiniteStateMachineError(
         FiniteStateMachineError::ReceiveUnexpectedMessageInOpenConfirmState { value: vec![] },
     );
@@ -3520,7 +3587,8 @@ async fn test_open_confirm_open_msg() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_bgp_open_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let bgp_version = 0x03;
     let notif =
         BgpNotificationMessage::OpenMessageError(OpenMessageError::UnsupportedVersionNumber {
@@ -3595,7 +3663,8 @@ async fn test_open_confirm_bgp_open_err() -> Result<(), FsmStateError<SocketAddr
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_bgp_header_err() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let bad_header = [0xee; 16];
     let notif =
         BgpNotificationMessage::MessageHeaderError(MessageHeaderError::ConnectionNotSynchronized {
@@ -3667,7 +3736,8 @@ async fn test_open_confirm_bgp_header_err() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3724,7 +3794,8 @@ async fn test_open_confirm_keep_alive_msg() -> Result<(), FsmStateError<SocketAd
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3791,7 +3862,8 @@ async fn test_open_confirm_update_msg() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3864,7 +3936,8 @@ async fn test_open_confirm_update_err() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -3934,7 +4007,8 @@ async fn test_open_confirm_route_refresh_msg() -> Result<(), FsmStateError<Socke
 
 #[test_log::test(tokio::test)]
 async fn test_established_starts() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4004,7 +4078,8 @@ async fn test_established_starts() -> Result<(), FsmStateError<SocketAddr>> {
 
 #[test_log::test(tokio::test)]
 async fn test_established_manual_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4073,7 +4148,8 @@ async fn test_established_manual_stop() -> Result<(), FsmStateError<SocketAddr>>
 
 #[test_log::test(tokio::test)]
 async fn test_established_automatic_stop() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4143,7 +4219,8 @@ async fn test_established_automatic_stop() -> Result<(), FsmStateError<SocketAdd
 #[test_log::test(tokio::test)]
 async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4223,7 +4300,8 @@ async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<Socke
 #[test_log::test(tokio::test)]
 async fn test_established_keep_alive_timer_expires() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4291,7 +4369,8 @@ async fn test_established_keep_alive_timer_expires() -> Result<(), FsmStateError
 #[test_log::test(tokio::test)]
 async fn test_established_collision_dump_main_connection() -> Result<(), FsmStateError<SocketAddr>>
 {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) + 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4403,7 +4482,8 @@ async fn test_established_collision_dump_main_connection() -> Result<(), FsmStat
 #[test_log::test(tokio::test)]
 async fn test_established_collision_dump_tracked_connection(
 ) -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4514,7 +4594,8 @@ async fn test_established_collision_dump_tracked_connection(
 #[test_log::test(tokio::test)]
 async fn test_established_reject_connection_tracking_disabled(
 ) -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_bgp_id = Ipv4Addr::from(u32::from(MY_BGP_ID) - 1);
     let properties = PeerProperties::new(
         MY_AS,
@@ -4600,7 +4681,8 @@ async fn test_established_reject_connection_tracking_disabled(
 #[test_log::test(tokio::test)]
 async fn test_established_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4667,7 +4749,8 @@ async fn test_established_notif_msg() -> Result<(), FsmStateError<SocketAddr>> {
 #[test_log::test(tokio::test)]
 async fn test_established_notif_version_error() -> Result<(), FsmStateError<SocketAddr>> {
     let hold_time = 3;
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, hold_time, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         hold_time,
@@ -4735,7 +4818,8 @@ async fn test_established_notif_version_error() -> Result<(), FsmStateError<Sock
 
 #[test_log::test(tokio::test)]
 async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let my_open = BgpMessage::Open(BgpOpenMessage::new(
         MY_AS as u16,
         HOLD_TIME,
@@ -4815,7 +4899,8 @@ async fn test_established_tcp_connection_fails() -> Result<(), FsmStateError<Soc
 
 #[test_log::test(tokio::test)]
 async fn test_established_keep_alive_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4875,7 +4960,8 @@ async fn test_established_keep_alive_msg() -> Result<(), FsmStateError<SocketAdd
 
 #[test_log::test(tokio::test)]
 async fn test_established_update_msg() -> Result<(), FsmStateError<SocketAddr>> {
-    let policy = EchoCapabilitiesPolicy::new(MY_AS, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
+    let policy =
+        EchoCapabilitiesPolicy::new(MY_AS, false, MY_BGP_ID, HOLD_TIME, Vec::new(), Vec::new());
     let peer_open = BgpOpenMessage::new(
         PEER_AS as u16,
         HOLD_TIME,
@@ -4964,6 +5050,7 @@ async fn test_connect_echo_policy() -> Result<(), FsmStateError<SocketAddr>> {
     ];
     let policy = EchoCapabilitiesPolicy::new(
         my_asn,
+        false,
         MY_BGP_ID,
         HOLD_TIME,
         pushed_caps.clone(),

--- a/crates/bgp-speaker/src/supervisor.rs
+++ b/crates/bgp-speaker/src/supervisor.rs
@@ -149,6 +149,7 @@ impl<
             .build();
         let policy = EchoCapabilitiesPolicy::new(
             self.my_asn,
+            true,
             self.my_bgp_id,
             peer_config.hold_timer_duration_large_value,
             Vec::new(),
@@ -194,14 +195,14 @@ mod tests {
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, Vec::new(), Vec::new()),
+            EchoCapabilitiesPolicy::new(my_asn, false, my_bgp_id, 100, Vec::new(), Vec::new()),
         )?;
         let second_create = supervisor.create_peer(
             peer_addr.ip(),
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, Vec::new(), Vec::new()),
+            EchoCapabilitiesPolicy::new(my_asn, false, my_bgp_id, 100, Vec::new(), Vec::new()),
         );
         let removed_peer = supervisor.remove_peer(&peer_addr.ip());
         let non_existing_peer = supervisor.remove_peer(&peer_addr.ip());
@@ -237,7 +238,7 @@ mod tests {
             peer_properties,
             PeerConfig::default(),
             TcpActiveConnect,
-            EchoCapabilitiesPolicy::new(my_asn, my_bgp_id, 100, Vec::new(), Vec::new()),
+            EchoCapabilitiesPolicy::new(my_asn, false, my_bgp_id, 100, Vec::new(), Vec::new()),
         );
 
         let removed_peer = supervisor.remove_peer(&peer_addr.ip());


### PR DESCRIPTION
* Make the default behavior of handling AS4 capabilities configurable in EchoCapabilitiesPolicy
* Make EchoCapabilitiesPolicy::new const, and reduce many duplicate test lines
* Don't send empty `vec![BgpOpenMessageParameter::Capabilities(capabilities)]` 