### PR TITLE
Fix a panic in the flow decoder and some error messages

### DIFF
--- a/crates/flow-service/src/flow_actor.rs
+++ b/crates/flow-service/src/flow_actor.rs
@@ -207,7 +207,7 @@ impl std::fmt::Display for FlowCollectorActorError {
 impl std::error::Error for FlowCollectorActorError {
     fn description(&self) -> &str {
         match self {
-            Self::SocketBindError(_, _, _) => "failed tob bind to socket address",
+            Self::SocketBindError(_, _, _) => "failed to bind to socket address",
             Self::GetLocalAddressError(_, _, _) => "failed to get local address",
             Self::CommandChannelClosed(_, _) => "command channel closed",
             Self::UnrecoverablePacketProcessingError(_, _, _) => {

--- a/crates/flow-service/src/flow_supervisor.rs
+++ b/crates/flow-service/src/flow_supervisor.rs
@@ -442,7 +442,7 @@ impl FlowCollectorsSupervisorActorHandle {
             ))
             .await
         {
-            error!("[SupervisorHandle] Error sending purge unused peers request: {err:?}");
+            error!("[SupervisorHandle] Error sending purge peer request: {err:?}");
             return Err(FlowCollectorsSupervisorActorHandleError::SendError);
         }
         let mut purged_peers = vec![];
@@ -465,7 +465,7 @@ impl FlowCollectorsSupervisorActorHandle {
             ))
             .await
         {
-            error!("[SupervisorHandle] Error sending purge unused peers request: {err:?}");
+            error!("[SupervisorHandle] Error sending get local addresses request: {err:?}");
             return Err(FlowCollectorsSupervisorActorHandleError::SendError);
         }
         let mut local = vec![];


### PR DESCRIPTION
- it does not change the buffer handling, only fixes the crash and some error messages
- reorders the length checking code in FlowInfoCodec similar to the one in UdpPacketCodec