### PR TITLE
Add TrimmedString transform function

### DIFF
--- a/crates/collector/config_vmware.yaml
+++ b/crates/collector/config_vmware.yaml
@@ -8,6 +8,9 @@ logging:
 
 telemetry:
   url: http://localhost:4317/v1/metrics
+  exporter_timeout: 3000
+  reader_interval: 60000
+  reader_timeout: 3000
 
 flow:
   subscriber_timeout: 100
@@ -261,7 +264,7 @@ flow:
                 select: !Single
                   ie: !VMWare virtualObsID
                   index: 0
-                transform: String
+                transform: TrimmedString
                 default: !String ''
               custom_primitives.vmuuid:
                 select: !Single
@@ -286,4 +289,5 @@ flow:
                 select: !Single
                   ie: tcpControlBits
                   index: 0
-                transform: String
+                transform: StringArray
+                default: !StringArray []

--- a/crates/collector/src/flow/config.rs
+++ b/crates/collector/src/flow/config.rs
@@ -549,6 +549,9 @@ pub enum FieldTransformFunction {
     /// Convert the value into a string
     String,
 
+    /// Convert the value into a string and trim trailing null characters
+    TrimmedString,
+
     /// Convert the value to string and rename.
     /// If no key is given for the rename, then the name is passed as is
     Rename(indexmap::IndexMap<String, String>),
@@ -569,6 +572,7 @@ impl FieldTransformFunction {
         match self {
             Self::Identity => identity_type,
             Self::String => AvroValueKind::String,
+            Self::TrimmedString => AvroValueKind::String,
             Self::Rename(_) => AvroValueKind::String,
             Self::MplsIndex => AvroValueKind::Array,
             Self::StringArray => AvroValueKind::Array,
@@ -586,6 +590,15 @@ impl FieldTransformFunction {
             Self::String => {
                 if let Some(field) = field.pop() {
                     Ok(Some(RawValue::String(field.try_into()?)))
+                } else {
+                    Ok(None)
+                }
+            }
+            Self::TrimmedString => {
+                if let Some(field) = field.pop() {
+                    let original: String = field.try_into()?;
+                    let trimmed = original.trim_end_matches(char::from(0)).to_string();
+                    Ok(Some(RawValue::String(trimmed)))
                 } else {
                     Ok(None)
                 }

--- a/crates/ipfix-code-generator/src/generator.rs
+++ b/crates/ipfix-code-generator/src/generator.rs
@@ -1725,7 +1725,6 @@ pub fn generate_into_for_field(
             if ie_rust_type == convert_rust_type
                 && ie.subregistry.is_none()
                 && ie.name != "tcpControlBits"
-                && ie.name != "virtualObsID"
             {
                 // Native type converstion
                 ret.push_str(
@@ -1735,7 +1734,6 @@ pub fn generate_into_for_field(
                 && ie_rust_type != "Vec<u8>"
                 && ie_rust_type != "[u8; 32]"
                 && ie_rust_type != "super::MacAddress"
-                && ie.name != "virtualObsID"
             {
                 // Convert to using the defined Display implementation of the method
                 ret.push_str(
@@ -1748,9 +1746,6 @@ pub fn generate_into_for_field(
             } else if convert_rust_type == "String" && ie_rust_type == "super::MacAddress" {
                 // convert MacAddresses to human-readable string
                 ret.push_str(format!("            Self::{}(value) => Ok(value.iter().map(|x| format!(\"{{x:x}}\")).collect::<Vec<_>>().join(\":\").to_string()),\n", ie.name).as_str());
-            } else if convert_rust_type == "String" && ie.name == "virtualObsID" {
-                // trim trailing null chars from virtualObsID
-                ret.push_str(format!("            Self::{}(value) => Ok(value.trim_end_matches(char::from(0)).to_string()),\n", ie.name).as_str());
             } else if convert_rust_type == "Vec<String>" && ie.name == "tcpControlBits" {
                 ret.push_str(
                     format!(


### PR DESCRIPTION
This PR adds a new transform function (TrimmedString) for avro converter which converts field into a string and remove trailing null chars. The workaround to perform this step in the code generation is removed.