### PR TITLE
Collector: improve tracing initialization with EnvFilter

### DIFF
--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -47,7 +47,7 @@ reqwest = { workspace = true, default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
 chrono = { workspace = true, default-features = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"]}
 anyhow = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics", "trace", "logs"] }
 opentelemetry_sdk = { workspace = true, features = [

--- a/crates/collector/README.md
+++ b/crates/collector/README.md
@@ -6,3 +6,113 @@ Work in progress for telemetry collection. Currently supports:
 2. UDP Notif
 
 With publisher towards Kafka and HTTP endpoints.
+
+## Running the Collector
+
+```bash
+# Run with a config file
+cargo run -p netgauze-collector -- /path/to/config.yaml
+```
+
+## Logging Configuration
+
+The collector uses `tracing` with `EnvFilter` for flexible log level control.
+
+### Basic Usage
+
+Set the default log level in your `config.yaml`:
+
+```yaml
+logging:
+  level: "info" # Valid: trace, debug, info, warn, error
+```
+
+### Runtime Override with `RUST_LOG`
+
+Override the log level at runtime using the `RUST_LOG` environment variable:
+
+```bash
+# Set global log level
+RUST_LOG=debug cargo run -p netgauze-collector -- config.yaml
+
+# Filter specific modules
+RUST_LOG=netgauze_collector=trace,tokio=info cargo run -p netgauze-collector -- config.yaml
+
+# Complex filtering (enable trace for flow, debug for UDP notif)
+RUST_LOG="warn,netgauze_collector::flow=trace,netgauze_collector::yang_push=debug" \
+  cargo run -p netgauze-collector -- config.yaml
+```
+
+### Filter Syntax Examples
+
+The `EnvFilter` supports powerful filtering directives:
+
+- `debug` - Set global level to debug
+- `my_crate=trace` - Enable trace logs for specific crate
+- `my_crate::module=info` - Enable info logs for specific module
+- `[span_name]=debug` - Enable debug logs within specific span
+- `[{field_name}]=trace` - Enable trace logs for events/spans with specific field
+- `warn,tokio::net=debug` - Global warn, but debug for tokio::net
+
+### Precedence
+
+1. **`RUST_LOG` environment variable** (highest priority)
+2. **Config file `logging.level`**
+
+**Note**: Invalid log levels or EnvFilters file will cause the collector to exit immediately with a clear error message.
+
+## Telemetry
+
+The collector exports OpenTelemetry metrics via OTLP/gRPC:
+
+```yaml
+telemetry:
+  id: "collector-01"
+  host: "localhost"
+  port: 4317
+  exporter_timeout: "10s"
+  reader_interval: "30s"
+```
+
+Metrics include:
+
+- Message processing rates
+- Buffer sizes and backpressure
+- Error counts
+- Publisher health
+
+## Graceful Shutdown
+
+The collector handles `Ctrl+C` (SIGINT) gracefully:
+
+1. Stops accepting new connections
+2. Drains in-flight messages from buffers
+3. Shuts down publishers (1s timeout each)
+4. Exits cleanly
+
+## Configuration
+
+See example configuration files in collector crate root.
+
+Key configuration sections:
+
+- `logging`: Log level configuration
+- `runtime`: Tokio runtime settings (thread count)
+- `telemetry`: OpenTelemetry exporter settings
+- `flow`: IPFIX/NetFlow v9 collection and publishing
+- `udp_notif`: UDP Notification collection and publishing
+
+## Memory Allocator
+
+The collector uses **jemalloc** for better memory efficiency on Linux (via `tikv-jemallocator`).
+
+## Build Information
+
+On startup, the collector logs:
+
+- Git commit hash, branch, and tag
+- Build timestamp
+- Rust version and toolchain
+- Operating system
+
+This is powered by the `shadow-rs` crate.


### PR DESCRIPTION
## Summary
Replaces basic tracing setup with `EnvFilter` to enable runtime log level control via `RUST_LOG` environment variable. Also adding some documentation in the collector's README.

## Changes
- **EnvFilter with builder pattern**: Supports default directive from config + runtime overrides
- **Fail-fast validation**: Invalid config log levels or RUST_LOG directive cause immediate exit with clear errors

## Runtime override examples 
```bash
# Global debug (override configured level)
RUST_LOG=debug cargo run -p netgauze-collector -- config.yaml

# Per-crate filtering (trace for netgauze-collector, info for everything else)
RUST_LOG=info,netgauze_collector=trace cargo run -p netgauze-collector -- config.yaml

# Per-module filtering (trace on flow module, debug on tokio, rest uses config level)
RUST_LOG=netgauze_collector::flow=trace,tokio=debug cargo run -p netgauze-collector -- config.yaml
```

## References
- https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html