### PR TITLE
Fix IPFIX minimum record length calculation for variable-length fields

### DIFF
--- a/crates/flow-pkt/src/wire/deserializer/ipfix.rs
+++ b/crates/flow-pkt/src/wire/deserializer/ipfix.rs
@@ -254,7 +254,7 @@ impl<'a> ReadablePduWithOneInput<'a, &mut TemplatesMap, LocatedSetParsingError<'
                     .iter()
                     .map(|x| {
                         if x.length() == 65535 {
-                            0
+                            1
                         } else {
                             x.length() as usize
                         }
@@ -265,7 +265,7 @@ impl<'a> ReadablePduWithOneInput<'a, &mut TemplatesMap, LocatedSetParsingError<'
                         .iter()
                         .map(|x| {
                             if x.length() == 65535 {
-                                0
+                                1
                             } else {
                                 x.length() as usize
                             }


### PR DESCRIPTION
When calculating minimum record length for data sets, variable-length fields were incorrectly counted as 0 bytes. This caused parsing issues when a data set contained fixed-length fields followed by variable-length fields with padding, as the parser would misinterpret padding bytes as new records.

Change minimum length for variable-length fields (length == 65535) from 0 to 1 byte to account for the minimum length encoding byte required by RFC 7011.

Add test case covering a data record with fixed-length field, variable-length strings, and trailing padding to verify correct parsing behavior.

Fixes #360