### PR TITLE
bmp-path-marking

### DIFF
--- a/crates/bmp-pkt/src/v4.rs
+++ b/crates/bmp-pkt/src/v4.rs
@@ -187,8 +187,29 @@ pub enum RouteMonitoringTlvValue {
 pub struct PathMarking {
     /// Represented as u32 instead of [PathStatus] since it is a bitflag
     /// [PathStatus] is just a collection of all possible flags in this bitflag
-    pub path_status: u32,
-    pub reason_code: Option<PathMarkingReason>,
+    path_status: u32,
+    /// Represented as u16 instead of [PathMarkingReason] to accept
+    /// non-IANA-defined reason codes Well-known reason codes are defined in
+    /// [PathMarkingReason] Reason codes are used (Some(_)) with
+    /// [PathStatus::Invalid] and [PathStatus::NonSelected]
+    reason_code: Option<u16>,
+}
+
+impl PathMarking {
+    pub const fn new(path_status: u32, reason_code: Option<PathStatus>) -> PathMarking {
+        Self {
+            path_status,
+            reason_code: reason_code.map(Into::into),
+        }
+    }
+
+    pub const fn path_status(&self) -> u32 {
+        self.path_status
+    }
+
+    pub const fn reason_code(&self) -> Option<u16> {
+        self.reason_code
+    }
 }
 
 // TODO assign real codes and move to IANA when draft becomes RFC

--- a/crates/bmp-pkt/src/v4.rs
+++ b/crates/bmp-pkt/src/v4.rs
@@ -169,7 +169,7 @@ pub enum RouteMonitoringTlvValue {
     Unknown { code: u16, value: Vec<u8> },
 }
 
-/// Path Status TLV
+/// Path Status TLV [draft-ietf-grow-bmp-path-marking-tlv](https://datatracker.ietf.org/doc/html/draft-ietf-grow-bmp-path-marking-tlv)
 /// ```text
 /// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 /// +-------------------------------+-------------------------------+
@@ -216,6 +216,7 @@ impl PathMarking {
 }
 
 // TODO assign real codes and move to IANA when draft becomes RFC
+//  (https://datatracker.ietf.org/doc/html/draft-ietf-grow-bmp-path-marking-tlv)
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, FromRepr, Display)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]

--- a/crates/bmp-pkt/src/wire/deserializer/v4.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/v4.rs
@@ -32,6 +32,7 @@ use netgauze_bgp_pkt::{
     BgpMessage,
 };
 
+use crate::v4::PathMarkingReason;
 use netgauze_parse_utils::{
     parse_into_located, parse_into_located_one_input, parse_till_empty_into_located,
     ErrorKindSerdeDeref, ReadablePdu, ReadablePduWithOneInput, Span,
@@ -399,6 +400,9 @@ impl<'a> ReadablePdu<'a, LocatedPathMarkingParsingError<'a>> for PathMarking {
             }
         };
 
-        Ok((data, PathMarking::new(path_status, reason_code)))
+        Ok((
+            data,
+            PathMarking::new(path_status, reason_code.map(PathMarkingReason::from_code)),
+        ))
     }
 }

--- a/crates/bmp-pkt/src/wire/serializer/v4.rs
+++ b/crates/bmp-pkt/src/wire/serializer/v4.rs
@@ -226,7 +226,7 @@ impl WritablePdu<RouteMonitoringTlvValueWritingError> for RouteMonitoringTlvValu
             RouteMonitoringTlvValue::StatelessParsing(capability) => capability.len(),
             RouteMonitoringTlvValue::Unknown { value, .. } => value.len(),
             RouteMonitoringTlvValue::PathMarking(path_marking) => {
-                4 + path_marking.reason_code.map(|_| 2).unwrap_or(0)
+                4 + path_marking.reason_code().map(|_| 2).unwrap_or(0)
             }
         }
     }
@@ -246,9 +246,9 @@ impl WritablePdu<RouteMonitoringTlvValueWritingError> for RouteMonitoringTlvValu
             RouteMonitoringTlvValue::StatelessParsing(capability) => capability.write(writer)?,
             RouteMonitoringTlvValue::Unknown { value, .. } => writer.write_all(value)?,
             RouteMonitoringTlvValue::PathMarking(path_marking) => {
-                writer.write_u32::<NetworkEndian>(path_marking.path_status)?;
-                if let Some(reason_code) = path_marking.reason_code {
-                    writer.write_u16::<NetworkEndian>(reason_code as u16)?
+                writer.write_u32::<NetworkEndian>(path_marking.path_status())?;
+                if let Some(reason_code) = path_marking.reason_code() {
+                    writer.write_u16::<NetworkEndian>(reason_code)?
                 }
             }
         }

--- a/crates/bmp-pkt/src/wire/serializer/v4.rs
+++ b/crates/bmp-pkt/src/wire/serializer/v4.rs
@@ -225,6 +225,9 @@ impl WritablePdu<RouteMonitoringTlvValueWritingError> for RouteMonitoringTlvValu
             /* afi + safi + bool */
             RouteMonitoringTlvValue::StatelessParsing(capability) => capability.len(),
             RouteMonitoringTlvValue::Unknown { value, .. } => value.len(),
+            RouteMonitoringTlvValue::PathMarking(path_marking) => {
+                4 + path_marking.reason_code.map(|_| 2).unwrap_or(0)
+            }
         }
     }
 
@@ -242,6 +245,12 @@ impl WritablePdu<RouteMonitoringTlvValueWritingError> for RouteMonitoringTlvValu
             }
             RouteMonitoringTlvValue::StatelessParsing(capability) => capability.write(writer)?,
             RouteMonitoringTlvValue::Unknown { value, .. } => writer.write_all(value)?,
+            RouteMonitoringTlvValue::PathMarking(path_marking) => {
+                writer.write_u32::<NetworkEndian>(path_marking.path_status)?;
+                if let Some(reason_code) = path_marking.reason_code {
+                    writer.write_u16::<NetworkEndian>(reason_code as u16)?
+                }
+            }
         }
 
         Ok(())

--- a/crates/bmp-pkt/src/wire/tests/v4.rs
+++ b/crates/bmp-pkt/src/wire/tests/v4.rs
@@ -562,10 +562,10 @@ fn test_bmp_v4_path_marking() -> Result<(), BmpMessageWritingError> {
                 .unwrap(),
                 RouteMonitoringTlv::build(
                     0,
-                    RouteMonitoringTlvValue::PathMarking(PathMarking {
-                        path_status: PathStatus::Primary | PathStatus::Best,
-                        reason_code: None,
-                    }),
+                    RouteMonitoringTlvValue::PathMarking(PathMarking::new(
+                        PathStatus::Primary | PathStatus::Best,
+                        None,
+                    )),
                 )
                 .unwrap(),
             ],
@@ -689,10 +689,10 @@ fn test_bmp_v4_path_marking_invalid_with_reason() -> Result<(), BmpMessageWritin
                 .unwrap(),
                 RouteMonitoringTlv::build(
                     0,
-                    RouteMonitoringTlvValue::PathMarking(PathMarking {
-                        path_status: 0 | PathStatus::Invalid,
-                        reason_code: Some(PathMarkingReason::InvalidAsLoop),
-                    }),
+                    RouteMonitoringTlvValue::PathMarking(PathMarking::new(
+                        0 | PathStatus::Invalid,
+                        Some(PathMarkingReason::InvalidAsLoop as u16),
+                    )),
                 )
                 .unwrap(),
             ],

--- a/crates/bmp-pkt/src/wire/tests/v4.rs
+++ b/crates/bmp-pkt/src/wire/tests/v4.rs
@@ -691,7 +691,7 @@ fn test_bmp_v4_path_marking_invalid_with_reason() -> Result<(), BmpMessageWritin
                     0,
                     RouteMonitoringTlvValue::PathMarking(PathMarking::new(
                         0 | PathStatus::Invalid,
-                        Some(PathMarkingReason::InvalidAsLoop as u16),
+                        Some(WellKnownPathMarkingReasonCode::InvalidAsLoop.into()),
                     )),
                 )
                 .unwrap(),


### PR DESCRIPTION
implementation of https://datatracker.ietf.org/doc/draft-ietf-grow-bmp-path-marking-tlv/02/

based on #136
this PR will be reduced to a single commit when #136 is merged.
