### PR TITLE
Add initial open telemetry support in NetGauze

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,4 @@ rstest = "0.24"
 pcap-parser = { version = "0.16", features = ["data"] }
 clap = { version = "4.5", features = ["derive"] }
 socket2 = { version = "0.5" }
+either = { version = "1.13" }

--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -35,6 +35,11 @@ reqwest = { workspace = true, features = ["http2", "json", "stream"] }
 chrono = { workspace = true, default-features = true }
 tracing-subscriber = { workspace = true }
 anyhow = { version = "1" }
+opentelemetry = { version = "0.27.1", features = ["metrics", "trace", "logs"] }
+opentelemetry_sdk = { version = "0.27.1", features = ["metrics", "trace", "logs", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.27.0", features = ["metrics", "trace", "logs", "tonic"] }
+opentelemetry-prometheus = { version = "0.27.0" }
+tonic = "0.12.3"
 
 [dev-dependencies]
 chrono = { workspace = true, default-features = false, features = [

--- a/crates/collector/config.yaml
+++ b/crates/collector/config.yaml
@@ -6,6 +6,9 @@ runtime:
 logging:
   level: info
 
+telemetry:
+  url: http://localhost:4317/v1/metrics
+
 flow:
   subscriber_timeout: 100
   template_cache_purge_timeout: 360
@@ -38,3 +41,4 @@ flow:
 #      kafka: !Kakfa
 #        url: http://10.212.242.69:8080/ingress/flows?format=json
 #        writer_id: writer1
+

--- a/crates/collector/src/config.rs
+++ b/crates/collector/src/config.rs
@@ -47,6 +47,7 @@ pub struct CollectorConfig {
     #[serde(default)]
     pub runtime: RuntimeConfig,
     pub logging: LoggingConfig,
+    pub telemetry: TelemetryConfig,
     pub flow: FlowConfig,
 }
 
@@ -66,6 +67,17 @@ impl Default for LoggingConfig {
         Self {
             level: "info".to_string(),
         }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TelemetryConfig {
+    pub url: String,
+}
+
+impl TelemetryConfig {
+    pub fn url(&self) -> &str {
+        self.url.as_str()
     }
 }
 

--- a/crates/flow-pkt/src/codec.rs
+++ b/crates/flow-pkt/src/codec.rs
@@ -57,6 +57,27 @@ impl From<std::io::Error> for FlowInfoCodecDecoderError {
     }
 }
 
+impl std::error::Error for FlowInfoCodecDecoderError {}
+
+impl std::fmt::Display for FlowInfoCodecDecoderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IoError(err) => write!(f, "IO error: {err}"),
+            Self::Incomplete(len) => write!(
+                f,
+                "Incomplete pkt, need {}",
+                len.map(|x| format!("{x} bytes"))
+                    .unwrap_or("unknown".to_string())
+            ),
+            Self::UnsupportedVersion(version) => {
+                write!(f, "Unsupported protocol version: {version}")
+            }
+            Self::IpfixParsingError(err) => write!(f, "IPFIX parsing error: {err}"),
+            Self::NetFlowV9ParingError(err) => write!(f, "NetFlow V9 parsing error: {err}"),
+        }
+    }
+}
+
 /// [`FlowInfo`] is either IPFIX or Netflow V9 packet.
 /// This struct keep track of the decode process, and keep a cache of the
 /// templates sent by client.

--- a/crates/flow-service/Cargo.toml
+++ b/crates/flow-service/Cargo.toml
@@ -27,6 +27,8 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 async-channel = { workspace = true }
 libc = {version = "0.2"}
+opentelemetry = { version = "0.27.1", features = ["metrics", "trace", "logs"] }
+either = {workspace = true}
 
 [dev-dependencies]
 chrono = { workspace = true, default-features = false, features = ["std", "clock"] }

--- a/crates/flow-service/examples/actor-example.rs
+++ b/crates/flow-service/examples/actor-example.rs
@@ -48,6 +48,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> 
             None,
             cmd_buffer_size,
             Duration::from_millis(500),
+            either::Either::Left(opentelemetry::global::meter("example")),
         )
         .await?;
         let (pkt_rx, subscriptions) = handler.subscribe(10).await?;

--- a/crates/flow-service/examples/actors-example.rs
+++ b/crates/flow-service/examples/actors-example.rs
@@ -42,8 +42,11 @@ pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> 
 
     runtime.block_on(async move {
         init_tracing();
-        let (supervisor_join_handle, handler) =
-            FlowCollectorsSupervisorActorHandle::new(config).await;
+        let (supervisor_join_handle, handler) = FlowCollectorsSupervisorActorHandle::new(
+            config,
+            opentelemetry::global::meter("example"),
+        )
+        .await;
         let (pkt_rx, subscriptions) = handler.subscribe(10).await?;
         for subscription in &subscriptions {
             info!("Subscribed to {:?}", subscription);


### PR DESCRIPTION
Start with open telemetry metrics for flow actors.