### PR TITLE
Telemetry Message: align to newest draft version 02

### DIFF
--- a/crates/yang-push/src/enrichment.rs
+++ b/crates/yang-push/src/enrichment.rs
@@ -678,7 +678,7 @@ mod tests {
             )
         );
         assert_eq!(
-            peer_subscription.module_version(),
+            peer_subscription.module(),
             Vec::new() // default
         );
         assert_eq!(peer_subscription.yang_library_content_id(), None);

--- a/crates/yang-push/src/model/notification.rs
+++ b/crates/yang-push/src/model/notification.rs
@@ -486,35 +486,37 @@ pub enum ChangeType {
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct YangPushModuleVersion {
-    module_name: String,
+    /// Alias 'module-name' still supported
+    /// (draft-ietf-netconf-yang-notifications-versioning < 9)
+    #[serde(alias = "module-name")]
+    name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     revision: Option<String>,
 
+    /// Alias 'revision-label' still supported
+    /// (draft-ietf-netconf-yang-notifications-versioning < 9)
+    #[serde(alias = "revision-label")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    revision_label: Option<String>,
+    version: Option<String>,
 }
 
 impl YangPushModuleVersion {
-    pub fn new(
-        module_name: String,
-        revision: Option<String>,
-        revision_label: Option<String>,
-    ) -> Self {
+    pub fn new(name: String, revision: Option<String>, version: Option<String>) -> Self {
         Self {
-            module_name,
+            name,
             revision,
-            revision_label,
+            version,
         }
     }
-    pub fn module_name(&self) -> &str {
-        &self.module_name
+    pub fn name(&self) -> &str {
+        &self.name
     }
     pub fn revision(&self) -> Option<&str> {
         self.revision.as_deref()
     }
-    pub fn revision_label(&self) -> Option<&str> {
-        self.revision_label.as_deref()
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
     }
 }
 
@@ -671,9 +673,9 @@ mod tests {
                 excluded_change: Some(vec![ChangeType::Create, ChangeType::Replace]),
             }),
             module_version: Some(vec![YangPushModuleVersion {
-                module_name: "example-module".to_string(),
+                name: "example-module".to_string(),
                 revision: Some("2025-04-25".to_string()),
-                revision_label: None,
+                version: None,
             }]),
             yang_library_content_id: Some("content-id".to_string()),
             extra_fields: serde_json::json!({}),
@@ -765,9 +767,9 @@ mod tests {
                 excluded_change: Some(vec![ChangeType::Create, ChangeType::Replace]),
             }),
             module_version: Some(vec![YangPushModuleVersion {
-                module_name: "example-module".to_string(),
+                name: "example-module".to_string(),
                 revision: Some("2025-04-25".to_string()),
-                revision_label: None,
+                version: None,
             }]),
             yang_library_content_id: Some("content-id".to_string()),
             extra_fields: serde_json::json!({}),

--- a/crates/yang-push/src/model/telemetry.rs
+++ b/crates/yang-push/src/model/telemetry.rs
@@ -282,7 +282,7 @@ pub struct YangPushSubscriptionMetadata {
     #[serde(flatten)]
     update_trigger: Option<UpdateTrigger>,
 
-    module_version: Vec<YangPushModuleVersion>,
+    module: Vec<YangPushModuleVersion>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     yang_library_content_id: Option<String>,
@@ -298,7 +298,7 @@ impl YangPushSubscriptionMetadata {
         encoding: Option<Encoding>,
         purpose: Option<String>,
         update_trigger: Option<UpdateTrigger>,
-        module_version: Vec<YangPushModuleVersion>,
+        module: Vec<YangPushModuleVersion>,
         yang_library_content_id: Option<String>,
     ) -> Self {
         Self {
@@ -309,7 +309,7 @@ impl YangPushSubscriptionMetadata {
             encoding,
             purpose,
             update_trigger,
-            module_version,
+            module,
             yang_library_content_id,
         }
     }
@@ -334,8 +334,8 @@ impl YangPushSubscriptionMetadata {
     pub fn update_trigger(&self) -> Option<&UpdateTrigger> {
         self.update_trigger.as_ref()
     }
-    pub fn module_version(&self) -> &[YangPushModuleVersion] {
-        &self.module_version
+    pub fn module(&self) -> &[YangPushModuleVersion] {
+        &self.module
     }
     pub fn yang_library_content_id(&self) -> Option<&str> {
         self.yang_library_content_id.as_deref()
@@ -528,7 +528,7 @@ mod tests {
                             period: Some(CentiSeconds::new(100)),
                             anchor_time: Some(Utc.timestamp_millis_opt(0).unwrap()),
                         }),
-                        module_version: vec![YangPushModuleVersion::new(
+                        module: vec![YangPushModuleVersion::new(
                             "example-module".to_string(),
                             Some("2025-01-01".to_string()),
                             Some("1.0.0".to_string()),
@@ -569,7 +569,7 @@ mod tests {
         let serialized = serde_json::to_string(&original_message).expect("Failed to serialize");
 
         // Expected JSON string
-        let expected_json = r#"{"ietf-telemetry-message:message":{"network-node-manifest":{"name":"node_id","vendor":"FRR"},"telemetry-message-metadata":{"collection-timestamp":"1970-01-01T00:00:00Z","session-protocol":"yp-push","export-address":"127.0.0.1","export-port":8080,"ietf-yang-push-telemetry-message:yang-push-subscription":{"id":1,"stream":"example-stream-subtree-filter-map","subtree-filter":{"example-map":{"e1":"v1","e2":"v2"}},"transport":"ietf-udp-notif-transport:udp-notif","encoding":"ietf-subscribed-notifications:encode-json","periodic":{"period":100,"anchor-time":"1970-01-01T00:00:00Z"},"module-version":[{"module-name":"example-module","revision":"2025-01-01","revision-label":"1.0.0"}],"yang-library-content-id":"random-content-id"}},"data-collection-manifest":{"name":"dev-collector","vendor":"NetGauze","vendor-pen":12345,"software-version":"1.0.0","software-flavor":"release","os-version":"8.10","os-type":"Rocky Linux"},"network-operator-metadata":{"labels":[{"name":"platform_id","string-value":"IETF LAB"},{"name":"test_anykey_label","anydata-values":{"key":"value"}}]}}}"#;
+        let expected_json = r#"{"ietf-telemetry-message:message":{"network-node-manifest":{"name":"node_id","vendor":"FRR"},"telemetry-message-metadata":{"collection-timestamp":"1970-01-01T00:00:00Z","session-protocol":"yp-push","export-address":"127.0.0.1","export-port":8080,"ietf-yang-push-telemetry-message:yang-push-subscription":{"id":1,"stream":"example-stream-subtree-filter-map","subtree-filter":{"example-map":{"e1":"v1","e2":"v2"}},"transport":"ietf-udp-notif-transport:udp-notif","encoding":"ietf-subscribed-notifications:encode-json","periodic":{"period":100,"anchor-time":"1970-01-01T00:00:00Z"},"module":[{"name":"example-module","revision":"2025-01-01","version":"1.0.0"}],"yang-library-content-id":"random-content-id"}},"data-collection-manifest":{"name":"dev-collector","vendor":"NetGauze","vendor-pen":12345,"software-version":"1.0.0","software-flavor":"release","os-version":"8.10","os-type":"Rocky Linux"},"network-operator-metadata":{"labels":[{"name":"platform_id","string-value":"IETF LAB"},{"name":"test_anykey_label","anydata-values":{"key":"value"}}]}}}"#;
 
         // Assert that the serialized JSON string matches the expected JSON string
         assert_eq!(


### PR DESCRIPTION
Align to latest version of the draft: https://datatracker.ietf.org/doc/html/draft-ietf-nmop-message-broker-telemetry-message.

For the moment we still support the older module-name and revision-label keys for decoding (thanks to serde alias)