### PR TITLE
Kafka json refactor

### DIFF
--- a/crates/collector/src/publishers/kafka_avro.rs
+++ b/crates/collector/src/publishers/kafka_avro.rs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::publishers::LoggingProducerContext;
 use netgauze_rdkafka::{
     config::{ClientConfig, FromClientConfigAndContext},
     error::{KafkaError, RDKafkaErrorCode},
-    message::DeliveryResult,
-    producer::{BaseRecord, NoCustomPartitioner, Producer, ProducerContext, ThreadedProducer},
-    ClientContext,
+    producer::{BaseRecord, Producer, ThreadedProducer},
 };
 use schema_registry_converter::{
     async_impl::{
@@ -137,26 +136,6 @@ impl KafkaAvroPublisherStats {
             error_avro_convert,
             error_avro_encode,
             error_send,
-        }
-    }
-}
-
-/// Producer context with tracing logs enabled
-#[derive(Clone)]
-pub struct LoggingProducerContext;
-
-impl ClientContext for LoggingProducerContext {}
-impl ProducerContext<NoCustomPartitioner> for LoggingProducerContext {
-    type DeliveryOpaque = ();
-
-    fn delivery(&self, delivery_result: &DeliveryResult<'_>, _: Self::DeliveryOpaque) {
-        match delivery_result {
-            Ok(_) => {
-                debug!("Message delivered successfully to kafka");
-            }
-            Err((err, _)) => {
-                warn!("Failed to deliver message to kafka: {err}");
-            }
         }
     }
 }

--- a/crates/collector/src/publishers/kafka_json.rs
+++ b/crates/collector/src/publishers/kafka_json.rs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::publishers::LoggingProducerContext;
 use netgauze_rdkafka::{
     config::{ClientConfig, FromClientConfigAndContext},
     error::{KafkaError, RDKafkaErrorCode},
-    message::DeliveryResult,
-    producer::{BaseRecord, NoCustomPartitioner, Producer, ProducerContext, ThreadedProducer},
-    ClientContext,
+    producer::{BaseRecord, Producer, ThreadedProducer},
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
@@ -78,29 +77,6 @@ impl KafkaJsonPublisherStats {
             send_retries,
             error_decode,
             error_send,
-        }
-    }
-}
-
-// --- producer ---
-
-/// Producer context with tracing logs enabled
-#[derive(Clone)]
-struct LoggingProducerContext;
-
-impl ClientContext for LoggingProducerContext {}
-
-impl ProducerContext<NoCustomPartitioner> for LoggingProducerContext {
-    type DeliveryOpaque = ();
-
-    fn delivery(&self, delivery_result: &DeliveryResult<'_>, _: Self::DeliveryOpaque) {
-        match delivery_result {
-            Ok(_) => {
-                debug!("Message delivered successfully to kafka");
-            }
-            Err((err, _)) => {
-                warn!("Failed to deliver message to kafka: {err}");
-            }
         }
     }
 }


### PR DESCRIPTION
- Make KafkaJsonPublisher generic to accept any message along with a conversion function
- Refactor LoggingProducerContext to a common location
- Support opentelemetry stats at LoggingProducerContext
- Publish raw Flow packets to Kafka in JSON format