### PR TITLE
use 2.8 version of librdkafka

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ serde_with = { version = "3.11" }
 indexmap = { version = "2.7" }
 apache-avro = { version = "0.17" }
 schema_registry_converter = { version = "4.2", default-features = false }
-rdkafka = { version = "0.37", default-features = false }
+rdkafka = { git= "https://github.com/ahassany/rust-rdkafka.git", branch = "custom-build", default-features = false }
 tracing-test = { version = "0.2" }
 syn = { version = "2.0" }
 quote = { version = "1.0" }


### PR DESCRIPTION
Use a newer (not officially merged upstream) version of librdkafka.
Previously, it was using 2.3.