### PR TITLE
Version bump for v0.3.0 to 0.3.1 to resolve the 'missing u256' issue

### DIFF
--- a/crates/flow-pkt/Cargo.toml
+++ b/crates/flow-pkt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netgauze-flow-pkt"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Ahmed Elhassany <a.hassany@gmail.com>"]
 license = "Apache-2.0"
@@ -41,7 +41,7 @@ serde_json = { workspace = true }
 [build-dependencies]
 reqwest = { workspace = true, features = ["blocking"] }
 roxmltree = { workspace = true }
-netgauze-ipfix-code-generator = { version = "0.3.0", path = "../ipfix-code-generator" }
+netgauze-ipfix-code-generator = { version = "0.3.1", path = "../ipfix-code-generator" }
 
 
 [[bench]]

--- a/crates/flow-pkt/src/ie.rs
+++ b/crates/flow-pkt/src/ie.rs
@@ -103,6 +103,9 @@ pub enum InformationElementDataType {
     /// [RFC6313](https://datatracker.ietf.org/doc/html/rfc6313)
     /// [RFC7011](https://datatracker.ietf.org/doc/html/rfc7011)
     subTemplateMultiList = 22,
+
+    /// [RFC-ietf-opsawg-ipfix-tcpo-v6eh-18](https://datatracker.ietf.org/doc/draft-ietf-opsawg-ipfix-tcpo-v6eh/18/)
+    unsigned256 = 23,
 }
 
 pub trait InformationElementTemplate {
@@ -141,6 +144,7 @@ pub trait InformationElementTemplate {
             InformationElementDataType::basicList => None,
             InformationElementDataType::subTemplateList => None,
             InformationElementDataType::subTemplateMultiList => None,
+            InformationElementDataType::unsigned256 => Some(std::ops::Range { start: 1, end: 33 }),
         }
     }
     fn value_range(&self) -> Option<std::ops::Range<u64>>;

--- a/crates/ipfix-code-generator/Cargo.toml
+++ b/crates/ipfix-code-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netgauze-ipfix-code-generator"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Ahmed Elhassany <a.hassany@gmail.com>"]
 license = "Apache-2.0"

--- a/crates/ipfix-code-generator/src/generator.rs
+++ b/crates/ipfix-code-generator/src/generator.rs
@@ -772,7 +772,6 @@ fn generate_u256_deserializer(ie_name: &String) -> String {
     ret.push_str("        let mut ret: [u8; 32] = [0; 32];\n");
     ret.push_str("        ret.copy_from_slice(buf.slice(..8).fragment());\n");
     ret.push_str(format!("        Ok((buf.slice(len..), {ie_name}(ret)))\n").as_str());
-
     ret.push_str("    }\n");
     ret.push_str("}\n\n");
     ret

--- a/crates/ipfix-code-generator/src/generator.rs
+++ b/crates/ipfix-code-generator/src/generator.rs
@@ -759,6 +759,30 @@ fn generate_u64_deserializer(ie_name: &String) -> String {
     ret
 }
 
+fn generate_u256_deserializer(ie_name: &String, enum_subreg: bool) -> String {
+    let mut ret = String::new();
+    let std_error = get_std_deserializer_error(ie_name.as_str());
+    let header = get_deserializer_header(ie_name.as_str());
+    ret.push_str(std_error.as_str());
+    ret.push_str(header.as_str());
+    ret.push_str("        let len = length as usize;\n");
+    ret.push_str("        if length > 32 || buf.input_len() < len {\n");
+    ret.push_str(format!("            return Err(nom::Err::Error(Located{ie_name}ParsingError::new(buf, {ie_name}ParsingError::InvalidLength(length))))\n").as_str());
+    ret.push_str("        }\n");
+    ret.push_str("        let mut ret: [u8; 32] = [0; 32];\n");
+    ret.push_str("        ret.copy_from_slice(buf.slice(..8).fragment());\n");
+    if enum_subreg {
+        ret.push_str(format!("        let enum_val = {ie_name}::from(ret);\n").as_str());
+        ret.push_str("        Ok((buf.slice(len..), ret))\n");
+    } else {
+        ret.push_str(format!("        Ok((buf.slice(len..), {ie_name}(ret)))\n").as_str());
+    }
+
+    ret.push_str("    }\n");
+    ret.push_str("}\n\n");
+    ret
+}
+
 fn generate_i8_deserializer(ie_name: &String) -> String {
     let mut ret = String::new();
     let std_error = get_std_deserializer_error(ie_name.as_str());
@@ -1117,6 +1141,7 @@ fn generate_ie_deserializer(data_type: &str, ie_name: &String) -> String {
         "basicList" => generate_vec_u8_deserializer(ie_name),
         "subTemplateList" => generate_vec_u8_deserializer(ie_name),
         "subTemplateMultiList" => generate_vec_u8_deserializer(ie_name),
+        "unsigned256" => generate_u256_deserializer(ie_name, enum_subreg),
         ty => todo!("Unsupported deserialization for type: {}", ty),
     };
     ret.push_str(gen.as_str());
@@ -1246,6 +1271,7 @@ fn get_rust_type(data_type: &str) -> String {
         "ipv4Address" => "std::net::Ipv4Addr",
         "ipv6Address" => "std::net::Ipv6Addr",
         "basicList" | "subTemplateList" | "subTemplateMultiList" => "Vec<u8>",
+        "unsigned256" => "[u8; 32]",
         other => todo!("Implement rust data type conversion for {}", other),
     };
     rust_type.to_string()
@@ -1651,6 +1677,7 @@ fn generate_ie_serializer(data_type: &str, ie_name: &String) -> String {
         "basicList" => generate_array_serializer(ie_name),
         "subTemplateList" => generate_array_serializer(ie_name),
         "subTemplateMultiList" => generate_array_serializer(ie_name),
+        "unsigned256" => generate_array_serializer(ie_name),
         ty => todo!("Unsupported serialization for type: {}", ty),
     };
     ret.push_str(gen.as_str());

--- a/crates/ipfix-code-generator/src/generator.rs
+++ b/crates/ipfix-code-generator/src/generator.rs
@@ -759,7 +759,7 @@ fn generate_u64_deserializer(ie_name: &String) -> String {
     ret
 }
 
-fn generate_u256_deserializer(ie_name: &String, enum_subreg: bool) -> String {
+fn generate_u256_deserializer(ie_name: &String) -> String {
     let mut ret = String::new();
     let std_error = get_std_deserializer_error(ie_name.as_str());
     let header = get_deserializer_header(ie_name.as_str());
@@ -771,12 +771,7 @@ fn generate_u256_deserializer(ie_name: &String, enum_subreg: bool) -> String {
     ret.push_str("        }\n");
     ret.push_str("        let mut ret: [u8; 32] = [0; 32];\n");
     ret.push_str("        ret.copy_from_slice(buf.slice(..8).fragment());\n");
-    if enum_subreg {
-        ret.push_str(format!("        let enum_val = {ie_name}::from(ret);\n").as_str());
-        ret.push_str("        Ok((buf.slice(len..), ret))\n");
-    } else {
-        ret.push_str(format!("        Ok((buf.slice(len..), {ie_name}(ret)))\n").as_str());
-    }
+    ret.push_str(format!("        Ok((buf.slice(len..), {ie_name}(ret)))\n").as_str());
 
     ret.push_str("    }\n");
     ret.push_str("}\n\n");
@@ -1141,7 +1136,7 @@ fn generate_ie_deserializer(data_type: &str, ie_name: &String) -> String {
         "basicList" => generate_vec_u8_deserializer(ie_name),
         "subTemplateList" => generate_vec_u8_deserializer(ie_name),
         "subTemplateMultiList" => generate_vec_u8_deserializer(ie_name),
-        "unsigned256" => generate_u256_deserializer(ie_name, enum_subreg),
+        "unsigned256" => generate_u256_deserializer(ie_name),
         ty => todo!("Unsupported deserialization for type: {}", ty),
     };
     ret.push_str(gen.as_str());


### PR DESCRIPTION
In reference to #89 and [abd6f27](https://github.com/NetGauze/NetGauze/commit/abd6f27eff7330b344e3ffc386ba4290637d0ad3), I'd like to propose the following hotfix for v0.3.0.

I've cherrypicked the initial hotfix from main v0.4.0 but applied it to v0.3.0 to retain functionality for the v0.3 minor version. This is done so v0.3.0 can be yanked from cargo and v0.3.1 can stand in its place. This would avoid production trip-ups for those still using v0.3.0.

This should probably not be merged into main (as the PR suggests), but exist on its own v0.3 branch for future patches.