### PR TITLE
remove unnecessary lifetime from PcapIter

### DIFF
--- a/crates/pcap-reader/src/lib.rs
+++ b/crates/pcap-reader/src/lib.rs
@@ -78,7 +78,7 @@ impl<'a> PcapIter<'a> {
     }
 }
 
-impl<'a> Iterator for PcapIter<'a> {
+impl Iterator for PcapIter<'_> {
     type Item = (IpAddr, u16, IpAddr, u16, TransportProtocol, Vec<u8>);
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
remove unnecessary lifetime from PcapIter