### PR TITLE
Add new id for otel telemetry 

### DIFF
--- a/crates/collector/config.yaml
+++ b/crates/collector/config.yaml
@@ -8,6 +8,7 @@ logging:
 
 telemetry:
   url: http://localhost:4317/v1/metrics
+  id: netgauze-sample-instance
   exporter_timeout: 3000
   reader_interval: 60000
   reader_timeout: 3000

--- a/crates/collector/config_ci_rpm_test.yaml
+++ b/crates/collector/config_ci_rpm_test.yaml
@@ -6,6 +6,7 @@ runtime:
 
   telemetry:
     url: http://localhost:4317/v1/metrics
+    id: netgauze-ci-rpm-test
     exporter_timeout: 3000
     reader_interval: 60000
     reader_timeout: 3000

--- a/crates/collector/config_udpnotif_telemetry.yaml
+++ b/crates/collector/config_udpnotif_telemetry.yaml
@@ -6,6 +6,7 @@ logging:
 
 telemetry:
   url: http://localhost:4317/v1/metrics
+  id: netgauze-udpnotif-telemetry
   exporter_timeout: 3000
   reader_interval: 60000
   reader_timeout: 3000

--- a/crates/collector/config_vmware.yaml
+++ b/crates/collector/config_vmware.yaml
@@ -8,6 +8,7 @@ logging:
 
 telemetry:
   url: http://localhost:4317/v1/metrics
+  id: netgauze-vmware
   exporter_timeout: 3000
   reader_interval: 60000
   reader_timeout: 3000

--- a/crates/collector/src/config.rs
+++ b/crates/collector/src/config.rs
@@ -93,6 +93,9 @@ impl Default for LoggingConfig {
 pub struct TelemetryConfig {
     pub url: String,
 
+    /// Id to distinguish multiple instances running at the same site
+    pub id: String,
+
     /// Metrics exporter GRPC timeout
     #[serde(default = "default_telemetry_timeout")]
     #[serde_as(as = "serde_with::DurationMilliSeconds<u64>")]
@@ -114,6 +117,9 @@ pub struct TelemetryConfig {
 impl TelemetryConfig {
     pub fn url(&self) -> &str {
         self.url.as_str()
+    }
+    pub fn id(&self) -> &str {
+        self.id.as_str()
     }
 }
 

--- a/crates/collector/src/main.rs
+++ b/crates/collector/src/main.rs
@@ -94,7 +94,11 @@ fn init_open_telemetry(
         .with_interval(config.reader_interval)
         .build();
 
-    let resource = Resource::builder().with_service_name("NetGauze").build();
+    let resource = Resource::builder()
+        .with_service_name("NetGauze")
+        .with_attributes([opentelemetry::KeyValue::new("id", config.id.clone())])
+        .build();
+
     let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
         .with_reader(reader)
         .with_resource(resource)


### PR DESCRIPTION
This PR introduces a new id for the telemetry section in the config, which will be added as a tag meant for distinguishing different instances of the netgauze collector running on the same site.

To export it then we need in the otel-col-config:

```yaml
exporters:
  prometheus:
   ...
    resource_to_telemetry_conversion:
      enabled: true
```
