### PR TITLE
Derive display with to_string property for IANA subregs

### DIFF
--- a/crates/ipfix-code-generator/src/generator_sub_registries.rs
+++ b/crates/ipfix-code-generator/src/generator_sub_registries.rs
@@ -93,10 +93,16 @@ pub fn generate_enum(
         match rec {
             InformationElementSubRegistry::ValueNameDescRegistry(rec) => {
                 ret.push_str(generate_desc_and_refs_common(rec).as_str());
+                ret.push_str(
+                    format!("    #[strum(to_string = \"{}\")]\n", rec.display_name).as_str(),
+                );
                 ret.push_str(format!("    {} = {},\n", rec.name, rec.value).as_str());
             }
             InformationElementSubRegistry::ReasonCodeNestedRegistry(rec) => {
                 ret.push_str(generate_desc_and_refs_common(rec).as_str());
+                ret.push_str(
+                    format!("    #[strum(to_string = \"{} {{0}}\")]\n", rec.display_name).as_str(),
+                );
                 ret.push_str(
                     format!("    {}({}{}Reason),\n", rec.name, enum_name, rec.name).as_str(),
                 );

--- a/crates/ipfix-code-generator/src/lib.rs
+++ b/crates/ipfix-code-generator/src/lib.rs
@@ -87,6 +87,7 @@ pub enum InformationElementSubRegistry {
 pub struct ValueNameDescRegistry {
     pub value: u8,
     pub name: String,
+    pub display_name: String,
     pub description: String,
     pub comments: Option<String>,
     pub parameters: Option<String>,
@@ -99,6 +100,7 @@ pub struct ValueNameDescRegistry {
 pub struct ReasonCodeNestedRegistry {
     pub value: u8,
     pub name: String,
+    pub display_name: String,
     pub description: String,
     pub comments: Option<String>,
     pub parameters: Option<String>,


### PR DESCRIPTION
For the IANA IE sub-registries we had to do some cleanup of original property names and could not use it directly as an enum variants because they sometimes contain non-accepted characters. 

With this PR we introduce the to_string property to derive the display implementation for the sub-registry enum variants so that they match the original names from the registry. 

When the name was implied from the description (for registries that don't have a name column) we have a fallback with a maximum character constraint check, because it could be very long otherwise.
