### PR TITLE
Add IPFIX options data record classification and normalization

### DIFF
--- a/crates/collector/src/flow/enrichment/actor.rs
+++ b/crates/collector/src/flow/enrichment/actor.rs
@@ -108,7 +108,10 @@ impl EnrichmentActor {
 
     /// Enrich a flow with cached metadata for the specified peer IP.
     fn enrich(&self, peer_ip: IpAddr, flow: FlowInfo) -> Result<FlowInfo, EnrichmentActorError> {
-        debug!("Enriching flow packet from peer: {}", peer_ip);
+        debug!(
+            "Enrichment Actor: received flow packet from peer: {}",
+            peer_ip
+        );
 
         let enriched_flow = match flow {
             FlowInfo::IPFIX(pkt) => self
@@ -130,7 +133,8 @@ impl EnrichmentActor {
     ///
     /// Processes each data record in the packet, applying enrichment fields
     /// that match the observation domain and record contents. Template sets
-    /// are filtered out and not processed further.
+    /// are as well as options data records filtered out and not processed
+    /// further.
     fn enrich_ipfix_packet(
         &self,
         peer_ip: IpAddr,
@@ -149,6 +153,7 @@ impl EnrichmentActor {
                     let enriched_records = records
                         .into_vec()
                         .into_iter()
+                        .filter(|record| record.scope_fields().is_empty())
                         .map(|record| {
                             if let Some(enrichment_fields) = self
                                 .enrichment_cache

--- a/crates/collector/src/flow/enrichment/inputs/flow_options/mod.rs
+++ b/crates/collector/src/flow/enrichment/inputs/flow_options/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (C) 2025-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod actor;
+mod normalize;
+
+pub use actor::FlowOptionsActorHandle;

--- a/crates/collector/src/flow/enrichment/inputs/flow_options/normalize.rs
+++ b/crates/collector/src/flow/enrichment/inputs/flow_options/normalize.rs
@@ -1,0 +1,442 @@
+// Copyright (C) 2025-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module provides functionality for:
+//!
+//! - Classifying options data records by type (Sampling, Interface, VRF)
+//! - Normalizing records into enrichment-ready format
+//! - Converting records to enrichment operations
+
+use crate::flow::{
+    enrichment::{EnrichmentOperation, Scope},
+    types::{FieldRefLookup, IndexedDataRecord},
+};
+use netgauze_flow_pkt::{
+    ie::{netgauze, Field, IE},
+    ipfix,
+};
+use std::{net::IpAddr, string::ToString};
+use tracing::debug;
+
+#[derive(strum_macros::Display, Debug, Clone, PartialEq, Eq)]
+pub enum OptionsDataRecordError {
+    #[strum(to_string = "DataRecord has no scope fields: not an Options Data Record")]
+    NoScopeFields,
+    #[strum(to_string = "Unsupported interface options data record format")]
+    UnsupportedInterfaceType,
+    #[strum(to_string = "Unsupported VRF options data record format")]
+    UnsupportedVrfType,
+    #[strum(to_string = "Missing required fields for {record_type}")]
+    MissingRequiredFields { record_type: String },
+}
+
+impl std::error::Error for OptionsDataRecordError {}
+
+/// Classified options data record
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OptionsDataRecord {
+    Sampling(IndexedDataRecord),
+
+    Interface(IndexedDataRecord),
+
+    Vrf(IndexedDataRecord),
+
+    Unclassified(IndexedDataRecord),
+}
+
+impl TryFrom<ipfix::DataRecord> for OptionsDataRecord {
+    type Error = OptionsDataRecordError;
+
+    fn try_from(record: ipfix::DataRecord) -> Result<Self, Self::Error> {
+        if record.scope_fields().is_empty() {
+            return Err(OptionsDataRecordError::NoScopeFields);
+        }
+
+        let record: IndexedDataRecord = record.into();
+        Ok(Self::classify(record))
+    }
+}
+
+impl From<OptionsDataRecord> for ipfix::DataRecord {
+    fn from(record: OptionsDataRecord) -> Self {
+        match record {
+            OptionsDataRecord::Sampling(record) => record.into(),
+            OptionsDataRecord::Interface(record) => record.into(),
+            OptionsDataRecord::Vrf(record) => record.into(),
+            OptionsDataRecord::Unclassified(record) => record.into(),
+        }
+    }
+}
+
+impl OptionsDataRecord {
+    /// Classify an indexed data record into a specific options type
+    fn classify(record: IndexedDataRecord) -> Self {
+        if Self::is_sampling_type(&record) {
+            debug!("Sampling option data record found");
+            Self::Sampling(record)
+        } else if Self::is_interface_type(&record) {
+            debug!("Interface option data record found");
+            Self::Interface(record)
+        } else if Self::is_vrf_type(&record) {
+            debug!("VRF option data record found");
+            Self::Vrf(record)
+        } else {
+            Self::Unclassified(record)
+        }
+    }
+
+    /// Check if a record contains sampling-related information elements
+    fn is_sampling_type(record: &IndexedDataRecord) -> bool {
+        let has_sampling_interval = record.contains_ie(IE::samplingInterval);
+        let has_sampler_random_interval = record.contains_ie(IE::samplerRandomInterval);
+        let has_sampling_packet_interval = record.contains_ie(IE::samplingPacketInterval);
+        let has_sampling_packet_space = record.contains_ie(IE::samplingPacketSpace);
+        let has_sampling_time_interval = record.contains_ie(IE::samplingTimeInterval);
+        let has_sampling_time_space = record.contains_ie(IE::samplingTimeSpace);
+        let has_sampling_size = record.contains_ie(IE::samplingSize);
+        let has_sampling_population = record.contains_ie(IE::samplingPopulation);
+        let has_sampling_probability = record.contains_ie(IE::samplingProbability);
+
+        has_sampling_interval
+            || has_sampler_random_interval
+            || (has_sampling_packet_interval && has_sampling_packet_space)
+            || (has_sampling_time_interval && has_sampling_time_space)
+            || (has_sampling_size && has_sampling_population)
+            || has_sampling_probability
+    }
+
+    /// Normalize sampling records by filtering and organizing fields
+    fn normalize_sampling_type(record: IndexedDataRecord) -> Vec<IndexedDataRecord> {
+        let mut records = Vec::new();
+
+        let (scope_fields, fields) = record.into_parts();
+
+        let scope_fields: Vec<Field> = scope_fields
+            .into_values()
+            .filter(|field| {
+                !matches!(
+                    field,
+                    Field::paddingOctets(_) | Field::exportingProcessId(_) /* ignore to support
+                                                                            * 6wind */
+                )
+            })
+            .collect();
+
+        let fields: Vec<Field> = fields
+            .into_values()
+            .filter(|field| !matches!(field, Field::paddingOctets(_)))
+            .collect();
+
+        records.push(IndexedDataRecord::new(&scope_fields, &fields));
+        records
+    }
+
+    /// Check if a record contains interface mapping information
+    fn is_interface_type(record: &IndexedDataRecord) -> bool {
+        let has_ingress_interface = record.contains_ie(IE::ingressInterface);
+        let has_egress_interface = record.contains_ie(IE::egressInterface);
+        let has_interface_name = record.contains_ie(IE::interfaceName);
+        let has_interface_description = record.contains_ie(IE::interfaceDescription);
+
+        (has_ingress_interface || has_egress_interface)
+            && (has_interface_name || has_interface_description)
+    }
+
+    /// Create a normalized interface record with ingress or egress specific
+    /// fields
+    fn create_interface_record(
+        iface: &Field,
+        add_scope: &[Field],
+        iface_name: Option<&Field>,
+        iface_desc: Option<&Field>,
+    ) -> Option<IndexedDataRecord> {
+        let mut scope_fields = vec![iface.clone()];
+        scope_fields.extend_from_slice(add_scope);
+
+        let mut fields = Vec::new();
+        match iface {
+            Field::ingressInterface(_) => {
+                if let Some(Field::interfaceName(name)) = iface_name {
+                    fields.push(Field::NetGauze(netgauze::Field::ingressInterfaceName(
+                        name.clone(),
+                    )));
+                }
+                if let Some(Field::interfaceDescription(desc)) = iface_desc {
+                    fields.push(Field::NetGauze(
+                        netgauze::Field::ingressInterfaceDescription(desc.clone()),
+                    ));
+                }
+            }
+            Field::egressInterface(_) => {
+                if let Some(Field::interfaceName(name)) = iface_name {
+                    fields.push(Field::NetGauze(netgauze::Field::egressInterfaceName(
+                        name.clone(),
+                    )));
+                }
+                if let Some(Field::interfaceDescription(desc)) = iface_desc {
+                    fields.push(Field::NetGauze(
+                        netgauze::Field::egressInterfaceDescription(desc.clone()),
+                    ));
+                }
+            }
+            _ => return None,
+        }
+
+        if !fields.is_empty() {
+            Some(IndexedDataRecord::new(&scope_fields, &fields))
+        } else {
+            None
+        }
+    }
+
+    /// Normalize interface records into separate ingress/egress mappings
+    ///
+    /// Creates separate records for ingress and egress interfaces when
+    /// they share the same interface ID, mapping to specific ingress/egress
+    /// interface name and description fields.
+    fn normalize_interface_type(
+        record: IndexedDataRecord,
+    ) -> Result<Vec<IndexedDataRecord>, OptionsDataRecordError> {
+        let in_iface = record.get_by_ie(IE::ingressInterface);
+        let out_iface = record.get_by_ie(IE::egressInterface);
+        let iface_name = record.fields().get_by_ie(IE::interfaceName);
+        let iface_desc = record.fields().get_by_ie(IE::interfaceDescription);
+
+        let add_scope: Vec<_> = record
+            .scope_fields()
+            .values()
+            .filter(|field| {
+                !matches!(
+                    field,
+                    Field::ingressInterface(_)
+                        | Field::egressInterface(_)
+                        | Field::paddingOctets(_)
+                        | Field::exportingProcessId(_) // ignore to support 6wind
+                )
+            })
+            .cloned()
+            .collect();
+
+        let mut records = Vec::new();
+        match (in_iface, out_iface) {
+            (
+                Some(in_iface @ Field::ingressInterface(in_id)),
+                Some(out_iface @ Field::egressInterface(out_id)),
+            ) if in_id == out_id => {
+                // Both interfaces with matching IDs - create both records
+                records.extend(Self::create_interface_record(
+                    in_iface, &add_scope, iface_name, iface_desc,
+                ));
+                records.extend(Self::create_interface_record(
+                    out_iface, &add_scope, iface_name, iface_desc,
+                ));
+            }
+            (Some(iface @ Field::ingressInterface(_)), None) => {
+                // Only ingress interface
+                records.extend(Self::create_interface_record(
+                    iface, &add_scope, iface_name, iface_desc,
+                ));
+            }
+            (None, Some(iface @ Field::egressInterface(_))) => {
+                // Only egress interface
+                records.extend(Self::create_interface_record(
+                    iface, &add_scope, iface_name, iface_desc,
+                ));
+            }
+            _ => {
+                return Err(OptionsDataRecordError::UnsupportedInterfaceType);
+            }
+        }
+
+        if records.is_empty() {
+            return Err(OptionsDataRecordError::MissingRequiredFields {
+                record_type: "interface".to_string(),
+            });
+        }
+
+        Ok(records)
+    }
+
+    /// Check if a record contains VRF mapping information
+    fn is_vrf_type(record: &IndexedDataRecord) -> bool {
+        let has_ingress_vrfid = record.contains_ie(IE::ingressVRFID);
+        let has_egress_vrfid = record.contains_ie(IE::egressVRFID);
+        let has_vrf_name = record.contains_ie(IE::VRFname);
+        let has_rd = record.contains_ie(IE::mplsVpnRouteDistinguisher);
+
+        (has_ingress_vrfid || has_egress_vrfid) && (has_vrf_name || has_rd)
+    }
+
+    /// Create a normalized vrf record with ingress or egress specific fields
+    fn create_vrf_record(
+        vrf: &Field,
+        add_scope: &[Field],
+        vrf_name: Option<&Field>,
+        rd: Option<&Field>,
+    ) -> Option<IndexedDataRecord> {
+        let mut scope_fields = vec![vrf.clone()];
+        scope_fields.extend_from_slice(add_scope);
+
+        let mut fields = Vec::new();
+        match vrf {
+            Field::ingressVRFID(_) => {
+                if let Some(Field::VRFname(name)) = vrf_name {
+                    fields.push(Field::NetGauze(netgauze::Field::ingressVRFname(
+                        name.clone(),
+                    )));
+                }
+                if let Some(Field::mplsVpnRouteDistinguisher(rd_val)) = rd {
+                    fields.push(Field::NetGauze(
+                        netgauze::Field::ingressMplsVpnRouteDistinguisher(rd_val.clone()),
+                    ));
+                }
+            }
+            Field::egressVRFID(_) => {
+                if let Some(Field::VRFname(name)) = vrf_name {
+                    fields.push(Field::NetGauze(netgauze::Field::egressVRFname(
+                        name.clone(),
+                    )));
+                }
+                if let Some(Field::mplsVpnRouteDistinguisher(rd_val)) = rd {
+                    fields.push(Field::NetGauze(
+                        netgauze::Field::egressMplsVpnRouteDistinguisher(rd_val.clone()),
+                    ));
+                }
+            }
+            _ => return None,
+        }
+
+        if !fields.is_empty() {
+            Some(IndexedDataRecord::new(&scope_fields, &fields))
+        } else {
+            None
+        }
+    }
+
+    /// Normalize VRF records into separate ingress/egress mappings
+    ///
+    /// Creates separate records for ingress and egress VRFs when they
+    /// share the same VRF ID, mapping to specific ingress/egress VRF name
+    /// and route distinguisher fields.
+    fn normalize_vrf_type(
+        record: IndexedDataRecord,
+    ) -> Result<Vec<IndexedDataRecord>, OptionsDataRecordError> {
+        let in_vrf = record.get_by_ie(IE::ingressVRFID);
+        let out_vrf = record.get_by_ie(IE::egressVRFID);
+        let vrf_name = record.fields().get_by_ie(IE::VRFname);
+        let rd = record.fields().get_by_ie(IE::mplsVpnRouteDistinguisher);
+
+        let add_scope: Vec<_> = record
+            .scope_fields()
+            .values()
+            .filter(|field| {
+                !matches!(
+                    field,
+                    Field::ingressVRFID(_)
+                        | Field::egressVRFID(_)
+                        | Field::paddingOctets(_)
+                        | Field::exportingProcessId(_) // ignore to support 6wind
+                )
+            })
+            .cloned()
+            .collect();
+
+        let mut records = Vec::new();
+        match (in_vrf, out_vrf) {
+            (
+                Some(in_vrf @ Field::ingressVRFID(in_id)),
+                Some(out_vrf @ Field::egressVRFID(out_id)),
+            ) if in_id == out_id => {
+                // Both VRFs with matching IDs - create both records
+                records.extend(Self::create_vrf_record(in_vrf, &add_scope, vrf_name, rd));
+                records.extend(Self::create_vrf_record(out_vrf, &add_scope, vrf_name, rd));
+            }
+            (Some(vrf @ Field::ingressVRFID(_)), None) => {
+                // Single ingress VRF
+                records.extend(Self::create_vrf_record(vrf, &add_scope, vrf_name, rd));
+            }
+            (None, Some(vrf @ Field::egressVRFID(_))) => {
+                // Single egress VRF
+                records.extend(Self::create_vrf_record(vrf, &add_scope, vrf_name, rd));
+            }
+            _ => {
+                return Err(OptionsDataRecordError::UnsupportedVrfType);
+            }
+        }
+
+        if records.is_empty() {
+            return Err(OptionsDataRecordError::MissingRequiredFields {
+                record_type: "VRF".to_string(),
+            });
+        }
+
+        Ok(records)
+    }
+
+    /// Create an enrichment upsert operation from a data record
+    fn upsert_from_rec(
+        peer_ip: IpAddr,
+        obs_id: u32,
+        weight: u8,
+        record: &IndexedDataRecord,
+    ) -> EnrichmentOperation {
+        EnrichmentOperation::Upsert {
+            ip: peer_ip,
+            scope: Scope::new(
+                obs_id,
+                Some(record.scope_fields().values().cloned().collect()),
+            ),
+            weight,
+            fields: record.fields().values().cloned().collect(),
+        }
+    }
+
+    /// Generate enrichment upsert operations from this options record
+    ///
+    /// Normalizes the record based on its type and creates appropriate
+    /// enrichment operations for each normalized record.
+    pub fn into_enrichment_operations(
+        self,
+        peer_ip: IpAddr,
+        obs_id: u32,
+    ) -> Result<Vec<EnrichmentOperation>, OptionsDataRecordError> {
+        let mut ops = Vec::new();
+
+        match self {
+            OptionsDataRecord::Sampling(record) => {
+                for rec in Self::normalize_sampling_type(record) {
+                    ops.push(Self::upsert_from_rec(peer_ip, obs_id, 16, &rec));
+                }
+            }
+            OptionsDataRecord::Interface(record) => {
+                for rec in Self::normalize_interface_type(record)? {
+                    ops.push(Self::upsert_from_rec(peer_ip, obs_id, 16, &rec));
+                }
+            }
+            OptionsDataRecord::Vrf(record) => {
+                for rec in Self::normalize_vrf_type(record)? {
+                    ops.push(Self::upsert_from_rec(peer_ip, obs_id, 16, &rec));
+                }
+            }
+            OptionsDataRecord::Unclassified(record) => {
+                ops.push(Self::upsert_from_rec(peer_ip, obs_id, 10, &record));
+            }
+        }
+        Ok(ops)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/collector/src/flow/enrichment/inputs/flow_options/normalize/tests.rs
+++ b/crates/collector/src/flow/enrichment/inputs/flow_options/normalize/tests.rs
@@ -1,0 +1,603 @@
+// Copyright (C) 2025-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::flow::enrichment::inputs::flow_options::normalize::*;
+use netgauze_flow_pkt::ie::Field;
+use std::net::{IpAddr, Ipv4Addr};
+
+#[test]
+fn test_options_data_record_try_from_valid_scope_fields() {
+    let scope_fields = vec![Field::selectorId(42)];
+    let fields = vec![Field::samplingInterval(1000)];
+
+    let ipfix_record =
+        ipfix::DataRecord::new(scope_fields.into_boxed_slice(), fields.into_boxed_slice());
+
+    let result = OptionsDataRecord::try_from(ipfix_record);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_options_data_record_try_from_no_scope_fields() {
+    let fields = vec![Field::samplingInterval(1000)];
+
+    let ipfix_record = ipfix::DataRecord::new(Box::new([]), fields.into_boxed_slice());
+
+    let result = OptionsDataRecord::try_from(ipfix_record);
+    assert!(matches!(result, Err(OptionsDataRecordError::NoScopeFields)));
+}
+
+#[test]
+fn test_is_sampling_type_sampling_interval() {
+    let scope_fields = vec![Field::selectorId(1)];
+    let fields = vec![Field::samplingInterval(1000)];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_sampling_type(&record));
+}
+
+#[test]
+fn test_is_sampling_type_sampler_random_interval() {
+    let scope_fields = vec![Field::observationPointId(1)];
+    let fields = vec![Field::samplerRandomInterval(500)];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_sampling_type(&record));
+}
+
+#[test]
+fn test_is_sampling_type_packet_interval_and_space() {
+    let scope_fields = vec![Field::selectorId(2)];
+    let fields = vec![
+        Field::samplingPacketInterval(10),
+        Field::samplingPacketSpace(90),
+    ];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_sampling_type(&record));
+}
+
+#[test]
+fn test_is_sampling_type_packet_interval_only() {
+    let scope_fields = vec![Field::selectorId(2)];
+    let fields = vec![Field::samplingPacketInterval(10)];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    // Should be false - needs both interval and space
+    assert!(!OptionsDataRecord::is_sampling_type(&record));
+}
+
+#[test]
+fn test_is_sampling_type_time_interval_and_space() {
+    let scope_fields = vec![Field::selectorId(3)];
+    let fields = vec![
+        Field::samplingTimeInterval(1000),
+        Field::samplingTimeSpace(9000),
+    ];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_sampling_type(&record));
+}
+
+#[test]
+fn test_is_sampling_type_size_and_population() {
+    let scope_fields = vec![Field::selectorId(4)];
+    let fields = vec![Field::samplingSize(100), Field::samplingPopulation(1000)];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_sampling_type(&record));
+}
+
+#[test]
+fn test_is_sampling_type_sampling_probability() {
+    let scope_fields = vec![Field::selectorId(5)];
+    let fields = vec![Field::samplingProbability(ordered_float::OrderedFloat(0.1))];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_sampling_type(&record));
+}
+
+#[test]
+fn test_is_sampling_type_false() {
+    let scope_fields = vec![Field::selectorId(1)];
+    let fields = vec![Field::interfaceName("eth0".to_string().into())];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(!OptionsDataRecord::is_sampling_type(&record));
+}
+
+#[test]
+fn test_normalize_sampling_type_basic() {
+    let scope_fields = vec![Field::selectorId(42)];
+    let fields = vec![
+        Field::samplingInterval(1000),
+        Field::paddingOctets(Box::new([0, 0, 0, 0])),
+    ];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let results = OptionsDataRecord::normalize_sampling_type(record);
+
+    // Construct expected normalized record
+    let expected_scope_fields = vec![Field::selectorId(42)];
+    let expected_fields = vec![Field::samplingInterval(1000)];
+    let expected_record = IndexedDataRecord::new(&expected_scope_fields, &expected_fields);
+    let expected_records = vec![expected_record];
+
+    assert_eq!(results, expected_records);
+}
+
+#[test]
+fn test_normalize_sampling_type_filters_exporting_process_id() {
+    let scope_fields = vec![
+        Field::selectorId(42),
+        Field::exportingProcessId(123),
+        Field::paddingOctets(Box::new([0, 0])),
+        Field::applicationGroupName("app-scope".into()),
+    ];
+    let fields = vec![
+        Field::samplingInterval(1000),
+        Field::paddingOctets(Box::new([0, 0, 0, 0])),
+        Field::samplingAlgorithm(2),
+    ];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let results = OptionsDataRecord::normalize_sampling_type(record);
+
+    // Construct expected normalized record
+    let expected_scope_fields = vec![
+        Field::selectorId(42),
+        Field::applicationGroupName("app-scope".into()),
+    ];
+    let expected_fields = vec![Field::samplingInterval(1000), Field::samplingAlgorithm(2)];
+    let expected_record = IndexedDataRecord::new(&expected_scope_fields, &expected_fields);
+    let expected_records = vec![expected_record];
+
+    assert_eq!(results, expected_records);
+}
+
+#[test]
+fn test_is_interface_type_ingress_and_name() {
+    let scope_fields = vec![Field::ingressInterface(1)];
+    let fields = vec![Field::interfaceName("eth0".to_string().into())];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_interface_type(&record));
+}
+
+#[test]
+fn test_is_interface_type_egress_and_description() {
+    let scope_fields = vec![Field::egressInterface(2)];
+    let fields = vec![Field::interfaceDescription(
+        "Management Interface".to_string().into(),
+    )];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_interface_type(&record));
+}
+
+#[test]
+fn test_is_interface_type_interface_only() {
+    let scope_fields = vec![Field::ingressInterface(1)];
+    let fields = vec![Field::octetDeltaCount(1000)];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    // Should be false - needs name or description
+    assert!(!OptionsDataRecord::is_interface_type(&record));
+}
+
+#[test]
+fn test_is_interface_type_name_only() {
+    let scope_fields = vec![Field::selectorId(1)];
+    let fields = vec![Field::interfaceName("eth0".to_string().into())];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    // Should be false - needs interface field
+    assert!(!OptionsDataRecord::is_interface_type(&record));
+}
+
+#[test]
+fn test_normalize_interface_type_matching_interfaces() {
+    let scope_fields = vec![
+        Field::ingressInterface(1),
+        Field::egressInterface(1),
+        Field::selectorId(42),
+    ];
+    let fields = vec![
+        Field::interfaceName("eth0".to_string().into()),
+        Field::interfaceDescription("MGMT Interface".to_string().into()),
+    ];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_interface_type(record).unwrap();
+
+    // Construct expected records vec
+    let mut expected = Vec::new();
+
+    // Expected ingress record
+    let expected_ingress_scope = vec![Field::ingressInterface(1), Field::selectorId(42)];
+    let expected_ingress_fields = vec![
+        Field::NetGauze(netgauze::Field::ingressInterfaceName(
+            "eth0".to_string().into(),
+        )),
+        Field::NetGauze(netgauze::Field::ingressInterfaceDescription(
+            "MGMT Interface".to_string().into(),
+        )),
+    ];
+    expected.push(IndexedDataRecord::new(
+        &expected_ingress_scope,
+        &expected_ingress_fields,
+    ));
+
+    // Expected egress record
+    let expected_egress_scope = vec![Field::egressInterface(1), Field::selectorId(42)];
+    let expected_egress_fields = vec![
+        Field::NetGauze(netgauze::Field::egressInterfaceName(
+            "eth0".to_string().into(),
+        )),
+        Field::NetGauze(netgauze::Field::egressInterfaceDescription(
+            "MGMT Interface".to_string().into(),
+        )),
+    ];
+    expected.push(IndexedDataRecord::new(
+        &expected_egress_scope,
+        &expected_egress_fields,
+    ));
+
+    // Check if results contain expected records (order might vary)
+    assert_eq!(expected, normalized);
+}
+
+#[test]
+fn test_normalize_interface_type_ingress_only() {
+    let scope_fields = vec![
+        Field::ingressInterface(1),
+        Field::selectorId(42),
+        Field::paddingOctets(Box::new([0, 0, 0])),
+    ];
+    let fields = vec![
+        Field::interfaceName("eth1".to_string().into()),
+        Field::interfaceDescription("Ingress Interface".to_string().into()),
+    ];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_interface_type(record).unwrap();
+
+    // Construct expected records vec
+    let mut expected = Vec::new();
+
+    let expected_scope = vec![Field::ingressInterface(1), Field::selectorId(42)];
+    let expected_fields = vec![
+        Field::NetGauze(netgauze::Field::ingressInterfaceName(
+            "eth1".to_string().into(),
+        )),
+        Field::NetGauze(netgauze::Field::ingressInterfaceDescription(
+            "Ingress Interface".to_string().into(),
+        )),
+    ];
+    expected.push(IndexedDataRecord::new(&expected_scope, &expected_fields));
+
+    assert_eq!(expected, normalized);
+}
+
+#[test]
+fn test_normalize_interface_type_egress_only() {
+    let scope_fields = vec![Field::egressInterface(2), Field::observationPointId(100)];
+    let fields = vec![Field::interfaceName("eth2".to_string().into())];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_interface_type(record).unwrap();
+
+    // Construct expected records vec
+    let mut expected = Vec::new();
+
+    let expected_scope = vec![Field::egressInterface(2), Field::observationPointId(100)];
+    let expected_fields = vec![Field::NetGauze(netgauze::Field::egressInterfaceName(
+        "eth2".to_string().into(),
+    ))];
+    expected.push(IndexedDataRecord::new(&expected_scope, &expected_fields));
+
+    assert_eq!(expected, normalized);
+}
+
+#[test]
+fn test_normalize_interface_type_different_interfaces() {
+    let scope_fields = vec![Field::ingressInterface(1), Field::egressInterface(2)];
+    let fields = vec![Field::interfaceName("eth0".to_string().into())];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_interface_type(record);
+
+    assert!(matches!(
+        normalized,
+        Err(OptionsDataRecordError::UnsupportedInterfaceType)
+    ));
+}
+
+#[test]
+fn test_normalize_interface_type_empty_fields() {
+    let scope_fields = vec![Field::ingressInterface(1)];
+    let fields: Vec<Field> = vec![];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_interface_type(record);
+
+    assert_eq!(
+        normalized,
+        Err(OptionsDataRecordError::MissingRequiredFields {
+            record_type: "interface".to_string(),
+        })
+    );
+}
+
+#[test]
+fn test_is_vrf_type_ingress_and_name() {
+    let scope_fields = vec![Field::ingressVRFID(100)];
+    let fields = vec![Field::VRFname("management".to_string().into())];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_vrf_type(&record));
+}
+
+#[test]
+fn test_is_vrf_type_egress_and_rd() {
+    let scope_fields = vec![Field::egressVRFID(200)];
+    let fields = vec![Field::mplsVpnRouteDistinguisher(Box::new([
+        1, 2, 3, 4, 5, 6, 7, 8,
+    ]))];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    assert!(OptionsDataRecord::is_vrf_type(&record));
+}
+
+#[test]
+fn test_is_vrf_type_vrf_only() {
+    let scope_fields = vec![Field::ingressVRFID(100)];
+    let fields = vec![Field::octetDeltaCount(1000)];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+
+    // Should be false - needs name or RD
+    assert!(!OptionsDataRecord::is_vrf_type(&record));
+}
+
+#[test]
+fn test_normalize_vrf_type_matching_vrfs() {
+    let scope_fields = vec![
+        Field::ingressVRFID(100),
+        Field::egressVRFID(100),
+        Field::observationPointId(42),
+    ];
+    let fields = vec![
+        Field::VRFname("customer_a".to_string().into()),
+        Field::mplsVpnRouteDistinguisher(Box::new([1, 2, 3, 4, 5, 6, 7, 8])),
+    ];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_vrf_type(record).unwrap();
+
+    // Construct expected records vec
+    let mut expected = Vec::new();
+
+    // Expected ingress record
+    let expected_ingress_scope = vec![Field::ingressVRFID(100), Field::observationPointId(42)];
+    let expected_ingress_fields = vec![
+        Field::NetGauze(netgauze::Field::ingressVRFname(
+            "customer_a".to_string().into(),
+        )),
+        Field::NetGauze(netgauze::Field::ingressMplsVpnRouteDistinguisher(Box::new(
+            [1, 2, 3, 4, 5, 6, 7, 8],
+        ))),
+    ];
+    expected.push(IndexedDataRecord::new(
+        &expected_ingress_scope,
+        &expected_ingress_fields,
+    ));
+
+    // Expected egress record
+    let expected_egress_scope = vec![Field::egressVRFID(100), Field::observationPointId(42)];
+    let expected_egress_fields = vec![
+        Field::NetGauze(netgauze::Field::egressVRFname(
+            "customer_a".to_string().into(),
+        )),
+        Field::NetGauze(netgauze::Field::egressMplsVpnRouteDistinguisher(Box::new(
+            [1, 2, 3, 4, 5, 6, 7, 8],
+        ))),
+    ];
+    expected.push(IndexedDataRecord::new(
+        &expected_egress_scope,
+        &expected_egress_fields,
+    ));
+
+    assert_eq!(normalized, expected);
+}
+
+#[test]
+fn test_normalize_vrf_type_ingress_only() {
+    let scope_fields = vec![Field::ingressVRFID(100), Field::observationPointId(42)];
+    let fields = vec![
+        Field::VRFname("VRF 100".to_string().into()),
+        Field::mplsVpnRouteDistinguisher(Box::new([1, 0, 0, 4, 3, 4, 3, 3])),
+    ];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_vrf_type(record).unwrap();
+
+    // Construct expected records vec
+    let mut expected = Vec::new();
+
+    let expected_scope = vec![Field::ingressVRFID(100), Field::observationPointId(42)];
+    let expected_fields = vec![
+        Field::NetGauze(netgauze::Field::ingressVRFname(
+            "VRF 100".to_string().into(),
+        )),
+        Field::NetGauze(netgauze::Field::ingressMplsVpnRouteDistinguisher(Box::new(
+            [1, 0, 0, 4, 3, 4, 3, 3],
+        ))),
+    ];
+    expected.push(IndexedDataRecord::new(&expected_scope, &expected_fields));
+
+    assert_eq!(normalized, expected);
+}
+
+#[test]
+fn test_normalize_vrf_type_egress_only() {
+    let scope_fields = vec![Field::egressVRFID(200)];
+    let fields = vec![Field::VRFname("VRF 200".to_string().into())];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_vrf_type(record).unwrap();
+
+    // Construct expected records vec
+    let mut expected = Vec::new();
+
+    let expected_scope = vec![Field::egressVRFID(200)];
+    let expected_fields = vec![Field::NetGauze(netgauze::Field::egressVRFname(
+        "VRF 200".to_string().into(),
+    ))];
+    expected.push(IndexedDataRecord::new(&expected_scope, &expected_fields));
+
+    assert_eq!(normalized, expected);
+}
+
+#[test]
+fn test_normalize_vrf_type_different_vrfs() {
+    let scope_fields = vec![Field::ingressVRFID(100), Field::egressVRFID(200)];
+    let fields = vec![Field::VRFname("customer_a".to_string().into())];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_vrf_type(record);
+
+    assert!(matches!(
+        normalized,
+        Err(OptionsDataRecordError::UnsupportedVrfType)
+    ));
+}
+
+#[test]
+fn test_normalize_vrf_type_empty_fields() {
+    let scope_fields = vec![Field::ingressVRFID(100)];
+    let fields: Vec<Field> = vec![];
+
+    let record = IndexedDataRecord::new(&scope_fields, &fields);
+    let normalized = OptionsDataRecord::normalize_vrf_type(record);
+
+    assert_eq!(
+        normalized,
+        Err(OptionsDataRecordError::MissingRequiredFields {
+            record_type: "VRF".to_string(),
+        })
+    );
+}
+
+#[test]
+fn test_into_enrichment_operations_sampling() {
+    let scope_fields = vec![Field::selectorId(42)];
+    let fields = vec![Field::samplingInterval(1000)];
+
+    let indexed_record = IndexedDataRecord::new(&scope_fields, &fields);
+    let options_record = OptionsDataRecord::Sampling(indexed_record);
+
+    let peer_ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+    let obs_id = 100;
+
+    let ops = options_record
+        .into_enrichment_operations(peer_ip, obs_id)
+        .unwrap();
+
+    let expected_ops = vec![EnrichmentOperation::Upsert {
+        ip: peer_ip,
+        scope: Scope::new(obs_id, Some(scope_fields)),
+        weight: 16,
+        fields,
+    }];
+
+    assert_eq!(ops, expected_ops);
+}
+
+#[test]
+fn test_into_enrichment_operations_interface_matching_ids() {
+    let scope_fields = vec![Field::ingressInterface(1), Field::egressInterface(1)];
+    let fields = vec![Field::interfaceName("eth0".to_string().into())];
+
+    let indexed_record = IndexedDataRecord::new(&scope_fields, &fields);
+    let options_record = OptionsDataRecord::Interface(indexed_record);
+
+    let peer_ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+    let obs_id = 200;
+
+    let ops = options_record
+        .into_enrichment_operations(peer_ip, obs_id)
+        .unwrap();
+
+    let expected_ops = vec![
+        EnrichmentOperation::Upsert {
+            ip: peer_ip,
+            scope: Scope::new(obs_id, Some(vec![Field::ingressInterface(1)])),
+            weight: 16,
+            fields: vec![Field::NetGauze(netgauze::Field::ingressInterfaceName(
+                "eth0".to_string().into(),
+            ))],
+        },
+        EnrichmentOperation::Upsert {
+            ip: peer_ip,
+            scope: Scope::new(obs_id, Some(vec![Field::egressInterface(1)])),
+            weight: 16,
+            fields: vec![Field::NetGauze(netgauze::Field::egressInterfaceName(
+                "eth0".to_string().into(),
+            ))],
+        },
+    ];
+
+    assert_eq!(ops, expected_ops);
+}
+
+#[test]
+fn test_into_enrichment_operations_unclassified() {
+    let scope_fields = vec![Field::selectorId(1)];
+    let fields = vec![Field::octetDeltaCount(1000)];
+
+    let indexed_record = IndexedDataRecord::new(&scope_fields, &fields);
+    let options_record = OptionsDataRecord::Unclassified(indexed_record);
+
+    let peer_ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+    let obs_id = 300;
+
+    let ops = options_record
+        .into_enrichment_operations(peer_ip, obs_id)
+        .unwrap();
+
+    let expected_ops = vec![EnrichmentOperation::Upsert {
+        ip: peer_ip,
+        scope: Scope::new(obs_id, Some(scope_fields)),
+        weight: 10,
+        fields,
+    }];
+
+    assert_eq!(ops, expected_ops);
+}

--- a/crates/collector/src/flow/enrichment/mod.rs
+++ b/crates/collector/src/flow/enrichment/mod.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 
 /// Operations to update or delete enrichment data
-#[derive(Debug, Clone, strum_macros::Display)]
+#[derive(Debug, Clone, PartialEq, Eq, strum_macros::Display)]
 pub enum EnrichmentOperation {
     #[strum(to_string = "Upsert(ip={ip}, scope={scope}, weight={weight}, fields={fields:?})")]
     Upsert {


### PR DESCRIPTION
**Depends on PR #262.** 

### Summary
This PR enhances the flow options handler actor with IPFIX options type classification and normalization capabilities to support various vendor implementations. Normalization is mainly required to handle options records that misuse the IPFIX scoping logic. 

Interface and VRF records are split into separate ingress/egress mappings before being inserted in the cache. Some IEs are being stripped from the scope due to wrong vendor usage.

In a future PR we will add config knobs to enable/disable these normalization steps as well as customize the weights of the various enrichment operations produces from those options records.
