### PR TITLE
Optimization flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -25,6 +25,4 @@ rustflags = [
     "-Dfuture_incompatible",
     "-Dnonstandard_style",
     "-Drust_2018_idioms",
-    "-C",
-    "target-cpu=native",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,7 @@ sysinfo = { version = "0.36" }
 shadow-rs = { version = "1.1", default-features = false }
 smallvec = { version = "1.15" }
 rustc-hash = { version = "2.1" }
+
+[profile.release]
+codegen-units = 1
+lto = true

--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -91,7 +91,3 @@ chrono = { workspace = true, default-features = false, features = [
 ] }
 tracing-subscriber = { workspace = true }
 bytes = { workspace = true }
-
-[profile.release]
-codegen-units = 1
-lto = false

--- a/crates/collector/src/flow/aggregation/aggregator.rs
+++ b/crates/collector/src/flow/aggregation/aggregator.rs
@@ -18,8 +18,8 @@
 //! This module implements the runtime aggregation engine that processes flow
 //! records in time windows. The main components are:
 //!
-//! - `FlowAggregator` - Main aggregation engine implementing time-windowed
-//!   flow aggregation with configurable operations
+//! - `FlowAggregator` - Main aggregation engine implementing time-windowed flow
+//!   aggregation with configurable operations
 //! - `FlowCacheKey` & `FlowCacheRecord` - In-memory cache structures for
 //!   maintaining aggregated flow state across time windows
 //! - `AggFlowInfo` - Wrapper for aggregatable flow data with time-series
@@ -37,7 +37,8 @@
 //!
 //! ## Processing Flow
 //!
-//! 1. Incoming flows are exploded into `AggFlowInfo` records using field selectors
+//! 1. Incoming flows are exploded into `AggFlowInfo` records using field
+//!    selectors
 //! 2. Records are grouped by `FlowCacheKey` (peer IP + key fields)
 //! 3. Aggregation operations are applied to combine records in the same group
 //! 4. Time windows manage when aggregated records are flushed

--- a/crates/collector/src/flow/aggregation/config.rs
+++ b/crates/collector/src/flow/aggregation/config.rs
@@ -20,10 +20,10 @@
 //!
 //! ## Types
 //!
-//! - `AggregationConfig` - User-facing configuration with time windows,
-//!   worker settings, and field transformation specifications
-//! - `Transform` - Field transformation specifications (single operation
-//!   or multi-index operations for array fields)
+//! - `AggregationConfig` - User-facing configuration with time windows, worker
+//!   settings, and field transformation specifications
+//! - `Transform` - Field transformation specifications (single operation or
+//!   multi-index operations for array fields)
 //! - `FieldRef` - Reference to specific field by IE and array index
 //!
 //! ## Validation
@@ -31,8 +31,8 @@
 //! The module provides comprehensive validation including:
 //! - Basic parameter validation (worker count, time windows)
 //! - Operation compatibility with Information Element (IE) types
-//! - Conversion from user configuration to optimized internal format
-//!   (`Unified Config`)
+//! - Conversion from user configuration to optimized internal format (`Unified
+//!   Config`)
 //!
 //! ## Configuration Flow
 //!


### PR DESCRIPTION
**Changelog**:

- remove native cpu optimization flag
- move release profile build optimization to main Cargo.toml with fat link time optmization (ltu=true) and codegen-units=1
- leftover fmt for docwrap (not detected by ci)