### PR TITLE
Improve Aggregation Actor OTEL statistic counters

### DIFF
--- a/crates/collector/src/flow/aggregation/actor.rs
+++ b/crates/collector/src/flow/aggregation/actor.rs
@@ -53,9 +53,10 @@ use tracing::{debug, error, info, trace, warn};
 #[derive(Debug, Clone)]
 pub struct AggregationStats {
     pub received_messages: Counter<u64>,
-    pub aggregated_messages: Counter<u64>,
     pub late_messages: Counter<u64>,
-    pub sent_messages: Counter<u64>,
+    pub exploded_records: Counter<u64>,
+    pub aggregated_records: Counter<u64>,
+    pub sent: Counter<u64>,
     pub send_timeout: Counter<u64>,
     pub send_error: Counter<u64>,
 }
@@ -66,33 +67,38 @@ impl AggregationStats {
             .u64_counter("netgauze.collector.flows.aggregation.received.messages")
             .with_description("Number of flow messages received for aggregation")
             .build();
-        let aggregated_messages = meter
-            .u64_counter("netgauze.collector.flows.aggregation.aggregated.messages")
-            .with_description("Number of flat flow messages aggregated")
-            .build();
         let late_messages = meter
             .u64_counter("netgauze.collector.flows.aggregation.late.messages")
-            .with_description("Number of late messages discarded")
+            .with_description("Number of late flow messages discarded")
             .build();
-        let sent_messages = meter
-            .u64_counter("netgauze.collector.flows.aggregation.sent.messages")
-            .with_description("Number of aggregated messages successfully sent upstream")
+        let exploded_records = meter
+            .u64_counter("netgauze.collector.flows.aggregation.exploded.records")
+            .with_description("Number of flat flow records exploded")
+            .build();
+        let aggregated_records = meter
+            .u64_counter("netgauze.collector.flows.aggregation.aggregated.records")
+            .with_description("Number of flat flow records aggregated")
+            .build();
+        let sent = meter
+            .u64_counter("netgauze.collector.flows.aggregation.sent")
+            .with_description("Number of aggregated records successfully sent upstream")
             .build();
         let send_timeout = meter
             .u64_counter("netgauze.collector.flows.aggregation.send.timeout")
             .with_description(
-                "Number aggregated messages timed out and dropped while sending to upstream",
+                "Number of aggregated records timed out and dropped while sending to upstream",
             )
             .build();
         let send_error = meter
             .u64_counter("netgauze.collector.flows.aggregation.send.error")
-            .with_description("Number aggregated messages sent upstream error")
+            .with_description("Number of aggregated records sent upstream error")
             .build();
         Self {
             received_messages,
-            aggregated_messages,
             late_messages,
-            sent_messages,
+            exploded_records,
+            aggregated_records,
+            sent,
             send_timeout,
             send_error,
         }
@@ -164,7 +170,12 @@ impl AggregationActor {
                 ];
                 stats.received_messages.add(1, &tags);
 
-                stream::iter(explode(&flow, peer, key_select, agg_select, Utc::now()))
+                // Explode the FlowInfo into single-record FlowInfos
+                let (exploded_count, records) =
+                    explode(&flow, peer, key_select, agg_select, Utc::now());
+                stats.exploded_records.add(exploded_count as u64, &tags);
+
+                stream::iter(records)
             })
             .window_aggregate(
                 unified_config.window_duration(),
@@ -204,6 +215,14 @@ impl AggregationActor {
                                 }
                             };
 
+                            let tags = [
+                                opentelemetry::KeyValue::new("shard_id", opentelemetry::Value::I64(self.shard_id as i64)),
+                                opentelemetry::KeyValue::new(
+                                    "network.peer.address",
+                                    format!("{peer_ip}"),
+                                ),
+                            ];
+
                             let exporter_ip = match peer_ip {
                                 IpAddr::V4(ipv4) => Field::originalExporterIPv4Address(ipv4),
                                 IpAddr::V6(ipv6) => Field::originalExporterIPv6Address(ipv6),
@@ -213,14 +232,7 @@ impl AggregationActor {
 
                             tokio::spawn(async move {
                                 for entry in cache.into_iter().map(AggFlowInfo::from) {
-                                    let tags = [
-                                        opentelemetry::KeyValue::new("shard_id", opentelemetry::Value::I64(self.shard_id as i64)),
-                                        opentelemetry::KeyValue::new(
-                                            "network.peer.address",
-                                            format!("{peer_ip}"),
-                                        ),
-                                    ];
-                                    stats.aggregated_messages.add(1, &tags);
+                                    stats.aggregated_records.add(1, &tags);
 
                                     let flow = entry.into_flowinfo_with_extra_fields(
                                       shard_id,
@@ -233,7 +245,7 @@ impl AggregationActor {
 
                                     let send_closure = tx.send((peer_ip, flow));
                                     match tokio::time::timeout(Duration::from_secs(1), send_closure).await {
-                                        Ok(Ok(_)) => stats.sent_messages.add(1, &tags),
+                                        Ok(Ok(_)) => stats.sent.add(1, &tags),
                                         Ok(Err(err)) => {
                                             error!("AggregationActor send error: {err}");
                                             stats.send_error.add(1, &tags);

--- a/crates/collector/src/flow/aggregation/aggregator.rs
+++ b/crates/collector/src/flow/aggregation/aggregator.rs
@@ -264,7 +264,7 @@ pub(crate) fn explode(
     key_select: &[FieldRef],
     agg_select: &[AggFieldRef],
     collection_time: DateTime<Utc>,
-) -> impl Iterator<Item = AggFlowInfo> {
+) -> (usize, impl Iterator<Item = AggFlowInfo>) {
     // FlowInfo are not expected to contain more than 16 records
     let mut exploded = SmallVec::<[AggFlowInfo; 16]>::new();
 
@@ -333,7 +333,7 @@ pub(crate) fn explode(
             info!("Unsupported flow version for peer {}", peer);
         }
     }
-    exploded.into_iter()
+    (exploded.len(), exploded.into_iter())
 }
 
 #[cfg(test)]

--- a/crates/collector/src/flow/aggregation/aggregator/tests.rs
+++ b/crates/collector/src/flow/aggregation/aggregator/tests.rs
@@ -520,7 +520,7 @@ fn test_explode_simple_ipfix_packet() {
 
     // Call explode and compare
     let result = explode(&flow_info, peer, &key_select, &agg_select, collection_time);
-    assert_eq!(result.collect::<Vec<AggFlowInfo>>(), expected);
+    assert_eq!(result.1.collect::<Vec<AggFlowInfo>>(), expected);
 }
 
 #[test]
@@ -610,7 +610,7 @@ fn test_explode_multiple_records() {
     // Call explode and compare
     let result = explode(&flow_info, peer, &key_select, &agg_select, collection_time);
 
-    assert_eq!(result.collect::<Vec<AggFlowInfo>>(), expected);
+    assert_eq!(result.1.collect::<Vec<AggFlowInfo>>(), expected);
 }
 
 #[test]
@@ -683,7 +683,7 @@ fn test_explode_repeating_ie_fields() {
     // Call explode and compare
     let result = explode(&flow_info, peer, &key_select, &agg_select, collection_time);
 
-    assert_eq!(result.collect::<Vec<AggFlowInfo>>(), expected);
+    assert_eq!(result.1.collect::<Vec<AggFlowInfo>>(), expected);
 }
 
 #[test]
@@ -747,7 +747,7 @@ fn test_explode_missing_fields() {
     // Call explode and compare
     let result = explode(&flow_info, peer, &key_select, &agg_select, collection_time);
 
-    assert_eq!(result.collect::<Vec<AggFlowInfo>>(), expected);
+    assert_eq!(result.1.collect::<Vec<AggFlowInfo>>(), expected);
 }
 
 #[test]
@@ -796,5 +796,5 @@ fn test_explode_empty_selectors() {
     // Call explode and compare
     let result = explode(&flow_info, peer, &key_select, &agg_select, collection_time);
 
-    assert_eq!(result.collect::<Vec<AggFlowInfo>>(), expected);
+    assert_eq!(result.1.collect::<Vec<AggFlowInfo>>(), expected);
 }


### PR DESCRIPTION
This PR:
- adds new exploded_records counter to keep track of the explosion rate and be able to distinguish between explosion rate and aggregation rate at the aggregation actor
- change stats names to uniform with other actors