### PR TITLE
Implement jitter for KeepAlive and ConnectRetry timers

### DIFF
--- a/crates/bgp-speaker/Cargo.toml
+++ b/crates/bgp-speaker/Cargo.toml
@@ -32,7 +32,7 @@ tokio-stream = { workspace = true, features = ["net"] }
 log = { workspace = true }
 nom = { workspace = true }
 ipnet = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ["small_rng"] }
 async-trait = { workspace = true }
 strum_macros = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/crates/bgp-speaker/src/tests/peer.rs
+++ b/crates/bgp-speaker/src/tests/peer.rs
@@ -2666,6 +2666,7 @@ async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<Sock
         .write(BgpMessage::KeepAlive)
         .write(BgpMessage::KeepAlive)
         .write(BgpMessage::KeepAlive)
+        .write(BgpMessage::KeepAlive)
         .write(BgpMessage::Notification(
             BgpNotificationMessage::HoldTimerExpiredError(HoldTimerExpiredError::Unspecific {
                 sub_code: 0,
@@ -2701,6 +2702,10 @@ async fn test_open_confirm_hold_timer_expires() -> Result<(), FsmStateError<Sock
 
     let event = peer.run().await?;
     assert_eq!(event, BgpEvent::BGPOpen(peer_open));
+    assert_eq!(peer.fsm_state(), FsmState::OpenConfirm);
+
+    let event = peer.run().await?;
+    assert_eq!(event, BgpEvent::KeepAliveTimerExpires);
     assert_eq!(peer.fsm_state(), FsmState::OpenConfirm);
 
     let event = peer.run().await?;
@@ -3732,6 +3737,7 @@ async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<Socke
         .read(BgpMessage::KeepAlive)
         .write(BgpMessage::KeepAlive)
         .write(BgpMessage::KeepAlive)
+        .write(BgpMessage::KeepAlive)
         .write(BgpMessage::Notification(
             BgpNotificationMessage::HoldTimerExpiredError(HoldTimerExpiredError::Unspecific {
                 sub_code: 0,
@@ -3769,6 +3775,10 @@ async fn test_established_hold_timer_expires() -> Result<(), FsmStateError<Socke
 
     let event = peer.run().await?;
     assert_eq!(event, BgpEvent::KeepAliveMsg);
+    assert_eq!(peer.fsm_state(), FsmState::Established);
+
+    let event = peer.run().await?;
+    assert_eq!(event, BgpEvent::KeepAliveTimerExpires);
     assert_eq!(peer.fsm_state(), FsmState::Established);
 
     let event = peer.run().await?;


### PR DESCRIPTION
In accordance with [RFC4271](https://datatracker.ietf.org/doc/html/rfc4271#section-10)