### PR TITLE
Integrate shadow-rs and sysinfo crates for easy retrieval of build-time and system information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,5 @@ ciborium = { version = "0.2" }
 ordered-float = { version = "5.0", default-features = false }
 proc-macro2 = { version = "1.0" }
 prettyplease = { version = "0.2" }
+sysinfo = { version = "0.35" }
+shadow-rs = { version = "1.1", default-features = false }

--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -12,6 +12,7 @@ Network metrics collector
 """
 keywords = ["ipfix", "netflow", "parser", "protocol"]
 categories = ["network-programming", "parsing"]
+build = "build.rs"
 
 [dependencies]
 netgauze-analytics = { workspace = true }
@@ -69,12 +70,16 @@ serde_yaml = { workspace = true }
 ordered-float = { workspace = true }
 ciborium = { workspace = true }
 bytes = { workspace = true }
-
+sysinfo = { workspace = true }
+shadow-rs = { workspace = true, features = ["default", "metadata", "build"]  }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = [
     "unprefixed_malloc_on_supported_platforms",
 ] }
+
+[build-dependencies]
+shadow-rs = { workspace = true, default-features = true }
 
 [dev-dependencies]
 chrono = { workspace = true, default-features = false, features = [

--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -68,6 +68,7 @@ pin-utils = { workspace = true }
 serde_yaml = { workspace = true }
 ordered-float = { workspace = true }
 ciborium = { workspace = true }
+bytes = { workspace = true }
 
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/collector/build.rs
+++ b/crates/collector/build.rs
@@ -1,0 +1,8 @@
+use shadow_rs::ShadowBuilder;
+
+fn main() {
+    ShadowBuilder::builder()
+        .deny_const(Default::default())
+        .build()
+        .unwrap();
+}

--- a/crates/collector/config_udpnotif_telemetry.yaml
+++ b/crates/collector/config_udpnotif_telemetry.yaml
@@ -1,0 +1,29 @@
+runtime:
+  threads: 4
+
+logging:
+  level: info
+
+telemetry:
+  url: http://localhost:4317/v1/metrics
+  exporter_timeout: 3000
+  reader_interval: 60000
+  reader_timeout: 3000
+
+udp_notif:
+  subscriber_timeout: 100
+  listeners:
+    - address: 0.0.0.0:10000
+      workers: 2
+
+  publishers:
+    group1:
+      buffer_size: 1000
+      endpoints:
+        full: !TelemetryKafkaJson
+          topic: telemetry-message-json
+          producer_config:
+            bootstrap.servers: localhost:49092
+            message.timeout.ms: "60000"
+            queue.buffering.max.messages: "1000"
+          writer_id: test-udpnotif-telemetry # TOOD: not considered yet, discuss...

--- a/crates/collector/src/config.rs
+++ b/crates/collector/src/config.rs
@@ -210,4 +210,5 @@ pub enum PublisherEndpoint {
     Http(HttpPublisherEndpoint),
     KafkaJson(kafka_json::KafkaConfig),
     FlowKafkaAvro(kafka_avro::KafkaConfig<FlowOutputConfig>),
+    TelemetryKafkaJson(kafka_json::KafkaConfig),
 }

--- a/crates/collector/src/yang_push/enrichment.rs
+++ b/crates/collector/src/yang_push/enrichment.rs
@@ -1,0 +1,780 @@
+// Copyright (C) 2025-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A module for processing Yang Push notifications messages.
+//!
+//! This module provides functionality to:
+//! - Cache and manage subscription metadata from Yang-Push Subscription
+//!   Started/Modified/Terminated notifications
+//! - Enrich Yang-Push notifications with metadata from cached subscriptions
+//! - Encapsulate Yang-Push notifications into Telemetry Message objects along
+//!   with the relevant metadata
+//!
+//! The main components are:
+//! - `YangPushEnrichmentActor` - The core actor responsible for processing and
+//!   enriching Yang Push notifications.
+//! - `YangPushEnrichmentActorHandle` - A handle for controlling the enrichment
+//!   actor and subscribing to enriched messages.
+//! - `YangPushEnrichmentStats` - Metrics for tracking the performance and
+//!   behavior of the enrichment process.
+use crate::yang_push::telemetry::{
+    DataCollectionMetadata, FilterSpec, Label, LabelValue, Manifest, SessionProtocol,
+    TelemetryMessage, TelemetryMessageMetadata, TelemetryMessageWrapper,
+    YangPushSubscriptionMetadata,
+};
+use netgauze_udp_notif_pkt::{
+    yang::notification::{
+        NotificationVariant, SubscriptionId, SubscriptionStartedModified, SubscriptionTerminated,
+    },
+    UdpNotifPacket, UdpNotifPacketDecoded, UdpNotifPayload,
+};
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
+
+use chrono::Utc;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tracing::{debug, error, info, warn};
+
+/// Cache for YangPush subscriptions metadata
+pub type SubscriptionsCache = HashMap<SubscriptionId, TelemetryMessageMetadata>;
+
+#[derive(Debug, Clone, Copy)]
+pub enum YangPushEnrichmentActorCommand {
+    Shutdown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum YangPushEnrichmentActorError {
+    EnrichmentChannelClosed,
+    YangPushReceiveError,
+    NotificationWithoutContent,
+    PayloadSerializationError,
+}
+
+impl std::fmt::Display for YangPushEnrichmentActorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EnrichmentChannelClosed => write!(f, "enrichment channel closed"),
+            Self::YangPushReceiveError => write!(f, "error in flow receive channel"),
+            Self::NotificationWithoutContent => {
+                write!(f, "Received Yang Push Notification without content")
+            }
+            Self::PayloadSerializationError => {
+                write!(f, "failed to serialize UDP-Notif Payload")
+            }
+        }
+    }
+}
+
+impl std::error::Error for YangPushEnrichmentActorError {}
+
+#[derive(Debug, Clone)]
+pub struct YangPushEnrichmentStats {
+    pub received_messages: opentelemetry::metrics::Counter<u64>,
+    pub sent_messages: opentelemetry::metrics::Counter<u64>,
+    pub send_error: opentelemetry::metrics::Counter<u64>,
+    pub udpnotif_payload_decoding_error: opentelemetry::metrics::Counter<u64>,
+    pub udpnotif_payload_processing_error: opentelemetry::metrics::Counter<u64>,
+    pub peer_subscriptions: opentelemetry::metrics::Gauge<u64>,
+    pub subscription_cache_miss: opentelemetry::metrics::Counter<u64>,
+}
+
+impl YangPushEnrichmentStats {
+    pub fn new(meter: opentelemetry::metrics::Meter) -> Self {
+        let received_messages = meter
+            .u64_counter("netgauze.collector.yang_push.enrichment.received.messages")
+            .with_description("Number of Yang-Push messages received for enrichment")
+            .build();
+        let sent_messages = meter
+            .u64_counter("netgauze.collector.yang_push.enrichment.sent.messages")
+            .with_description("Number of Telemetry Messages successfully sent upstream")
+            .build();
+        let send_error = meter
+            .u64_counter("netgauze.collector.yang_push.enrichment.send.error")
+            .with_description("Number of upstream sending errors")
+            .build();
+        let udpnotif_payload_decoding_error = meter
+            .u64_counter("netgauze.collector.yang_push.enrichment.payload.decoding.error")
+            .with_description("Number of errors decoding UDP-Notif payloads")
+            .build();
+        let udpnotif_payload_processing_error = meter
+            .u64_counter("netgauze.collector.yang_push.enrichment.notification.processing.error")
+            .with_description("Number of errors processing Yang Push notifications")
+            .build();
+        let peer_subscriptions = meter
+            .u64_gauge("netgauze.collector.yang_push.enrichment.peer.subscriptions")
+            .with_description("Number of active subscriptions per peer")
+            .build();
+        let subscription_cache_miss = meter
+            .u64_counter("netgauze.collector.yang_push.enrichment.subscription.cache.miss")
+            .with_description("Number of subscription cache misses")
+            .build();
+        Self {
+            received_messages,
+            sent_messages,
+            send_error,
+            udpnotif_payload_decoding_error,
+            udpnotif_payload_processing_error,
+            peer_subscriptions,
+            subscription_cache_miss,
+        }
+    }
+
+    /// Updates the gauge tracking the number of subscriptions per peer.
+    pub fn update_peer_subscriptions_gauge(&self, peer: &SocketAddr, subscription_count: usize) {
+        let peer_tags = [
+            opentelemetry::KeyValue::new("network.peer.address", format!("{}", peer.ip())),
+            opentelemetry::KeyValue::new(
+                "network.peer.port",
+                opentelemetry::Value::I64(peer.port().into()),
+            ),
+        ];
+        self.peer_subscriptions
+            .record(subscription_count as u64, &peer_tags);
+    }
+}
+
+/// Actor responsible for enriching Yang Push notifications.
+/// Sends enriched TelemetryMessage objects.
+struct YangPushEnrichmentActor {
+    cmd_rx: mpsc::Receiver<YangPushEnrichmentActorCommand>,
+    udp_notif_rx: async_channel::Receiver<Arc<(SocketAddr, UdpNotifPacket)>>,
+    enriched_tx: async_channel::Sender<TelemetryMessageWrapper>,
+    labels: HashMap<IpAddr, (u32, HashMap<String, String>)>,
+    default_labels: (u32, HashMap<String, String>),
+    subscriptions: HashMap<SocketAddr, SubscriptionsCache>,
+    manifest: Manifest,
+    stats: YangPushEnrichmentStats,
+}
+
+impl YangPushEnrichmentActor {
+    fn new(
+        cmd_rx: mpsc::Receiver<YangPushEnrichmentActorCommand>,
+        udp_notif_rx: async_channel::Receiver<Arc<(SocketAddr, UdpNotifPacket)>>,
+        enriched_tx: async_channel::Sender<TelemetryMessageWrapper>,
+        stats: YangPushEnrichmentStats,
+    ) -> Self {
+        let default_labels = (
+            0,
+            HashMap::from([
+                ("pkey".to_string(), "unknown".to_string()),
+                ("nkey".to_string(), "unknown".to_string()),
+            ]),
+        );
+        Self {
+            cmd_rx,
+            udp_notif_rx,
+            enriched_tx,
+            labels: HashMap::new(),
+            default_labels,
+            subscriptions: HashMap::new(),
+            manifest: Manifest::default(),
+            stats,
+        }
+    }
+
+    /// Caches metadata from SubscriptionStarted and SubscriptionModified
+    /// messages.
+    fn cache_subscription(
+        &mut self,
+        peer: SocketAddr,
+        sub: &SubscriptionStartedModified,
+    ) -> Result<TelemetryMessageMetadata, YangPushEnrichmentActorError> {
+        let stream = sub.target().stream().map(|f| f.to_string());
+
+        let datastore = sub.target().datastore().map(|f| f.to_string());
+
+        let xpath_filter: Option<String> = sub
+            .target()
+            .datastore_xpath_filter()
+            .map(|f| f.to_string())
+            .or_else(|| sub.target().stream_xpath_filter().map(|f| f.to_string()));
+
+        let subtree_filter: Option<Value> = sub
+            .target()
+            .datastore_subtree_filter()
+            .cloned()
+            .or_else(|| sub.target().stream_subtree_filter().cloned());
+
+        let filter_spec = FilterSpec::new(stream, datastore, xpath_filter, subtree_filter);
+
+        let subscription_metadata = YangPushSubscriptionMetadata::new(
+            Some(sub.id()),
+            filter_spec,
+            sub.stop_time().cloned(),
+            sub.transport().cloned(),
+            sub.encoding().cloned(),
+            sub.purpose().map(|id| id.to_string()),
+            sub.update_trigger().clone().into(),
+            sub.module_version().cloned().unwrap_or_default(),
+            sub.yang_library_content_id().map(|id| id.to_string()),
+        );
+
+        let telemetry_message_metadata =
+            TelemetryMessageMetadata::new(None, Some(subscription_metadata));
+
+        // Insert the subscription metadata into the cache
+        let peer_subscriptions = self.subscriptions.entry(peer).or_default();
+        peer_subscriptions.insert(sub.id(), telemetry_message_metadata.clone());
+
+        // Update the gauge tracking per-peer subscriptions
+        self.stats
+            .update_peer_subscriptions_gauge(&peer, peer_subscriptions.len());
+
+        debug!(
+            "Yang Push Subscription Cache: {}",
+            serde_json::to_string(&self.subscriptions).unwrap()
+        );
+
+        Ok(telemetry_message_metadata)
+    }
+
+    /// Handles SubscriptionTerminated messages by removing subscription
+    /// metadata from the cache.
+    fn delete_subscription(
+        &mut self,
+        peer: SocketAddr,
+        sub: &SubscriptionTerminated,
+    ) -> Result<TelemetryMessageMetadata, YangPushEnrichmentActorError> {
+        // Get and delete subscription information from the cache
+        let telemetry_message_metadata = self
+            .subscriptions
+            .get_mut(&peer)
+            .and_then(|subscriptions| subscriptions.remove(&sub.id()))
+            .unwrap_or_default();
+
+        // Update the gauge tracking per-peer subscriptions
+        if let Some(subscriptions) = self.subscriptions.get(&peer) {
+            self.stats
+                .update_peer_subscriptions_gauge(&peer, subscriptions.len());
+        } else {
+            self.stats.update_peer_subscriptions_gauge(&peer, 0);
+        }
+
+        debug!(
+            "Yang Push Subscription Cache: {}",
+            serde_json::to_string(&self.subscriptions).unwrap()
+        );
+
+        Ok(telemetry_message_metadata)
+    }
+
+    /// Retrieves subscription metadata from the cache based on the peer address
+    /// and subscription ID.
+    fn get_subscription(
+        &self,
+        peer: SocketAddr,
+        subscription_id: &SubscriptionId,
+    ) -> Result<TelemetryMessageMetadata, YangPushEnrichmentActorError> {
+        // Get subscription information from the cache
+        let telemetry_message_metadata = self
+            .subscriptions
+            .get(&peer)
+            .and_then(|subscriptions| subscriptions.get(subscription_id))
+            .cloned()
+            .unwrap_or_else(|| {
+                let peer_tags = [
+                    opentelemetry::KeyValue::new("network.peer.address", format!("{}", peer.ip())),
+                    opentelemetry::KeyValue::new(
+                        "network.peer.port",
+                        opentelemetry::Value::I64(peer.port().into()),
+                    ),
+                ];
+                self.stats.subscription_cache_miss.add(1, &peer_tags);
+
+                TelemetryMessageMetadata::default()
+            });
+
+        Ok(telemetry_message_metadata)
+    }
+
+    /// Processes Notification and returns the relevant TelemetryMessageMetadata
+    fn process_notification(
+        &mut self,
+        peer: SocketAddr,
+        notification: Option<&NotificationVariant>,
+    ) -> Result<TelemetryMessageMetadata, YangPushEnrichmentActorError> {
+        match notification {
+            Some(NotificationVariant::SubscriptionStarted(sub_started)) => {
+                debug!(
+                    "Received Subscription Started Message (peer: {}, id={})",
+                    peer,
+                    sub_started.id()
+                );
+                self.cache_subscription(peer, sub_started)
+            }
+            Some(NotificationVariant::SubscriptionModified(sub_modified)) => {
+                debug!(
+                    "Received Subscription Modified Message (peer: {}, id={})",
+                    peer,
+                    sub_modified.id()
+                );
+                self.cache_subscription(peer, sub_modified)
+            }
+            Some(NotificationVariant::SubscriptionTerminated(sub_terminated)) => {
+                debug!(
+                    "Received Subscription Terminated Message (peer: {}, id={})",
+                    peer,
+                    sub_terminated.id()
+                );
+                self.delete_subscription(peer, sub_terminated)
+            }
+            Some(NotificationVariant::YangPushUpdate(push_update)) => {
+                debug!(
+                    "Received Yang Push Update Message (peer: {}, id={})",
+                    peer,
+                    push_update.id()
+                );
+                self.get_subscription(peer, &push_update.id())
+            }
+            Some(NotificationVariant::YangPushChangeUpdate(push_change_update)) => {
+                debug!(
+                    "Received Yang Push Change Update Message (peer: {}, id={})",
+                    peer,
+                    push_change_update.id()
+                );
+                self.get_subscription(peer, &push_change_update.id())
+            }
+            None => {
+                warn!(
+                    "Received Notification Message (peer: {}) without content",
+                    peer
+                );
+                Err(YangPushEnrichmentActorError::NotificationWithoutContent)
+            }
+        }
+    }
+
+    /// Processes UDP-Notif Payload and produces a TelemetryMessage object.
+    fn process_payload(
+        &mut self,
+        peer: SocketAddr,
+        payload: &UdpNotifPayload,
+    ) -> Result<TelemetryMessageWrapper, YangPushEnrichmentActorError> {
+        let timestamp = Utc::now();
+
+        // Get sonata labels from the cache
+        let (_, labels) = self.labels.get(&peer.ip()).unwrap_or(&self.default_labels);
+        let labels: Vec<Label> = labels
+            .iter()
+            .map(|(key, value)| {
+                Label::new(
+                    key.clone(),
+                    Some(LabelValue::StringValue {
+                        string_value: value.clone(),
+                    }),
+                )
+            })
+            .collect();
+
+        // Match on the wrapper and process the notification content
+        let telemetry_message_metadata = match payload {
+            UdpNotifPayload::NotificationLegacy(legacy) => {
+                self.process_notification(peer, legacy.notification())?
+            }
+            UdpNotifPayload::NotificationEnvelope(envelope) => {
+                self.process_notification(peer, envelope.contents())?
+            }
+        };
+
+        // Re-serialize the UDP-Notif payload into JSON
+        let json_payload = serde_json::to_value(payload).map_err(|err| {
+            error!("Failed to re-serialize UDP-Notif Payload (should never happen): {err}");
+            YangPushEnrichmentActorError::PayloadSerializationError
+        })?;
+
+        // Populate metadata and payload in a new TelemetryMessage
+        Ok(TelemetryMessageWrapper::new(TelemetryMessage::new(
+            timestamp,
+            SessionProtocol::YangPush, // only option at the moment
+            Manifest::default(),
+            self.manifest.clone(),
+            telemetry_message_metadata,
+            DataCollectionMetadata::new(peer.ip(), Some(peer.port()), None, None, labels),
+            Some(json_payload),
+        )))
+    }
+
+    /// Main loop for the actor: handling commands and incoming notification
+    /// messages.
+    async fn run(mut self) -> anyhow::Result<String> {
+        loop {
+            tokio::select! {
+                biased;
+                cmd = self.cmd_rx.recv() => {
+                    return match cmd {
+                        Some(YangPushEnrichmentActorCommand::Shutdown) => {
+                            info!("Shutting down Yang Push enrichment actor");
+                            Ok("Enrichment shutdown successfully".to_string())
+                        }
+                        None => {
+                            warn!("Yang Push enrichment actor terminated due to command channel closing");
+                            Ok("Enrichment shutdown successfully".to_string())
+                        }
+                    }
+                }
+                msg = self.udp_notif_rx.recv() => {
+                    match msg {
+                        Ok(arc_tuple) => {
+                            let (peer, pkt) = arc_tuple.as_ref();
+                            let peer_tags = [
+                                opentelemetry::KeyValue::new(
+                                    "network.peer.address",
+                                    format!("{}", peer.ip()),
+                                ),
+                                opentelemetry::KeyValue::new(
+                                    "network.peer.port",
+                                    opentelemetry::Value::I64(peer.port().into()),
+                                ),
+                            ];
+                            self.stats.received_messages.add(1, &peer_tags);
+
+                            // Decode the UdpNotifPacket into UdpNotifPacketDecoded
+                            let pkt_decoded: UdpNotifPacketDecoded = match pkt.try_into() {
+                              Ok(decoded) => decoded,
+                              Err(err) => {
+                                  warn!("Failed to decode Udp-Notif Payload: {err}");
+                                  self.stats.udpnotif_payload_decoding_error.add(1, &peer_tags);
+                                  continue;
+                              }
+                            };
+
+                            // Process the payload and send the enriched TelemetryMessage
+                            match self.process_payload(*peer, pkt_decoded.payload()) {
+                                Ok(telemetry_message) => {
+                                    if let Err(err) = self.enriched_tx.send(telemetry_message).await {
+                                        error!("YangPushEnrichmentActor send error: {err}");
+                                        self.stats.send_error.add(1, &peer_tags);
+                                    } else {
+                                        self.stats.sent_messages.add(1, &peer_tags);
+                                    }
+                                }
+                                Err(err) => {
+                                    warn!("Error processing payload: {err}");
+                                    self.stats.udpnotif_payload_processing_error.add(1, &peer_tags);
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            error!("Shutting down due to FlowEnrichment recv error: {err}");
+                            Err(YangPushEnrichmentActorError::YangPushReceiveError)?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum YangPushEnrichmentActorHandleError {
+    SendError,
+}
+impl std::fmt::Display for YangPushEnrichmentActorHandleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            YangPushEnrichmentActorHandleError::SendError => {
+                write!(f, "Failed to send yang-push enrichment actor")
+            }
+        }
+    }
+}
+
+impl std::error::Error for YangPushEnrichmentActorHandleError {}
+
+/// Handle for interacting with the `YangPushEnrichmentActor`.
+#[derive(Debug, Clone)]
+pub struct YangPushEnrichmentActorHandle {
+    cmd_send: mpsc::Sender<YangPushEnrichmentActorCommand>,
+    enriched_rx: async_channel::Receiver<TelemetryMessageWrapper>,
+}
+
+impl YangPushEnrichmentActorHandle {
+    pub fn new(
+        buffer_size: usize,
+        udp_notif_rx: async_channel::Receiver<Arc<(SocketAddr, UdpNotifPacket)>>,
+        stats: either::Either<opentelemetry::metrics::Meter, YangPushEnrichmentStats>,
+    ) -> (JoinHandle<anyhow::Result<String>>, Self) {
+        let (cmd_send, cmd_recv) = mpsc::channel(10);
+        let (enriched_tx, enriched_rx) = async_channel::bounded(buffer_size);
+        let stats = match stats {
+            either::Either::Left(meter) => YangPushEnrichmentStats::new(meter),
+            either::Either::Right(stats) => stats,
+        };
+        let actor = YangPushEnrichmentActor::new(cmd_recv, udp_notif_rx, enriched_tx, stats);
+        let join_handle = tokio::spawn(actor.run());
+        let handle = Self {
+            cmd_send,
+            enriched_rx,
+        };
+        (join_handle, handle)
+    }
+
+    pub async fn shutdown(&self) -> Result<(), YangPushEnrichmentActorHandleError> {
+        self.cmd_send
+            .send(YangPushEnrichmentActorCommand::Shutdown)
+            .await
+            .map_err(|_| YangPushEnrichmentActorHandleError::SendError)
+    }
+
+    pub fn subscribe(&self) -> async_channel::Receiver<TelemetryMessageWrapper> {
+        self.enriched_rx.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MediaType;
+    use bytes::Bytes;
+    use netgauze_udp_notif_pkt::yang::notification::{
+        CentiSeconds, Encoding, Target, Transport, UpdateTrigger,
+    };
+    use serde_json::json;
+    use std::{collections::HashMap, net::SocketAddr};
+
+    fn create_subscription_started_modified(
+        id: SubscriptionId,
+        purpose: String,
+    ) -> SubscriptionStartedModified {
+        SubscriptionStartedModified::new(
+            id,
+            Target::new(
+                None,
+                None,
+                None,
+                None,
+                Some("example-datastore-name".to_string()),
+                None,
+                Some("/example/datastore/xpath".to_string()),
+            ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some(purpose),
+            UpdateTrigger::Periodic {
+                period: Some(CentiSeconds::new(100)),
+                anchor_time: None,
+            },
+            None,
+            None,
+            json!({}),
+        )
+    }
+
+    fn create_subscription_terminated(id: SubscriptionId) -> SubscriptionTerminated {
+        SubscriptionTerminated::new(id, "some-termination-reason".to_string(), json!({}))
+    }
+
+    fn create_actor() -> YangPushEnrichmentActor {
+        YangPushEnrichmentActor {
+            cmd_rx: mpsc::channel(10).1,
+            udp_notif_rx: async_channel::bounded(10).1,
+            enriched_tx: async_channel::bounded(10).0,
+            labels: HashMap::new(),
+            default_labels: (0, HashMap::new()),
+            subscriptions: HashMap::new(),
+            manifest: Manifest::default(),
+            stats: YangPushEnrichmentStats::new(opentelemetry::global::meter("my-meter")),
+        }
+    }
+
+    #[test]
+    fn test_cache_and_get_subscription() {
+        let mut actor = create_actor();
+        let peer: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+
+        // Create a SubscriptionStartedModified message and cache it
+        let subscription_started =
+            create_subscription_started_modified(1, "example-purpose".to_string());
+        let result = actor.cache_subscription(peer, &subscription_started);
+        assert!(result.is_ok());
+
+        // Check get_subscription method
+        let get_result = actor.get_subscription(peer, &1);
+        assert!(get_result.is_ok());
+        assert_eq!(result.clone().unwrap(), get_result.unwrap());
+
+        // Check if the subscription is cached correctly
+        let peer_subscription = result.unwrap();
+        assert_eq!(
+            peer_subscription.yang_push_subscription().unwrap().id(),
+            Some(1)
+        );
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .filter_spec()
+                .datastore(),
+            Some("example-datastore-name")
+        );
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .filter_spec()
+                .xpath_filter(),
+            Some("/example/datastore/xpath")
+        );
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .transport()
+                .cloned(),
+            Some(Transport::UDPNotif)
+        );
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .encoding()
+                .cloned(),
+            Some(Encoding::Json)
+        );
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .purpose(),
+            Some("example-purpose")
+        );
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .update_trigger()
+                .clone(),
+            UpdateTrigger::Periodic {
+                period: Some(CentiSeconds::new(100)),
+                anchor_time: None
+            }
+            .into()
+        );
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .module_version(),
+            Vec::new() // default
+        );
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .yang_library_content_id(),
+            None
+        );
+
+        // Modify the subscription and check if it updates the cache
+        let subscription_modified =
+            create_subscription_started_modified(1, "updated-purpose".to_string());
+        let peer_subscription = actor
+            .cache_subscription(peer, &subscription_modified)
+            .unwrap();
+        assert_eq!(
+            peer_subscription
+                .yang_push_subscription()
+                .unwrap()
+                .purpose(),
+            Some("updated-purpose")
+        );
+    }
+
+    #[test]
+    fn test_delete_subscription() {
+        let mut actor = create_actor();
+        let peer: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+
+        // Create a SubscriptionStartedModified message and cache it
+        let subscription_started = create_subscription_started_modified(1, "".to_string());
+        actor
+            .cache_subscription(peer, &subscription_started)
+            .unwrap();
+
+        // Ensure the subscription is cached before deletion
+        let peer_subscriptions = actor.subscriptions.get(&peer);
+        assert!(peer_subscriptions.is_some() && peer_subscriptions.unwrap().contains_key(&1));
+
+        let terminated = create_subscription_terminated(1);
+        let result = actor.delete_subscription(peer, &terminated);
+        assert!(result.is_ok());
+
+        let peer_subscriptions = actor.subscriptions.get(&peer);
+        assert!(peer_subscriptions.is_none() || !peer_subscriptions.unwrap().contains_key(&1));
+    }
+
+    #[test]
+    fn test_get_subscription_cache_miss() {
+        let mut actor = create_actor();
+        let peer: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+        let subscription_id_1 = create_subscription_started_modified(1, "".to_string());
+        let subscription_id_23 = create_subscription_started_modified(23, "".to_string());
+        actor.cache_subscription(peer, &subscription_id_1).unwrap();
+        actor.cache_subscription(peer, &subscription_id_23).unwrap();
+
+        assert_eq!(actor.subscriptions.len(), 1);
+        assert!(actor.subscriptions.contains_key(&peer));
+        assert!(actor.subscriptions[&peer].contains_key(&1));
+        assert!(actor.subscriptions[&peer].contains_key(&23));
+        assert_eq!(actor.subscriptions[&peer].len(), 2);
+
+        let get_result = actor.get_subscription(peer, &12);
+        assert!(get_result.is_ok());
+
+        let peer_subscription = get_result.unwrap();
+        assert_eq!(peer_subscription, TelemetryMessageMetadata::default());
+    }
+
+    #[test]
+    fn test_process_payload_envelope_without_content() {
+        let mut actor = create_actor();
+        let peer: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+
+        // Create a UdpNotifPayload without content
+        let payload = json!({
+                    "ietf-yp-notification:envelope": {
+                        "event-time": "2025-03-04T07:11:33.252679191+00:00",
+                        "hostname": "some-router",
+                        "sequence-number": 5,
+                      }
+        })
+        .to_string()
+        .into_bytes();
+
+        let packet = UdpNotifPacket::new(
+            MediaType::YangDataJson,
+            1,
+            1,
+            HashMap::new(),
+            Bytes::from(payload),
+        );
+
+        // Attempt to decode the packet (should succeed)
+        let decoded: UdpNotifPacketDecoded = (&packet).try_into().unwrap();
+
+        let result = actor.process_payload(peer, decoded.payload());
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            YangPushEnrichmentActorError::NotificationWithoutContent
+        );
+    }
+}

--- a/crates/collector/src/yang_push/mod.rs
+++ b/crates/collector/src/yang_push/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (C) 2025-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pub mod enrichment;
+pub mod telemetry;

--- a/crates/collector/src/yang_push/telemetry.rs
+++ b/crates/collector/src/yang_push/telemetry.rs
@@ -1,0 +1,568 @@
+// Copyright (C) 2025-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Telemetry Message Module
+//!
+//! This module defines the structure and serialization logic for telemetry
+//! messages as specified in:
+//! - [Telemetry Message](https://datatracker.ietf.org/doc/html/draft-netana-nmop-message-broker-telemetry-message).
+//!
+//! Key components include:
+//! - **TelemetryMessage**: The main structure representing a telemetry message.
+//! - **SessionProtocol**: Enum for supported telemetry session protocols (e.g.,
+//!   YANG Push, NETCONF).
+//! - **Manifest**: Metadata about the network node or data collection system.
+//! - **TelemetryMessageMetadata**: Metadata specific to the telemetry
+//!   notification, with YANG Push subscription details such as filters,
+//!   transport, and encoding.
+//! - **DataCollectionMetadata**: Metadata about the data collection, including
+//!   remote addresses and labels.
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::net::IpAddr;
+
+use netgauze_udp_notif_pkt::yang::notification::{
+    CentiSeconds, ChangeType, Encoding, SubscriptionId, Transport, YangPushModuleVersion,
+};
+
+/// Telemetry Message Wrapper
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct TelemetryMessageWrapper {
+    #[serde(rename = "ietf-telemetry-message:message")]
+    message: TelemetryMessage,
+}
+
+impl TelemetryMessageWrapper {
+    pub fn new(message: TelemetryMessage) -> Self {
+        Self { message }
+    }
+    pub fn message(&self) -> &TelemetryMessage {
+        &self.message
+    }
+}
+
+/// Telemetry Message
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct TelemetryMessage {
+    timestamp: DateTime<Utc>,
+    session_protocol: SessionProtocol,
+    network_node_manifest: Manifest,
+    data_collection_manifest: Manifest,
+    telemetry_message_metadata: TelemetryMessageMetadata,
+    data_collection_metadata: DataCollectionMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    payload: Option<Value>,
+}
+
+impl TelemetryMessage {
+    pub fn new(
+        timestamp: DateTime<Utc>,
+        session_protocol: SessionProtocol,
+        network_node_manifest: Manifest,
+        data_collection_manifest: Manifest,
+        telemetry_message_metadata: TelemetryMessageMetadata,
+        data_collection_metadata: DataCollectionMetadata,
+        payload: Option<Value>,
+    ) -> Self {
+        Self {
+            timestamp,
+            session_protocol,
+            network_node_manifest,
+            data_collection_manifest,
+            telemetry_message_metadata,
+            data_collection_metadata,
+            payload,
+        }
+    }
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+    pub fn session_protocol(&self) -> &SessionProtocol {
+        &self.session_protocol
+    }
+    pub fn network_node_manifest(&self) -> &Manifest {
+        &self.network_node_manifest
+    }
+    pub fn data_collection_manifest(&self) -> &Manifest {
+        &self.data_collection_manifest
+    }
+    pub fn telemetry_message_metadata(&self) -> &TelemetryMessageMetadata {
+        &self.telemetry_message_metadata
+    }
+    pub fn data_collection_metadata(&self) -> &DataCollectionMetadata {
+        &self.data_collection_metadata
+    }
+    pub fn payload(&self) -> Option<&Value> {
+        self.payload.as_ref()
+    }
+}
+
+/// Telemetry Session Protocol Type
+#[derive(Default, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum SessionProtocol {
+    #[serde(rename = "yp-push")]
+    YangPush,
+
+    #[serde(rename = "netconf")]
+    Netconf,
+
+    #[serde(rename = "restconf")]
+    Restconf,
+
+    #[default]
+    #[serde(other)]
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+/// Generic Metadata Manifest
+#[derive(Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct Manifest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vendor: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vendor_pen: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    software_version: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    software_flavor: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    os_version: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    os_type: Option<String>,
+}
+
+impl Manifest {
+    pub fn new(
+        name: Option<String>,
+        vendor: Option<String>,
+        vendor_pen: Option<u32>,
+        software_version: Option<String>,
+        software_flavor: Option<String>,
+        os_version: Option<String>,
+        os_type: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            vendor,
+            vendor_pen,
+            software_version,
+            software_flavor,
+            os_version,
+            os_type,
+        }
+    }
+}
+
+/// Telemetry Notification Metadata
+#[derive(Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct TelemetryMessageMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "event-time")]
+    event_time: Option<DateTime<Utc>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "ietf-yang-push-telemetry-message:yang-push-subscription")]
+    yang_push_subscription: Option<YangPushSubscriptionMetadata>,
+}
+
+impl TelemetryMessageMetadata {
+    pub fn new(
+        event_time: Option<DateTime<Utc>>,
+        yang_push_subscription: Option<YangPushSubscriptionMetadata>,
+    ) -> Self {
+        Self {
+            event_time,
+            yang_push_subscription,
+        }
+    }
+    pub fn event_time(&self) -> Option<DateTime<Utc>> {
+        self.event_time
+    }
+    pub fn yang_push_subscription(&self) -> Option<&YangPushSubscriptionMetadata> {
+        self.yang_push_subscription.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct YangPushSubscriptionMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<SubscriptionId>,
+
+    #[serde(flatten)]
+    filter_spec: FilterSpec,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_time: Option<DateTime<Utc>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transport: Option<Transport>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encoding: Option<Encoding>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    purpose: Option<String>,
+
+    #[serde(flatten)]
+    update_trigger: UpdateTrigger,
+
+    module_version: Vec<YangPushModuleVersion>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    yang_library_content_id: Option<String>,
+}
+
+impl YangPushSubscriptionMetadata {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: Option<SubscriptionId>,
+        filter_spec: FilterSpec,
+        stop_time: Option<DateTime<Utc>>,
+        transport: Option<Transport>,
+        encoding: Option<Encoding>,
+        purpose: Option<String>,
+        update_trigger: UpdateTrigger,
+        module_version: Vec<YangPushModuleVersion>,
+        yang_library_content_id: Option<String>,
+    ) -> Self {
+        Self {
+            id,
+            filter_spec,
+            stop_time,
+            transport,
+            encoding,
+            purpose,
+            update_trigger,
+            module_version,
+            yang_library_content_id,
+        }
+    }
+    pub fn id(&self) -> Option<SubscriptionId> {
+        self.id
+    }
+    pub fn filter_spec(&self) -> &FilterSpec {
+        &self.filter_spec
+    }
+    pub fn stop_time(&self) -> Option<DateTime<Utc>> {
+        self.stop_time
+    }
+    pub fn transport(&self) -> Option<&Transport> {
+        self.transport.as_ref()
+    }
+    pub fn encoding(&self) -> Option<&Encoding> {
+        self.encoding.as_ref()
+    }
+    pub fn purpose(&self) -> Option<&str> {
+        self.purpose.as_deref()
+    }
+    pub fn update_trigger(&self) -> &UpdateTrigger {
+        &self.update_trigger
+    }
+    pub fn module_version(&self) -> &[YangPushModuleVersion] {
+        &self.module_version
+    }
+    pub fn yang_library_content_id(&self) -> Option<&str> {
+        self.yang_library_content_id.as_deref()
+    }
+}
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct FilterSpec {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    datastore: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    xpath_filter: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subtree_filter: Option<Value>,
+}
+
+impl FilterSpec {
+    pub fn new(
+        stream: Option<String>,
+        datastore: Option<String>,
+        xpath_filter: Option<String>,
+        subtree_filter: Option<Value>,
+    ) -> Self {
+        Self {
+            stream,
+            datastore,
+            xpath_filter,
+            subtree_filter,
+        }
+    }
+    pub fn stream(&self) -> Option<&str> {
+        self.stream.as_deref()
+    }
+    pub fn datastore(&self) -> Option<&str> {
+        self.datastore.as_deref()
+    }
+    pub fn xpath_filter(&self) -> Option<&str> {
+        self.xpath_filter.as_deref()
+    }
+    pub fn subtree_filter(&self) -> Option<&Value> {
+        self.subtree_filter.as_ref()
+    }
+}
+
+/// Update Trigger for Yang Push Subscription
+/// (redefined for Telemetry Message)
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum UpdateTrigger {
+    #[serde(rename = "periodic")]
+    #[serde(rename_all = "kebab-case")]
+    Periodic {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        period: Option<CentiSeconds>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        anchor_time: Option<DateTime<Utc>>,
+    },
+
+    #[serde(rename = "on-change")]
+    #[serde(rename_all = "kebab-case")]
+    OnChange {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dampening_period: Option<CentiSeconds>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sync_on_start: Option<bool>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        excluded_change: Option<Vec<ChangeType>>,
+    },
+}
+impl From<netgauze_udp_notif_pkt::yang::notification::UpdateTrigger> for UpdateTrigger {
+    fn from(trigger: netgauze_udp_notif_pkt::yang::notification::UpdateTrigger) -> Self {
+        match trigger {
+            netgauze_udp_notif_pkt::yang::notification::UpdateTrigger::Periodic {
+                period,
+                anchor_time,
+            } => UpdateTrigger::Periodic {
+                period,
+                anchor_time,
+            },
+            netgauze_udp_notif_pkt::yang::notification::UpdateTrigger::OnChange {
+                dampening_period,
+                sync_on_start,
+                excluded_change,
+            } => UpdateTrigger::OnChange {
+                dampening_period,
+                sync_on_start,
+                excluded_change,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct DataCollectionMetadata {
+    remote_address: IpAddr,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_port: Option<u16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_address: Option<IpAddr>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_port: Option<u16>,
+
+    labels: Vec<Label>,
+}
+
+impl DataCollectionMetadata {
+    pub fn new(
+        remote_address: IpAddr,
+        remote_port: Option<u16>,
+        local_address: Option<IpAddr>,
+        local_port: Option<u16>,
+        labels: Vec<Label>,
+    ) -> Self {
+        Self {
+            remote_address,
+            remote_port,
+            local_address,
+            local_port,
+            labels,
+        }
+    }
+    pub fn remote_address(&self) -> IpAddr {
+        self.remote_address
+    }
+    pub fn remote_port(&self) -> Option<u16> {
+        self.remote_port
+    }
+    pub fn local_address(&self) -> Option<IpAddr> {
+        self.local_address
+    }
+    pub fn local_port(&self) -> Option<u16> {
+        self.local_port
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Label {
+    name: String,
+
+    #[serde(flatten)]
+    value: Option<LabelValue>,
+}
+
+impl Label {
+    pub fn new(name: String, value: Option<LabelValue>) -> Self {
+        Self { name, value }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum LabelValue {
+    StringValue {
+        #[serde(rename = "string-value")]
+        string_value: String,
+    },
+    AnydataValue {
+        #[serde(rename = "anydata-values")]
+        anydata_values: Value,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use netgauze_udp_notif_pkt::yang::notification::CentiSeconds;
+    use serde_json;
+    use std::vec;
+
+    #[test]
+    fn test_telemetry_message_serde() {
+        let original_message = TelemetryMessageWrapper {
+            message: TelemetryMessage {
+                timestamp: Utc.timestamp_millis_opt(0).unwrap(),
+                session_protocol: SessionProtocol::YangPush,
+                network_node_manifest: Manifest {
+                    name: Some("node_id".to_string()),
+                    vendor: Some("FRR".to_string()),
+                    vendor_pen: None,
+                    software_version: None,
+                    software_flavor: None,
+                    os_version: None,
+                    os_type: None,
+                },
+                data_collection_manifest: Manifest {
+                    name: Some("dev-collector".to_string()),
+                    vendor: Some("NetGauze".to_string()),
+                    vendor_pen: Some(12345),
+                    software_version: Some("1.0.0".to_string()),
+                    software_flavor: Some("release".to_string()),
+                    os_version: Some("8.10".to_string()),
+                    os_type: Some("Rocky Linux".to_string()),
+                },
+                telemetry_message_metadata: TelemetryMessageMetadata {
+                    event_time: None,
+                    yang_push_subscription: Some(YangPushSubscriptionMetadata {
+                        id: Some(1),
+                        filter_spec: FilterSpec {
+                            stream: Some("example-stream-subtree-filter-map".to_string()),
+                            datastore: None,
+                            xpath_filter: None,
+                            subtree_filter: Some(serde_json::json!({
+                              "example-map": serde_json::json!({
+                                  "e1": "v1",
+                                  "e2": "v2",
+                              }),
+                            })),
+                        },
+                        stop_time: None,
+                        transport: Some(Transport::UDPNotif),
+                        encoding: Some(Encoding::Json),
+                        purpose: None,
+                        update_trigger: UpdateTrigger::Periodic {
+                            period: Some(CentiSeconds::new(100)),
+                            anchor_time: Some(Utc.timestamp_millis_opt(0).unwrap()),
+                        },
+                        module_version: vec![YangPushModuleVersion {
+                            module_name: "example-module".to_string(),
+                            revision: Some("2025-01-01".to_string()),
+                            revision_label: Some("1.0.0".to_string()),
+                        }],
+                        yang_library_content_id: Some("random-content-id".to_string()),
+                    }),
+                },
+                data_collection_metadata: DataCollectionMetadata {
+                    remote_address: "127.0.0.1".parse().unwrap(),
+                    remote_port: Some(8080),
+                    local_address: None,
+                    local_port: None,
+                    labels: vec![
+                        Label {
+                            name: "platform_id".to_string(),
+                            value: Some(LabelValue::StringValue {
+                                string_value: "IETF LAB".to_string(),
+                            }),
+                        },
+                        Label {
+                            name: "test_anykey_label".to_string(),
+                            value: Some(LabelValue::AnydataValue {
+                                anydata_values: serde_json::json!({"key": "value"}),
+                            }),
+                        },
+                    ],
+                },
+                payload: None,
+            },
+        };
+
+        // Serialize the TelemetryMessage to JSON
+        let serialized = serde_json::to_string(&original_message).expect("Failed to serialize");
+
+        // Expected JSON string
+        let expected_json = r#"{"ietf-telemetry-message:message":{"timestamp":"1970-01-01T00:00:00Z","session-protocol":"yp-push","network-node-manifest":{"name":"node_id","vendor":"FRR"},"data-collection-manifest":{"name":"dev-collector","vendor":"NetGauze","vendor-pen":12345,"software-version":"1.0.0","software-flavor":"release","os-version":"8.10","os-type":"Rocky Linux"},"telemetry-message-metadata":{"ietf-yang-push-telemetry-message:yang-push-subscription":{"id":1,"stream":"example-stream-subtree-filter-map","subtree-filter":{"example-map":{"e1":"v1","e2":"v2"}},"transport":"ietf-udp-notif-transport:udp-notif","encoding":"ietf-subscribed-notifications:encode-json","periodic":{"period":100,"anchor-time":"1970-01-01T00:00:00Z"},"module-version":[{"module-name":"example-module","revision":"2025-01-01","revision-label":"1.0.0"}],"yang-library-content-id":"random-content-id"}},"data-collection-metadata":{"remote-address":"127.0.0.1","remote-port":8080,"labels":[{"name":"platform_id","string-value":"IETF LAB"},{"name":"test_anykey_label","anydata-values":{"key":"value"}}]}}}"#;
+
+        // Assert that the serialized JSON string matches the expected JSON string
+        assert_eq!(
+            serialized, expected_json,
+            "Serialized JSON does not match the expected JSON"
+        );
+
+        // Deserialize the JSON string back to a TelemetryMessage
+        let deserialized: TelemetryMessageWrapper =
+            serde_json::from_str(&serialized).expect("Failed to deserialize");
+
+        // Assert that the original and deserialized messages are equal
+        assert_eq!(original_message, deserialized);
+    }
+}

--- a/crates/udp-notif-pkt/Cargo.toml
+++ b/crates/udp-notif-pkt/Cargo.toml
@@ -28,6 +28,9 @@ bytes = { workspace = true, features = ["serde"]}
 tokio-util = { workspace = true, features = ["full", "tracing"] , optional = true}
 arbitrary = { workspace = true, optional = true }
 arbitrary_ext = { workspace = true, optional = true }
+serde_json = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+ciborium = { workspace = true }
 
 [features]
 default = ["serde", "codec"]

--- a/crates/udp-notif-pkt/src/lib.rs
+++ b/crates/udp-notif-pkt/src/lib.rs
@@ -17,15 +17,29 @@
 pub mod codec;
 #[cfg(feature = "serde")]
 pub mod wire;
+pub mod yang;
 
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde_json::Value;
+use std::{collections::HashMap, convert::TryFrom, fmt};
+use strum_macros::Display;
+
+use yang::notification::{NotificationEnvelope, NotificationLegacy};
 
 const UDP_NOTIF_VERSION: u8 = 1;
 
 #[derive(
-    Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash, strum_macros::EnumDiscriminants,
+    Display,
+    Debug,
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Hash,
+    strum_macros::EnumDiscriminants,
 )]
 #[strum_discriminants(name(MediaTypeNames))]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
@@ -155,4 +169,417 @@ impl UdpNotifPacket {
 pub(crate) fn arbitrary_bytes(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Bytes> {
     let value: Vec<u8> = u.arbitrary()?;
     Ok(Bytes::from(value))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct UdpNotifPacketDecoded {
+    media_type: MediaType,
+    publisher_id: u32,
+    message_id: u32,
+    options: HashMap<UdpNotifOptionCode, UdpNotifOption>,
+    payload: UdpNotifPayload,
+}
+
+impl UdpNotifPacketDecoded {
+    pub const fn new(
+        media_type: MediaType,
+        publisher_id: u32,
+        message_id: u32,
+        options: HashMap<UdpNotifOptionCode, UdpNotifOption>,
+        payload: UdpNotifPayload,
+    ) -> Self {
+        Self {
+            media_type,
+            publisher_id,
+            message_id,
+            options,
+            payload,
+        }
+    }
+    pub const fn version(&self) -> u8 {
+        UDP_NOTIF_VERSION
+    }
+    pub const fn media_type(&self) -> MediaType {
+        self.media_type
+    }
+    pub const fn publisher_id(&self) -> u32 {
+        self.publisher_id
+    }
+    pub const fn message_id(&self) -> u32 {
+        self.message_id
+    }
+    pub const fn options(&self) -> &HashMap<UdpNotifOptionCode, UdpNotifOption> {
+        &self.options
+    }
+    pub const fn payload(&self) -> &UdpNotifPayload {
+        &self.payload
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum UdpNotifPayload {
+    #[serde(rename = "ietf-yp-notification:envelope")]
+    NotificationEnvelope(NotificationEnvelope),
+
+    #[serde(rename = "ietf-notification:notification")]
+    NotificationLegacy(NotificationLegacy), // deprecated
+}
+
+#[derive(Debug)]
+pub enum UdpNotifPayloadConversionError {
+    UnsupportedMediaType(MediaType),
+    JsonError(serde_json::Error),
+    CborError(ciborium::de::Error<std::io::Error>),
+}
+
+impl From<serde_json::Error> for UdpNotifPayloadConversionError {
+    fn from(err: serde_json::Error) -> Self {
+        UdpNotifPayloadConversionError::JsonError(err)
+    }
+}
+
+impl From<ciborium::de::Error<std::io::Error>> for UdpNotifPayloadConversionError {
+    fn from(err: ciborium::de::Error<std::io::Error>) -> Self {
+        UdpNotifPayloadConversionError::CborError(err)
+    }
+}
+
+impl fmt::Display for UdpNotifPayloadConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UdpNotifPayloadConversionError::UnsupportedMediaType(media_type) => {
+                write!(f, "Unsupported media type: {media_type}")
+            }
+            UdpNotifPayloadConversionError::JsonError(err) => {
+                write!(f, "JSON error: {err}")
+            }
+            UdpNotifPayloadConversionError::CborError(err) => {
+                write!(f, "CBOR error: {err}")
+            }
+        }
+    }
+}
+
+impl TryFrom<&UdpNotifPacket> for UdpNotifPacketDecoded {
+    type Error = UdpNotifPayloadConversionError;
+
+    fn try_from(pkt: &UdpNotifPacket) -> Result<Self, UdpNotifPayloadConversionError> {
+        let payload = match pkt.media_type() {
+            MediaType::YangDataJson => serde_json::from_slice(pkt.payload())?,
+            MediaType::YangDataCbor => {
+                let val: Value = ciborium::de::from_reader(std::io::Cursor::new(pkt.payload()))?;
+                serde_json::from_value(val)?
+            }
+            media_type => {
+                return Err(UdpNotifPayloadConversionError::UnsupportedMediaType(
+                    media_type,
+                ));
+            }
+        };
+
+        Ok(UdpNotifPacketDecoded {
+            media_type: pkt.media_type,
+            publisher_id: pkt.publisher_id,
+            message_id: pkt.message_id,
+            options: pkt.options.clone(),
+            payload,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use core::panic;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use yang::notification::{Encoding, NotificationVariant, UpdateTrigger};
+
+    #[test]
+    fn test_udp_notif_packet_decoded_envelope_sub_started() {
+        let payload = json!({
+            "ietf-yp-notification:envelope": {
+                "contents": {
+                    "ietf-subscribed-notifications:subscription-started": {
+                        "encoding": "encode-json",
+                        "id": 30,
+                        "ietf-yang-push-revision:module-version": [
+                            { "module-name": "openconfig-interfaces", "revision": "" }
+                        ],
+                        "ietf-yang-push:datastore": "operational",
+                        "ietf-yang-push:datastore-xpath-filter": "openconfig-interfaces:interfaces",
+                        "ietf-yang-push:on-change": { "sync-on-start": true },
+                    }
+                },
+                "event-time": "2025-04-17T15:20:14.840Z",
+                "hostname": "ipf-zbl1327-r-daisy-91",
+                "sequence-number": 0
+            }
+        })
+        .to_string()
+        .into_bytes();
+
+        let packet = UdpNotifPacket::new(
+            MediaType::YangDataJson,
+            1234,
+            5678,
+            HashMap::new(),
+            Bytes::from(payload),
+        );
+
+        let decoded: UdpNotifPacketDecoded = (&packet).try_into().unwrap();
+
+        // Test UdpNotifPacketDecoded getters
+        assert_eq!(decoded.media_type(), MediaType::YangDataJson);
+        assert_eq!(decoded.publisher_id(), 1234);
+        assert_eq!(decoded.message_id(), 5678);
+
+        // Check that the payload is a NotificationEnvelope with a SubscriptionStarted
+        // notification
+        match decoded.payload() {
+            UdpNotifPayload::NotificationEnvelope(envelope) => {
+                assert_eq!(envelope.hostname().unwrap(), "ipf-zbl1327-r-daisy-91");
+                assert_eq!(envelope.sequence_number().unwrap(), 0);
+
+                if let Some(notif_variant) = envelope.contents() {
+                    match notif_variant {
+                        NotificationVariant::SubscriptionStarted(subscription_started) => {
+                            assert_eq!(subscription_started.id(), 30);
+                            assert_eq!(subscription_started.encoding().unwrap(), &Encoding::Json);
+                            assert_eq!(
+                                subscription_started.target().datastore().unwrap(),
+                                "operational"
+                            );
+                            assert_eq!(
+                                subscription_started
+                                    .target()
+                                    .datastore_xpath_filter()
+                                    .unwrap(),
+                                "openconfig-interfaces:interfaces"
+                            );
+                            if let UpdateTrigger::OnChange {
+                                sync_on_start: Some(sync_on_start),
+                                ..
+                            } = subscription_started.update_trigger()
+                            {
+                                assert!(*sync_on_start);
+                            } else {
+                                panic!("Expected UpdateTrigger::OnChange with sync_on_start set to true");
+                            }
+                        }
+                        _ => {
+                            panic!("Expected NotificationVariant::SubscriptionStarted");
+                        }
+                    }
+                } else {
+                    panic!("Expected contents in NotificationEnvelope");
+                }
+            }
+            _ => {
+                panic!("Expected UdpNotifPayload::NotificationEnvelope");
+            }
+        }
+    }
+
+    #[test]
+    fn test_udp_notif_packet_decoded_legacy_sub_started() {
+        let payload = json!({
+            "ietf-notification:notification": {
+                "eventTime": "2025-05-12T12:00:00Z",
+                "additional_stuff": "example",
+                "ietf-subscribed-notifications:subscription-started": {
+                  "encoding": "encode-json",
+                  "id": 1,
+                  "ietf-distributed-notif:message-publisher-ids": [
+                    16974839, 16973828, 16974828
+                  ],
+                  "ietf-yang-push:datastore": "ietf-datastores:running",
+                  "additional_stuff": [ { "key1": "a" }, { "key2": "b" } ],
+                }
+            }
+        })
+        .to_string()
+        .into_bytes();
+
+        let packet = UdpNotifPacket::new(
+            MediaType::YangDataJson,
+            1234,
+            5678,
+            HashMap::new(),
+            Bytes::from(payload),
+        );
+
+        let decoded: UdpNotifPacketDecoded = (&packet).try_into().unwrap();
+
+        // Check that the payload is a Legacy Notification Wrapper with a
+        // SubscriptionStarted notification
+        match decoded.payload() {
+            UdpNotifPayload::NotificationLegacy(notification) => {
+                if let Some(notif_variant) = notification.notification() {
+                    match notif_variant {
+                        NotificationVariant::SubscriptionStarted(subscription_started) => {
+                            assert_eq!(subscription_started.id(), 1);
+                            assert_eq!(subscription_started.encoding().unwrap(), &Encoding::Json);
+                            assert_eq!(
+                                subscription_started.target().datastore().unwrap(),
+                                "ietf-datastores:running"
+                            );
+                        }
+                        _ => {
+                            panic!("Expected NotificationVariant::SubscriptionStarted");
+                        }
+                    }
+                }
+            }
+            _ => {
+                panic!("Expected UdpNotifPayload::NotificationLegacy");
+            }
+        }
+    }
+
+    #[test]
+    fn test_udp_notif_packet_decoded_unknown_mediatype() {
+        let payload = Bytes::from(vec![0x01, 0x02, 0x03]);
+
+        let packet =
+            UdpNotifPacket::new(MediaType::Unknown(99), 1234, 5678, HashMap::new(), payload);
+
+        // Attempt to decode the packet (will throw an error since the media type is
+        // unknown)
+        let result = UdpNotifPacketDecoded::try_from(&packet);
+
+        assert!(result.is_err());
+        if let Err(UdpNotifPayloadConversionError::UnsupportedMediaType(media_type)) = result {
+            assert_eq!(media_type, MediaType::Unknown(99));
+        } else {
+            panic!("Expected UnsupportedMediaType error");
+        }
+    }
+
+    #[test]
+    fn test_udp_notif_packet_decoded_invalid_json_payload() {
+        let payload = Bytes::from(b"invalid json".to_vec());
+
+        let packet =
+            UdpNotifPacket::new(MediaType::YangDataJson, 1234, 5678, HashMap::new(), payload);
+
+        // Attempt to decode the packet (will throw an error since the payload is not
+        // valid JSON)
+        let result = UdpNotifPacketDecoded::try_from(&packet);
+
+        assert!(result.is_err());
+        if let Err(UdpNotifPayloadConversionError::JsonError(json_error)) = result {
+            println!("Expected JsonError: {json_error:?}");
+        } else {
+            panic!("Expected JsonError");
+        }
+    }
+
+    #[test]
+    fn test_udp_notif_packet_decoded_unknown_notification_variant() {
+        let payload = json!({
+                    "ietf-yp-notification:envelope": {
+                        "event-time": "2025-03-04T07:11:33.252679191+00:00",
+                        "hostname": "some-router",
+                        "sequence-number": 5,
+                        "contents": {
+                            "unknown-notification-variant": {
+                                "id": 12345678,
+                                "encoding": "encode-json",
+                                "transport": "ietf-udp-notif-transport:udp-notif",
+                            }
+                        },
+                      }
+        })
+        .to_string()
+        .into_bytes();
+
+        let packet = UdpNotifPacket::new(
+            MediaType::YangDataJson,
+            1,
+            1,
+            HashMap::new(),
+            Bytes::from(payload),
+        );
+
+        // Attempt to decode the packet (will throw an error since the
+        // NotificationVariant is unknown)
+        let result = UdpNotifPacketDecoded::try_from(&packet);
+
+        assert!(result.is_err());
+        if let Err(UdpNotifPayloadConversionError::JsonError(json_error)) = result {
+            println!("Expected JsonError: {json_error:?}");
+        } else {
+            panic!("Expected JsonError");
+        }
+    }
+
+    #[test]
+    fn test_udp_notif_packet_decoded_empty_content() {
+        let payload = json!({
+                    "ietf-yp-notification:envelope": {
+                        "event-time": "2025-03-04T07:11:33.252679191+00:00",
+                        "hostname": "some-router",
+                        "sequence-number": 5,
+                        "contents": {},
+                      }
+        })
+        .to_string()
+        .into_bytes();
+
+        let packet = UdpNotifPacket::new(
+            MediaType::YangDataJson,
+            1,
+            1,
+            HashMap::new(),
+            Bytes::from(payload),
+        );
+
+        // Attempt to decode the packet (will throw an error since there
+        // isn't any of the defined NotificationVariant)
+        let result = UdpNotifPacketDecoded::try_from(&packet);
+
+        assert!(result.is_err());
+        if let Err(UdpNotifPayloadConversionError::JsonError(json_error)) = result {
+            println!("Expected JsonError: {json_error:?}");
+        } else {
+            panic!("Expected JsonError");
+        }
+    }
+
+    #[test]
+    fn test_udp_notif_packet_decoded_no_content() {
+        let payload = json!({
+                    "ietf-yp-notification:envelope": {
+                        "event-time": "2025-03-04T07:11:33.252679191+00:00",
+                        "hostname": "some-router",
+                        "sequence-number": 5,
+                      }
+        })
+        .to_string()
+        .into_bytes();
+
+        let packet = UdpNotifPacket::new(
+            MediaType::YangDataJson,
+            1,
+            1,
+            HashMap::new(),
+            Bytes::from(payload),
+        );
+
+        // Attempt to decode the packet (should succeed)
+        let decoded: UdpNotifPacketDecoded = (&packet).try_into().unwrap();
+
+        // Check hostname and sequence number
+        match decoded.payload() {
+            UdpNotifPayload::NotificationEnvelope(envelope) => {
+                assert_eq!(envelope.hostname().unwrap(), "some-router");
+                assert_eq!(envelope.sequence_number().unwrap(), 5);
+            }
+            _ => {
+                panic!("Expected UdpNotifPayload::NotificationEnvelope");
+            }
+        }
+    }
 }

--- a/crates/udp-notif-pkt/src/yang/mod.rs
+++ b/crates/udp-notif-pkt/src/yang/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (C) 2025-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pub mod notification;

--- a/crates/udp-notif-pkt/src/yang/notification.rs
+++ b/crates/udp-notif-pkt/src/yang/notification.rs
@@ -1,0 +1,890 @@
+// Copyright (C) 2025-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # YANG Notification Message
+//!
+//! This module defines data structures and serialization logic for handling
+//! YANG notifications as specified in:
+//! - [RFC 8639](https://datatracker.ietf.org/doc/html/rfc8639): Subscription to
+//!   YANG Notifications
+//! - [RFC 8641](https://datatracker.ietf.org/doc/html/rfc8641): Subscription to
+//!   YANG Notifications for Datastore Updates
+//! - [Notification Versioning Draft](https://datatracker.ietf.org/doc/html/draft-ietf-netconf-yang-notifications-versioning-08)
+//! - [Notification Envelope Draft](https://datatracker.ietf.org/doc/html/draft-ietf-netconf-notif-envelope-01)
+//!
+//! ## Key components:
+//! - **NotificationEnvelope**: Extensible wrapper for Yang-Push notification
+//!   messages with metadata like hostname and sequence number.
+//! - **NotificationLegacy**: Legacy notification wrapper (deprecated).
+//! - **NotificationVariant**: Enumerates specific notification types (e.g.,
+//!   subscription started/modified/terminated, YANG push updates, etc.).
+//!
+//! ## Notes:
+//! - `extra_fields` with serde(flatten) annotations is used for handling
+//!   additional fields to ensure compatibility with YANG augmentations
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use strum_macros::Display;
+
+pub type SubscriptionId = u32;
+
+/// Yang-Push Notification Envelope
+/// This is an extensible wrapper for Yang-Push notification messages.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct NotificationEnvelope {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hostname: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sequence_number: Option<u32>,
+
+    /// Alias for supporting deprecated 'notification-contents'
+    /// instead of 'contents' (> draft-ietf-netconf-notif-envelope-01)
+    #[serde(alias = "notification-contents")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    contents: Option<NotificationVariant>,
+
+    #[serde(flatten)]
+    extra_fields: Value,
+}
+
+impl NotificationEnvelope {
+    pub fn hostname(&self) -> Option<&str> {
+        self.hostname.as_deref()
+    }
+    pub fn sequence_number(&self) -> Option<u32> {
+        self.sequence_number
+    }
+    pub fn contents(&self) -> Option<&NotificationVariant> {
+        self.contents.as_ref()
+    }
+}
+
+/// Legacy Yang-Push Notification Wrapper
+/// This is deprecated: use NotificationEnvelope instead
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NotificationLegacy {
+    #[serde(rename = "ietf-notification-sequencing:sysName")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sys_name: Option<String>,
+
+    #[serde(flatten)]
+    notification: Option<NotificationVariant>,
+
+    #[serde(flatten)]
+    extra_fields: Value,
+}
+
+impl NotificationLegacy {
+    pub fn sys_name(&self) -> Option<&str> {
+        self.sys_name.as_deref()
+    }
+    pub fn notification(&self) -> Option<&NotificationVariant> {
+        self.notification.as_ref()
+    }
+}
+
+/// Notification Variants
+#[derive(Clone, Debug, Display, Serialize, Deserialize, PartialEq, Eq)]
+pub enum NotificationVariant {
+    #[serde(rename = "ietf-subscribed-notifications:subscription-started")]
+    SubscriptionStarted(SubscriptionStartedModified),
+
+    #[serde(rename = "ietf-subscribed-notifications:subscription-modified")]
+    SubscriptionModified(SubscriptionStartedModified),
+
+    #[serde(rename = "ietf-subscribed-notifications:subscription-terminated")]
+    SubscriptionTerminated(SubscriptionTerminated),
+
+    #[serde(rename = "ietf-yang-push:push-update")]
+    YangPushUpdate(YangPushUpdate),
+
+    #[serde(rename = "ietf-yang-push:push-change-update")]
+    YangPushChangeUpdate(YangPushChangeUpdate),
+}
+
+/// Subscription Started and Modified Message
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubscriptionStartedModified {
+    id: SubscriptionId,
+
+    #[serde(flatten)]
+    target: Target,
+
+    #[serde(rename = "stop-time")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_time: Option<DateTime<Utc>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transport: Option<Transport>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encoding: Option<Encoding>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    purpose: Option<String>,
+
+    #[serde(flatten)]
+    update_trigger: UpdateTrigger,
+
+    #[serde(rename = "ietf-yang-push-revision:module-version")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    module_version: Option<Vec<YangPushModuleVersion>>,
+
+    #[serde(rename = "ietf-yang-push-revision:yang-library-content-id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    yang_library_content_id: Option<String>,
+
+    #[serde(flatten)]
+    extra_fields: Value,
+}
+
+impl SubscriptionStartedModified {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: SubscriptionId,
+        target: Target,
+        stop_time: Option<DateTime<Utc>>,
+        transport: Option<Transport>,
+        encoding: Option<Encoding>,
+        purpose: Option<String>,
+        update_trigger: UpdateTrigger,
+        module_version: Option<Vec<YangPushModuleVersion>>,
+        yang_library_content_id: Option<String>,
+        extra_fields: Value,
+    ) -> Self {
+        Self {
+            id,
+            target,
+            stop_time,
+            transport,
+            encoding,
+            purpose,
+            update_trigger,
+            module_version,
+            yang_library_content_id,
+            extra_fields,
+        }
+    }
+    pub fn id(&self) -> SubscriptionId {
+        self.id
+    }
+    pub fn target(&self) -> &Target {
+        &self.target
+    }
+    pub fn stop_time(&self) -> Option<&DateTime<Utc>> {
+        self.stop_time.as_ref()
+    }
+    pub fn transport(&self) -> Option<&Transport> {
+        self.transport.as_ref()
+    }
+    pub fn encoding(&self) -> Option<&Encoding> {
+        self.encoding.as_ref()
+    }
+    pub fn purpose(&self) -> Option<&str> {
+        self.purpose.as_deref()
+    }
+    pub fn update_trigger(&self) -> &UpdateTrigger {
+        &self.update_trigger
+    }
+    pub fn module_version(&self) -> Option<&Vec<YangPushModuleVersion>> {
+        self.module_version.as_ref()
+    }
+    pub fn yang_library_content_id(&self) -> Option<&str> {
+        self.yang_library_content_id.as_deref()
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubscriptionTerminated {
+    id: SubscriptionId,
+
+    reason: String,
+
+    #[serde(flatten)]
+    extra_fields: Value,
+}
+
+impl SubscriptionTerminated {
+    pub fn new(id: SubscriptionId, reason: String, extra_fields: Value) -> Self {
+        Self {
+            id,
+            reason,
+            extra_fields,
+        }
+    }
+    pub fn id(&self) -> SubscriptionId {
+        self.id
+    }
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct YangPushUpdate {
+    id: SubscriptionId,
+
+    datastore_contents: Value,
+
+    #[serde(flatten)]
+    extra_fields: Value,
+}
+
+impl YangPushUpdate {
+    pub fn new(id: SubscriptionId, datastore_contents: Value, extra_fields: Value) -> Self {
+        Self {
+            id,
+            datastore_contents,
+            extra_fields,
+        }
+    }
+    pub fn id(&self) -> SubscriptionId {
+        self.id
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct YangPushChangeUpdate {
+    id: SubscriptionId,
+
+    datastore_changes: Value,
+
+    #[serde(flatten)]
+    extra_fields: Value,
+}
+
+impl YangPushChangeUpdate {
+    pub fn new(id: SubscriptionId, datastore_changes: Value, extra_fields: Value) -> Self {
+        Self {
+            id,
+            datastore_changes,
+            extra_fields,
+        }
+    }
+    pub fn id(&self) -> SubscriptionId {
+        self.id
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Target {
+    #[serde(rename = "stream")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<String>,
+
+    #[serde(rename = "stream-subtree-filter")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream_subtree_filter: Option<Value>,
+
+    #[serde(rename = "stream-xpath-filter")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream_xpath_filter: Option<String>,
+
+    #[serde(rename = "replay-start-time")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    replay_start_time: Option<DateTime<Utc>>,
+
+    #[serde(rename = "ietf-yang-push:datastore")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    datastore: Option<String>,
+
+    #[serde(rename = "datastore-subtree-filter")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    datastore_subtree_filter: Option<Value>,
+
+    #[serde(rename = "ietf-yang-push:datastore-xpath-filter")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    datastore_xpath_filter: Option<String>,
+}
+
+impl Target {
+    pub fn new(
+        stream: Option<String>,
+        stream_subtree_filter: Option<Value>,
+        stream_xpath_filter: Option<String>,
+        replay_start_time: Option<DateTime<Utc>>,
+        datastore: Option<String>,
+        datastore_subtree_filter: Option<Value>,
+        datastore_xpath_filter: Option<String>,
+    ) -> Self {
+        Self {
+            stream,
+            stream_subtree_filter,
+            stream_xpath_filter,
+            replay_start_time,
+            datastore,
+            datastore_subtree_filter,
+            datastore_xpath_filter,
+        }
+    }
+    pub fn stream(&self) -> Option<&str> {
+        self.stream.as_deref()
+    }
+    pub fn stream_subtree_filter(&self) -> Option<&Value> {
+        self.stream_subtree_filter.as_ref()
+    }
+    pub fn stream_xpath_filter(&self) -> Option<&str> {
+        self.stream_xpath_filter.as_deref()
+    }
+    pub fn replay_start_time(&self) -> Option<&DateTime<Utc>> {
+        self.replay_start_time.as_ref()
+    }
+    pub fn datastore(&self) -> Option<&str> {
+        self.datastore.as_deref()
+    }
+    pub fn datastore_subtree_filter(&self) -> Option<&Value> {
+        self.datastore_subtree_filter.as_ref()
+    }
+    pub fn datastore_xpath_filter(&self) -> Option<&str> {
+        self.datastore_xpath_filter.as_deref()
+    }
+}
+
+/// Transport protocol used to deliver the notification message to the data
+/// collection
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Transport {
+    #[serde(rename = "ietf-udp-notif-transport:udp-notif")]
+    UDPNotif,
+
+    #[serde(rename = "ietf-https-notif:https")]
+    HTTPSNotif,
+
+    #[default]
+    #[serde(other)]
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+// Encoding used for the notification payload
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Encoding {
+    #[serde(rename = "ietf-subscribed-notifications:encode-xml")]
+    #[serde(alias = "encode-xml")]
+    Xml,
+
+    #[serde(rename = "ietf-subscribed-notifications:encode-json")]
+    #[serde(alias = "encode-json")]
+    Json,
+
+    #[serde(rename = "ietf-udp-notif-transport:encode-cbor")]
+    #[serde(alias = "encode-cbor")]
+    Cbor,
+
+    #[default]
+    #[serde(other)]
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum UpdateTrigger {
+    #[serde(rename = "ietf-yang-push:periodic")]
+    #[serde(rename_all = "kebab-case")]
+    Periodic {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        period: Option<CentiSeconds>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        anchor_time: Option<DateTime<Utc>>,
+    },
+
+    #[serde(rename = "ietf-yang-push:on-change")]
+    #[serde(rename_all = "kebab-case")]
+    OnChange {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dampening_period: Option<CentiSeconds>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sync_on_start: Option<bool>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        excluded_change: Option<Vec<ChangeType>>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ChangeType {
+    Create,
+    Delete,
+    Insert,
+    Move,
+    Replace,
+}
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct YangPushModuleVersion {
+    pub module_name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision_label: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CentiSeconds(u32);
+
+impl CentiSeconds {
+    pub fn new(value: u32) -> Self {
+        CentiSeconds(value)
+    }
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
+    pub fn to_milliseconds(&self) -> u32 {
+        self.0 * 10
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use serde_json;
+
+    #[test]
+    fn test_transport_serialization() {
+        assert_eq!(
+            serde_json::to_string(&Transport::UDPNotif).unwrap(),
+            r#""ietf-udp-notif-transport:udp-notif""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Transport::HTTPSNotif).unwrap(),
+            r#""ietf-https-notif:https""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Transport::Unknown).unwrap(),
+            r#""unknown""#
+        );
+    }
+
+    #[test]
+    fn test_transport_deserialization() {
+        assert_eq!(
+            serde_json::from_str::<Transport>(r#""ietf-udp-notif-transport:udp-notif""#).unwrap(),
+            Transport::UDPNotif
+        );
+        assert_eq!(
+            serde_json::from_str::<Transport>(r#""ietf-https-notif:https""#).unwrap(),
+            Transport::HTTPSNotif
+        );
+        assert_eq!(
+            serde_json::from_str::<Transport>(r#""unknown""#).unwrap(),
+            Transport::Unknown
+        );
+
+        // Test deserialization of unknown/empty values
+        assert_eq!(
+            serde_json::from_str::<Transport>(r#""unsupported-value""#).unwrap(),
+            Transport::Unknown
+        );
+        assert_eq!(
+            serde_json::from_str::<Transport>(r#""""#).unwrap(),
+            Transport::Unknown
+        );
+    }
+
+    #[test]
+    fn test_encoding_serialization() {
+        assert_eq!(
+            serde_json::to_string(&Encoding::Xml).unwrap(),
+            r#""ietf-subscribed-notifications:encode-xml""#
+        );
+
+        assert_eq!(
+            serde_json::to_string(&Encoding::Json).unwrap(),
+            r#""ietf-subscribed-notifications:encode-json""#
+        );
+
+        assert_eq!(
+            serde_json::to_string(&Encoding::Cbor).unwrap(),
+            r#""ietf-udp-notif-transport:encode-cbor""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Encoding::Unknown).unwrap(),
+            r#""unknown""#
+        );
+    }
+
+    #[test]
+    fn test_encoding_deserialization() {
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""ietf-subscribed-notifications:encode-xml""#)
+                .unwrap(),
+            Encoding::Xml
+        );
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""encode-xml""#).unwrap(),
+            Encoding::Xml
+        );
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""ietf-subscribed-notifications:encode-json""#)
+                .unwrap(),
+            Encoding::Json
+        );
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""encode-json""#).unwrap(),
+            Encoding::Json
+        );
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""ietf-udp-notif-transport:encode-cbor""#).unwrap(),
+            Encoding::Cbor
+        );
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""encode-cbor""#).unwrap(),
+            Encoding::Cbor
+        );
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""unknown""#).unwrap(),
+            Encoding::Unknown
+        );
+
+        // Test deserialization of unknown/empty values
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""unsupported-value""#).unwrap(),
+            Encoding::Unknown
+        );
+        assert_eq!(
+            serde_json::from_str::<Encoding>(r#""""#).unwrap(),
+            Encoding::Unknown
+        );
+    }
+
+    #[test]
+    fn test_sub_started_modified_serde() {
+        // Create a SubscriptionStartedModified instance
+        let sub_started = SubscriptionStartedModified {
+            id: 1,
+            target: Target {
+                stream: None,
+                stream_subtree_filter: None,
+                stream_xpath_filter: None,
+                replay_start_time: None,
+                datastore: Some("example-datastore".to_string()),
+                datastore_subtree_filter: None,
+                datastore_xpath_filter: Some("/example/datastore/xpath/filter".to_string()),
+            },
+            encoding: Some(Encoding::Json),
+            transport: Some(Transport::UDPNotif),
+            stop_time: Some(Utc.timestamp_millis_opt(0).unwrap()),
+            purpose: Some("test-purpose".to_string()),
+            update_trigger: UpdateTrigger::OnChange {
+                dampening_period: Some(CentiSeconds::new(100)),
+                sync_on_start: Some(true),
+                excluded_change: Some(vec![ChangeType::Create, ChangeType::Replace]),
+            },
+            module_version: Some(vec![YangPushModuleVersion {
+                module_name: "example-module".to_string(),
+                revision: Some("2025-04-25".to_string()),
+                revision_label: None,
+            }]),
+            yang_library_content_id: Some("content-id".to_string()),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Create a Notification instance
+        let notification = NotificationLegacy {
+            sys_name: Some("example-node".to_string()),
+            notification: Some(NotificationVariant::SubscriptionStarted(
+                sub_started.clone(),
+            )),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Serialize the Notification to JSON
+        let serialized = serde_json::to_string(&notification).expect("Serialization failed");
+
+        // Deserialize the JSON back to a Notification
+        let deserialized: NotificationLegacy =
+            serde_json::from_str(&serialized).expect("Deserialization failed");
+
+        // Assert that the deserialized Notification matches the original
+        assert_eq!(notification, deserialized);
+
+        // Create a NotificationEnvelope instance
+        let notification_envelope = NotificationEnvelope {
+            hostname: Some("example-host".to_string()),
+            sequence_number: Some(12345),
+            contents: Some(NotificationVariant::SubscriptionStarted(sub_started)),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Serialize the NotificationEnvelope to JSON
+        let serialized_envelope =
+            serde_json::to_string(&notification_envelope).expect("Serialization failed");
+
+        // Deserialize the JSON back to a NotificationEnvelope
+        let deserialized_envelope: NotificationEnvelope =
+            serde_json::from_str(&serialized_envelope).expect("Deserialization failed");
+
+        // Assert that the deserialized NotificationEnvelope matches the original
+        assert_eq!(notification_envelope, deserialized_envelope);
+    }
+
+    #[test]
+    fn test_sub_started_modified_getters() {
+        // Create a Target instance
+        let target = Target {
+            stream: None,
+            stream_subtree_filter: None,
+            stream_xpath_filter: None,
+            replay_start_time: Some(Utc.timestamp_millis_opt(0).unwrap()),
+            datastore: Some("example-datastore".to_string()),
+            datastore_subtree_filter: Some(serde_json::json!({"example-map": "example-value"})),
+            datastore_xpath_filter: Some("/example/datastore/xpath/filter".to_string()),
+        };
+
+        // Target getters
+        assert_eq!(target.stream(), None);
+        assert_eq!(target.stream_subtree_filter(), None);
+        assert_eq!(target.stream_xpath_filter(), None);
+        assert_eq!(
+            target.replay_start_time(),
+            Some(&Utc.timestamp_millis_opt(0).unwrap())
+        );
+        assert_eq!(target.datastore(), Some("example-datastore"));
+        assert_eq!(
+            target.datastore_subtree_filter(),
+            Some(&serde_json::json!({"example-map": "example-value"}))
+        );
+        assert_eq!(
+            target.datastore_xpath_filter(),
+            Some("/example/datastore/xpath/filter")
+        );
+
+        // Create a SubscriptionStartedModified instance
+        let sub_started = SubscriptionStartedModified {
+            id: 1,
+            target: target.clone(),
+            encoding: Some(Encoding::Json),
+            transport: Some(Transport::UDPNotif),
+            stop_time: Some(Utc.timestamp_millis_opt(10000).unwrap()),
+            purpose: Some("test-purpose".to_string()),
+            update_trigger: UpdateTrigger::OnChange {
+                dampening_period: Some(CentiSeconds::new(100)),
+                sync_on_start: Some(true),
+                excluded_change: Some(vec![ChangeType::Create, ChangeType::Replace]),
+            },
+            module_version: Some(vec![YangPushModuleVersion {
+                module_name: "example-module".to_string(),
+                revision: Some("2025-04-25".to_string()),
+                revision_label: None,
+            }]),
+            yang_library_content_id: Some("content-id".to_string()),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // SubscriptionStartedModified getters
+        assert_eq!(sub_started.id(), 1);
+        assert_eq!(sub_started.target(), &target);
+        assert_eq!(
+            sub_started.stop_time(),
+            Some(&Utc.timestamp_millis_opt(10000).unwrap())
+        );
+        assert_eq!(sub_started.transport(), Some(&Transport::UDPNotif));
+        assert_eq!(sub_started.encoding(), Some(&Encoding::Json));
+        assert_eq!(sub_started.purpose(), Some("test-purpose"));
+        assert_eq!(sub_started.yang_library_content_id(), Some("content-id"));
+
+        // Create a Notification instance
+        let notification = NotificationLegacy {
+            sys_name: Some("example-node".to_string()),
+            notification: Some(NotificationVariant::SubscriptionStarted(
+                sub_started.clone(),
+            )),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Notification getters
+        assert_eq!(notification.sys_name(), Some("example-node"));
+        assert!(matches!(
+            notification.notification(),
+            Some(NotificationVariant::SubscriptionStarted(_))
+        ));
+
+        // Create a NotificationEnvelope instance
+        let notification_envelope = NotificationEnvelope {
+            hostname: Some("example-host".to_string()),
+            sequence_number: Some(12345),
+            contents: Some(NotificationVariant::SubscriptionStarted(sub_started)),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // NotificationEnvelope getters
+        assert_eq!(notification_envelope.hostname(), Some("example-host"));
+        assert_eq!(notification_envelope.sequence_number(), Some(12345));
+        assert!(matches!(
+            notification_envelope.contents(),
+            Some(NotificationVariant::SubscriptionStarted(_))
+        ));
+    }
+
+    #[test]
+    fn test_sub_terminated_serde() {
+        // Create a SubscriptionTerminated instance
+        let sub_terminated = SubscriptionTerminated {
+            id: 1,
+            reason: "some-reason".to_string(),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Create a Notification instance
+        let notification = NotificationLegacy {
+            sys_name: Some("example-node".to_string()),
+            notification: Some(NotificationVariant::SubscriptionTerminated(
+                sub_terminated.clone(),
+            )),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Serialize the Notification to JSON
+        let serialized = serde_json::to_string(&notification).expect("Serialization failed");
+
+        // Deserialize the JSON back to a Notification
+        let deserialized: NotificationLegacy =
+            serde_json::from_str(&serialized).expect("Deserialization failed");
+
+        // Assert that the deserialized Notification matches the original
+        assert_eq!(notification, deserialized);
+
+        // Create a NotificationEnvelope instance
+        let notification_envelope = NotificationEnvelope {
+            hostname: Some("example-host".to_string()),
+            sequence_number: Some(12345),
+            contents: Some(NotificationVariant::SubscriptionTerminated(sub_terminated)),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Serialize the NotificationEnvelope to JSON
+        let serialized_envelope =
+            serde_json::to_string(&notification_envelope).expect("Serialization failed");
+
+        // Deserialize the JSON back to a NotificationEnvelope
+        let deserialized_envelope: NotificationEnvelope =
+            serde_json::from_str(&serialized_envelope).expect("Deserialization failed");
+
+        // Assert that the deserialized NotificationEnvelope matches the original
+        assert_eq!(notification_envelope, deserialized_envelope);
+    }
+
+    #[test]
+    fn test_sub_terminated_getters() {
+        // Create a SubscriptionTerminated instance
+        let sub_terminated = SubscriptionTerminated {
+            id: 2462462462,
+            reason: "this-is-the-yang-push-sub-terminated-reason".to_string(),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // SubscriptionTerminated getters
+        assert_eq!(sub_terminated.id(), 2462462462);
+        assert_eq!(
+            sub_terminated.reason(),
+            "this-is-the-yang-push-sub-terminated-reason"
+        );
+    }
+
+    #[test]
+    fn test_yang_push_update_serde() {
+        // Create a YangPushUpdate instance
+        let yang_push_update = YangPushUpdate {
+            id: 1,
+            datastore_contents: serde_json::json!({
+              "layer1": {
+                  "layer2": {
+                      "layer3": {
+                          "key1": "value1",
+                          "key2": 42,
+                          "key3": {
+                              "subkey1": true,
+                              "subkey2": [1, 2, 3],
+                              "subkey3": {
+                                  "deepkey": "deepvalue"
+                              }
+                          }
+                      },
+                      "anotherKey": "anotherValue"
+                  },
+                  "simpleKey": "simpleValue"
+              }
+            }),
+            extra_fields: serde_json::json!({
+                "ietf-distributed-notif:message-publisher-id": 1,
+                "ietf-yp-observation:point-in-time": "current-accounting",
+                "ietf-yp-observation:timestamp": "2025-05-06T00:00:00Z"
+            }),
+        };
+
+        // Create a Notification instance
+        let notification = NotificationLegacy {
+            sys_name: Some("example-node".to_string()),
+            notification: Some(NotificationVariant::YangPushUpdate(
+                yang_push_update.clone(),
+            )),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Serialize the Notification to JSON
+        let serialized = serde_json::to_string(&notification).expect("Serialization failed");
+
+        // Deserialize the JSON back to a Notification
+        let deserialized: NotificationLegacy =
+            serde_json::from_str(&serialized).expect("Deserialization failed");
+
+        // Assert that the deserialized Notification matches the original
+        assert_eq!(notification, deserialized);
+
+        // Create a NotificationEnvelope instance
+        let notification_envelope = NotificationEnvelope {
+            hostname: Some("example-host".to_string()),
+            sequence_number: Some(12345),
+            contents: Some(NotificationVariant::YangPushUpdate(yang_push_update)),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // Serialize the NotificationEnvelope to JSON
+        let serialized_envelope =
+            serde_json::to_string(&notification_envelope).expect("Serialization failed");
+
+        // Deserialize the JSON back to a NotificationEnvelope
+        let deserialized_envelope: NotificationEnvelope =
+            serde_json::from_str(&serialized_envelope).expect("Deserialization failed");
+
+        // Assert that the deserialized NotificationEnvelope matches the original
+        assert_eq!(notification_envelope, deserialized_envelope);
+    }
+
+    #[test]
+    fn test_yang_push_update_getter() {
+        // Create a YangPushUpdate instance
+        let yang_push_update = YangPushUpdate {
+            id: 798798779,
+            datastore_contents: serde_json::json!({}),
+            extra_fields: serde_json::json!({}),
+        };
+
+        // YangPushUpdate getters
+        assert_eq!(yang_push_update.id(), 798798779);
+    }
+}


### PR DESCRIPTION
Depends on PR #213

Changes:
- ascii art and dump of build/source control information at collector startup
- add build info to data-collection-mainfest in Yang Push Telemetry Message