### PR TITLE
BMP: support new stat counters from draft-ietf-grow-bmp-bgp-rib-stats

### DIFF
--- a/crates/bmp-pkt/src/iana.rs
+++ b/crates/bmp-pkt/src/iana.rs
@@ -371,6 +371,7 @@ impl TryFrom<u16> for RouteMirroringInformation {
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum BmpStatisticsType {
+    // [RFC8671](https://datatracker.ietf.org/doc/html/rfc8671)
     NumberOfPrefixesRejectedByInboundPolicy = 0,
     NumberOfDuplicatePrefixAdvertisements = 1,
     NumberOfDuplicateWithdraws = 2,
@@ -389,6 +390,32 @@ pub enum BmpStatisticsType {
     NumberOfRoutesInPostPolicyAdjRibOut = 15,
     NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOut = 16,
     NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOut = 17,
+    // [RFC-ietf-grow-bmp-bgp-rib-stats-17](https://datatracker.ietf.org/doc/html/draft-ietf-grow-bmp-bgp-rib-stats)
+    NumberOfRoutesInPrePolicyAdjRibIn = 18,
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn = 19,
+    NumberOfRoutesInPostPolicyAdjRibIn = 20,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn = 21,
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected = 22,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted = 23,
+    NumberOfRoutesInPerAfiSafiSuppressedByDamping = 26,
+    NumberOfRoutesInPerAfiSafiMarkedStaleByGr = 27,
+    NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr = 28,
+    NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold = 29,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold = 30,
+    NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold = 31,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold = 32,
+    NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength = 33,
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength = 34,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki = 35,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki = 36,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound = 37,
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected = 38,
+    NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength = 39,
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength = 40,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki = 41,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki = 42,
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound = 43,
+    // [RFC7854](https://datatracker.ietf.org/doc/html/rfc7854)
     Experimental65531 = 65531,
     Experimental65532 = 65532,
     Experimental65533 = 65533,

--- a/crates/bmp-pkt/src/v3.rs
+++ b/crates/bmp-pkt/src/v3.rs
@@ -660,6 +660,33 @@ pub enum StatisticsCounter {
     NumberOfRoutesInPostPolicyAdjRibOut(GaugeU64),
     NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOut(AddressType, GaugeU64),
     NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOut(AddressType, GaugeU64),
+    NumberOfRoutesInPrePolicyAdjRibIn(GaugeU64),
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn(AddressType, GaugeU64),
+    NumberOfRoutesInPostPolicyAdjRibIn(GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiSuppressedByDamping(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiMarkedStaleByGr(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr(AddressType, GaugeU64),
+    NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold(GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold(AddressType, GaugeU64),
+    NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(
+        AddressType,
+        GaugeU64,
+    ),
+    NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength(GaugeU64),
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected(AddressType, GaugeU64),
+    NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength(GaugeU64),
+    NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki(AddressType, GaugeU64),
+    NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound(AddressType, GaugeU64),
     Experimental65531(Vec<u8>),
     Experimental65532(Vec<u8>),
     Experimental65533(Vec<u8>),
@@ -719,6 +746,78 @@ impl StatisticsCounter {
             }
             Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOut(_, _) => {
                 Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOut)
+            }
+            Self::NumberOfRoutesInPrePolicyAdjRibIn(_) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPrePolicyAdjRibIn)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn)
+            }
+            Self::NumberOfRoutesInPostPolicyAdjRibIn(_) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPostPolicyAdjRibIn)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted)
+            }
+            Self::NumberOfRoutesInPerAfiSafiSuppressedByDamping(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiSuppressedByDamping)
+            }
+            Self::NumberOfRoutesInPerAfiSafiMarkedStaleByGr(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiMarkedStaleByGr)
+            }
+            Self::NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr)
+            }
+            Self::NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold(_) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold)
+            }
+            Self::NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(_) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold)
+            }
+            Self::NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength(_) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected)
+            }
+            Self::NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength(_) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki)
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound(_, _) => {
+                Ok(BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound)
             }
             Self::Experimental65531(_) => Ok(BmpStatisticsType::Experimental65531),
             Self::Experimental65532(_) => Ok(BmpStatisticsType::Experimental65532),

--- a/crates/bmp-pkt/src/wire/deserializer/v3.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/v3.rs
@@ -1018,6 +1018,228 @@ impl<'a> ReadablePdu<'a, LocatedStatisticsCounterParsingError<'a>> for v3::Stati
                         ),
                     )
                 }
+                BmpStatisticsType::NumberOfRoutesInPrePolicyAdjRibIn => {
+                    let (buf, value) = be_u64(buf)?;
+                    (buf, v3::StatisticsCounter::NumberOfRoutesInPrePolicyAdjRibIn(GaugeU64(value)))
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPostPolicyAdjRibIn => {
+                    let (buf, value) = be_u64(buf)?;
+                    (buf, v3::StatisticsCounter::NumberOfRoutesInPostPolicyAdjRibIn(GaugeU64(value)))
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiSuppressedByDamping => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiSuppressedByDamping(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiMarkedStaleByGr => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiMarkedStaleByGr(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold => {
+                    let (buf, value) = be_u64(buf)?;
+                    (buf, v3::StatisticsCounter::NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold(GaugeU64(value)))
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold => {
+                    let (buf, value) = be_u64(buf)?;
+                    (buf, v3::StatisticsCounter::NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(GaugeU64(value)))
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength => {
+                    let (buf, value) = be_u64(buf)?;
+                    (buf, v3::StatisticsCounter::NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength(GaugeU64(value)))
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength => {
+                    let (buf, value) = be_u64(buf)?;
+                    (buf, v3::StatisticsCounter::NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength(GaugeU64(value)))
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
+                BmpStatisticsType::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound => {
+                    let (buf, address_type) = parse_address_type(buf)?;
+                    let (buf, value) = be_u64(buf)?;
+                    (
+                        buf,
+                        v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound(
+                            address_type,
+                            GaugeU64::new(value),
+                        ),
+                    )
+                }
                 BmpStatisticsType::Experimental65531 => {
                     let (buf, data) = nom::bytes::complete::take(length)(buf)?;
                     (buf, v3::StatisticsCounter::Experimental65531(data.to_vec()))

--- a/crates/bmp-pkt/src/wire/serializer/v3.rs
+++ b/crates/bmp-pkt/src/wire/serializer/v3.rs
@@ -612,32 +612,58 @@ impl WritablePdu<StatisticsCounterMessageWritingError> for StatisticsCounter {
     const BASE_LENGTH: usize = 4;
 
     fn len(&self) -> usize {
-        Self::BASE_LENGTH
-            + match self {
-                Self::NumberOfPrefixesRejectedByInboundPolicy(_) => 4,
-                Self::NumberOfDuplicatePrefixAdvertisements(_) => 4,
-                Self::NumberOfDuplicateWithdraws(_) => 4,
-                Self::NumberOfUpdatesInvalidatedDueToClusterListLoop(_) => 4,
-                Self::NumberOfUpdatesInvalidatedDueToAsPathLoop(_) => 4,
-                Self::NumberOfUpdatesInvalidatedDueToOriginatorId(_) => 4,
-                Self::NumberOfUpdatesInvalidatedDueToAsConfederationLoop(_) => 4,
-                Self::NumberOfRoutesInAdjRibIn(_) => 8,
-                Self::NumberOfRoutesInLocRib(_) => 8,
-                Self::NumberOfRoutesInPerAfiSafiAdjRibIn(_, _) => 11,
-                Self::NumberOfRoutesInPerAfiSafiLocRib(_, _) => 11,
-                Self::NumberOfUpdatesSubjectedToTreatAsWithdraw(_) => 4,
-                Self::NumberOfPrefixesSubjectedToTreatAsWithdraw(_) => 4,
-                Self::NumberOfDuplicateUpdateMessagesReceived(_) => 4,
-                Self::NumberOfRoutesInPrePolicyAdjRibOut(_) => 8,
-                Self::NumberOfRoutesInPostPolicyAdjRibOut(_) => 8,
-                Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOut(_, _) => 11,
-                Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOut(_, _) => 11,
-                Self::Experimental65531(value) => value.len(),
-                Self::Experimental65532(value) => value.len(),
-                Self::Experimental65533(value) => value.len(),
-                Self::Experimental65534(value) => value.len(),
-                Self::Unknown(_, value) => value.len(),
-            }
+        Self::BASE_LENGTH + match self {
+            Self::NumberOfPrefixesRejectedByInboundPolicy(_) => 4,
+            Self::NumberOfDuplicatePrefixAdvertisements(_) => 4,
+            Self::NumberOfDuplicateWithdraws(_) => 4,
+            Self::NumberOfUpdatesInvalidatedDueToClusterListLoop(_) => 4,
+            Self::NumberOfUpdatesInvalidatedDueToAsPathLoop(_) => 4,
+            Self::NumberOfUpdatesInvalidatedDueToOriginatorId(_) => 4,
+            Self::NumberOfUpdatesInvalidatedDueToAsConfederationLoop(_) => 4,
+            Self::NumberOfRoutesInAdjRibIn(_) => 8,
+            Self::NumberOfRoutesInLocRib(_) => 8,
+            Self::NumberOfRoutesInPerAfiSafiAdjRibIn(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiLocRib(_, _) => 11,
+            Self::NumberOfUpdatesSubjectedToTreatAsWithdraw(_) => 4,
+            Self::NumberOfPrefixesSubjectedToTreatAsWithdraw(_) => 4,
+            Self::NumberOfDuplicateUpdateMessagesReceived(_) => 4,
+            Self::NumberOfRoutesInPrePolicyAdjRibOut(_) => 8,
+            Self::NumberOfRoutesInPostPolicyAdjRibOut(_) => 8,
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOut(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOut(_, _) => 11,
+            Self::NumberOfRoutesInPrePolicyAdjRibIn(_) => 8,
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn(_, _) => 11,
+            Self::NumberOfRoutesInPostPolicyAdjRibIn(_) => 8,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiSuppressedByDamping(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiMarkedStaleByGr(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr(_, _) => 11,
+            Self::NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold(_) => 8,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold(_, _) => 11,
+            Self::NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(_) => 8,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(
+                _,
+                _,
+            ) => 11,
+            Self::NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength(_) => 8,
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected(_, _) => 11,
+            Self::NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength(_) => 8,
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki(_, _) => 11,
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound(_, _) => 11,
+            Self::Experimental65531(value) => value.len(),
+            Self::Experimental65532(value) => value.len(),
+            Self::Experimental65533(value) => value.len(),
+            Self::Experimental65534(value) => value.len(),
+            Self::Unknown(_, value) => value.len(),
+        }
     }
 
     fn write<T: Write>(&self, writer: &mut T) -> Result<(), StatisticsCounterMessageWritingError> {
@@ -701,6 +727,141 @@ impl WritablePdu<StatisticsCounterMessageWritingError> for StatisticsCounter {
                 writer.write_u64::<NetworkEndian>(value.0)?;
             }
             Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOut(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPrePolicyAdjRibIn(value) => {
+                writer.write_u64::<NetworkEndian>(value.0)?
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPostPolicyAdjRibIn(value) => {
+                writer.write_u64::<NetworkEndian>(value.0)?
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiSuppressedByDamping(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiMarkedStaleByGr(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold(value) => {
+                writer.write_u64::<NetworkEndian>(value.0)?
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold(
+                address_type,
+                value,
+            ) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(value) => {
+                writer.write_u64::<NetworkEndian>(value.0)?
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(
+                address_type,
+                value,
+            ) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength(value) => {
+                writer.write_u64::<NetworkEndian>(value.0)?
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength(
+                address_type,
+                value,
+            ) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki(
+                address_type,
+                value,
+            ) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki(
+                address_type,
+                value,
+            ) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected(address_type, value) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength(value) => {
+                writer.write_u64::<NetworkEndian>(value.0)?
+            }
+            Self::NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength(
+                address_type,
+                value,
+            ) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki(
+                address_type,
+                value,
+            ) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki(
+                address_type,
+                value,
+            ) => {
+                writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
+                writer.write_u8(address_type.subsequent_address_family().into())?;
+                writer.write_u64::<NetworkEndian>(value.0)?;
+            }
+            Self::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound(
+                address_type,
+                value,
+            ) => {
                 writer.write_u16::<NetworkEndian>(address_type.address_family().into())?;
                 writer.write_u8(address_type.subsequent_address_family().into())?;
                 writer.write_u64::<NetworkEndian>(value.0)?;


### PR DESCRIPTION
Supporting new u64 gauges for BMP Stats TLVs added by https://datatracker.ietf.org/doc/html/draft-ietf-grow-bmp-bgp-rib-stats (in RFC editor queue).