### PR TITLE
event-time parsed and enriched to node-export-timestamp in TelemetryMessage

### DIFF
--- a/crates/udp-notif-pkt/Cargo.toml
+++ b/crates/udp-notif-pkt/Cargo.toml
@@ -29,7 +29,7 @@ tokio-util = { workspace = true, features = ["full", "tracing"] , optional = tru
 arbitrary = { workspace = true, optional = true }
 arbitrary_ext = { workspace = true, optional = true }
 serde_json = { workspace = true }
-chrono = { workspace = true, features = ["serde"] }
+chrono = { workspace = true, default-features = true, features = ["serde"] }
 ciborium = { workspace = true }
 
 [features]

--- a/crates/udp-notif-pkt/src/lib.rs
+++ b/crates/udp-notif-pkt/src/lib.rs
@@ -291,6 +291,7 @@ impl TryFrom<&UdpNotifPacket> for UdpNotifPacketDecoded {
 mod tests {
     use super::*;
     use bytes::Bytes;
+    use chrono::{DateTime, Utc};
     use core::panic;
     use serde_json::json;
     use std::collections::HashMap;
@@ -316,6 +317,7 @@ mod tests {
                     }
                 },
                 "event-time": "2025-04-17T15:20:14.840Z",
+                "another-time": "2025-01-01T15:20:14.840Z",
                 "hostname": "ipf-zbl1327-r-daisy-91",
                 "sequence-number": 0
             }
@@ -368,10 +370,13 @@ mod tests {
             serde_json::json!({}),
         );
         let expected = NotificationEnvelope::new(
+            DateTime::parse_from_rfc3339("2025-04-17T15:20:14.840Z")
+                .unwrap()
+                .with_timezone(&Utc),
             Some("ipf-zbl1327-r-daisy-91".to_string()),
             Some(0),
             Some(NotificationVariant::SubscriptionStarted(sub_started)),
-            json!({"event-time": "2025-04-17T15:20:14.840Z"}),
+            json!({"another-time": "2025-01-01T15:20:14.840Z"}),
         );
 
         // Compare the decoded payload with expected NotificationEnvelope
@@ -440,10 +445,12 @@ mod tests {
                   "additional_stuff": [ { "key1": "a" }, { "key2": "b" } ]}),
         );
         let expected = NotificationLegacy::new(
+            DateTime::parse_from_rfc3339("2025-05-12T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
             None,
             Some(NotificationVariant::SubscriptionStarted(sub_started)),
             serde_json::json!({
-              "eventTime": "2025-05-12T12:00:00Z",
               "additional_stuff": "example"}),
         );
 
@@ -587,10 +594,13 @@ mod tests {
 
         // Create expected NotificationEnvelope
         let expected = NotificationEnvelope::new(
+            DateTime::parse_from_rfc3339("2025-03-04T07:11:33.252679191+00:00")
+                .unwrap()
+                .with_timezone(&Utc),
             Some("some-router".to_string()),
             Some(5),
             None,
-            json!({"event-time": "2025-03-04T07:11:33.252679191+00:00"}),
+            json!({}),
         );
 
         // Check hostname and sequence number


### PR DESCRIPTION
Example Telemetry Message with optional field node-export-timestamp populated (validated with yanglint):
```json
{
  "ietf-telemetry-message:message": {
    "data-collection-manifest": {
      "name": "netgauze-collector@leo-rocky",
      "os-type": "Rocky Linux",
      "os-version": "8.10",
      "software-flavor": "debug",
      "software-version": "0.6.2 (b22a878c)",
      "vendor": "NetGauze"
    },
    "network-operator-metadata": {
      "labels": [
        {
          "name": "pkey",
          "string-value": "unknown"
        },
        {
          "name": "nkey",
          "string-value": "unknown"
        }
      ]
    },
    "payload": {
      "ietf-yp-notification:envelope": {
        "contents": {
          "ietf-subscribed-notifications:subscription-terminated": {
            "id": 12345678,
            "reason": "no-such-subscription"
          }
        },
        "event-time": "2025-03-04T07:41:40.577666687Z",
        "hostname": "daisy-ietf-ipf-zbl1843-r-daisy-58",
        "sequence-number": 66
      }
    },
    "telemetry-message-metadata": {
      "collection-timestamp": "2025-06-13T13:46:04.162353613Z",
      "export-address": "192.168.100.3",
      "export-port": 42911,
      "ietf-yang-push-telemetry-message:yang-push-subscription": {
        "datastore": "ietf-datastores:operational",
        "encoding": "ietf-subscribed-notifications:encode-json",
        "id": 12345678,
        "module-version": [
          {
            "module-name": "vrouter-interface",
            "revision": "2024-04-22"
          }
        ],
        "periodic": {
          "period": 3000
        },
        "purpose": "send notifications",
        "transport": "ietf-udp-notif-transport:udp-notif",
        "xpath-filter": "/state/vrf/interface/physical[name='ens192']/counters",
        "yang-library-content-id": "3625735881"
      },
      "node-export-timestamp": "2025-03-04T07:41:40.577666687Z",
      "session-protocol": "yp-push"
    }
  }
}

```