### PR TITLE
udp-notif-service: allow to bind to a single interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ netgauze-udp-notif-service = { version = "0.5.0", path = "crates/udp-notif-servi
 log = "0.4"
 thiserror = "2.0"
 async-channel = "2.3"
+libc = { version = "0.2" }
 byteorder = { version = "1.5" }
 chrono = { version = "0.4", default-features = false, features = [
     "std",

--- a/crates/flow-service/Cargo.toml
+++ b/crates/flow-service/Cargo.toml
@@ -26,7 +26,7 @@ socket2 = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 async-channel = { workspace = true }
-libc = {version = "0.2"}
+libc = { workspace = true }
 opentelemetry = { version = "0.27.1", features = ["metrics", "trace", "logs"] }
 either = {workspace = true}
 

--- a/crates/udp-notif-service/Cargo.toml
+++ b/crates/udp-notif-service/Cargo.toml
@@ -18,6 +18,7 @@ async-channel = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
+libc = { workspace = true }
 netgauze-parse-utils = { workspace = true }
 netgauze-udp-notif-pkt = { workspace = true, features = ["codec"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/udp-notif-service/examples/udp-notif-actor.rs
+++ b/crates/udp-notif-service/examples/udp-notif-actor.rs
@@ -45,6 +45,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> 
         let (join_handle, handler) = ActorHandle::new(
             actor_id,
             socket_addr,
+            None,
             cmd_buffer_size,
             Duration::from_millis(500),
         )

--- a/crates/udp-notif-service/src/lib.rs
+++ b/crates/udp-notif-service/src/lib.rs
@@ -46,13 +46,14 @@ impl Display for Subscription {
     }
 }
 
-/// Enable socket reuse
-/// TODO: Allow interface bind to be optionally specified
-/// See: [bind_device_by_index_v4](https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.bind_device_by_index_v4)
-/// and [bind_device_by_index_v6](https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.bind_device_by_index_v6)
+/// Enable socket reuse and bind to a device or a VRF on selected platforms.
+/// Binding to a device or VRF is supported on: MacOS and Linux.
+/// Unused variables is enabled to silence the Clippy error for platforms
+/// that doesn't support binding to an interface.
+#[allow(unused_variables)]
 pub fn new_udp_reuse_port(
     local_addr: SocketAddr,
-    _device: Option<String>,
+    device: Option<String>,
 ) -> io::Result<tokio::net::UdpSocket> {
     let udp_sock = socket2::Socket::new(
         if local_addr.is_ipv4() {
@@ -70,6 +71,39 @@ pub fn new_udp_reuse_port(
     // from tokio-rs/mio/blob/master/src/sys/unix/net.rs
     udp_sock.set_cloexec(true)?;
     udp_sock.set_nonblocking(true)?;
+    // Binding a socket to a device or VRF is a platform specific operation,
+    // hence we guard it for only a selected subset of target platforms.
+    // The first cfg block filters for the supported platforms to avoid Clippy
+    // errors about unused `name` for the unsupported platforms.
+    #[cfg(any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux"
+    ))]
+    if let Some(name) = device {
+        #[cfg(any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos",
+        ))]
+        {
+            let c_str = std::ffi::CString::new(name)?;
+            let c_index = unsafe { libc::if_nametoindex(c_str.as_ptr() as *const libc::c_char) };
+            let index = std::num::NonZeroU32::new(c_index as u32);
+            if local_addr.is_ipv4() {
+                udp_sock.bind_device_by_index_v4(index)?;
+            } else {
+                udp_sock.bind_device_by_index_v6(index)?;
+            }
+        }
+        #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+        udp_sock.bind_device(Some(name.as_bytes()))?
+    }
     udp_sock.bind(&socket2::SockAddr::from(local_addr))?;
     let udp_sock: std::net::UdpSocket = udp_sock.into();
     udp_sock.try_into()

--- a/crates/udp-notif-service/src/supervisor.rs
+++ b/crates/udp-notif-service/src/supervisor.rs
@@ -86,7 +86,7 @@ pub struct BindingAddress {
     pub socket_addr: SocketAddr,
     /// How many workers assigned to the given socket
     pub num_workers: usize,
-    // TODO: optionally bind to a specific interface
+    pub interface: Option<String>,
 }
 
 impl Default for SupervisorConfig {
@@ -95,6 +95,7 @@ impl Default for SupervisorConfig {
             binding_addresses: vec![BindingAddress {
                 socket_addr: SocketAddr::from_str("0.0.0.0:9999").unwrap(),
                 num_workers: 2,
+                interface: None,
             }],
             cmd_buffer_size: 100,
             subscriber_timeout: Duration::from_secs(1),
@@ -298,6 +299,7 @@ impl UdpNotifSupervisorHandle {
                 let actor_ret = ActorHandle::new(
                     next_actor_id,
                     binding_address.socket_addr,
+                    binding_address.interface.clone(),
                     10,
                     config.subscriber_timeout,
                 )
@@ -511,10 +513,12 @@ mod test {
                 BindingAddress {
                     socket_addr: "127.0.0.1:0".parse().unwrap(),
                     num_workers: 2,
+                    interface: None,
                 },
                 BindingAddress {
                     socket_addr: "127.0.0.1:0".parse().unwrap(),
                     num_workers: 1,
+                    interface: None,
                 },
             ],
             cmd_buffer_size: 10,


### PR DESCRIPTION
Allow UDP-Notif service to bind to a single interface