### PR TITLE
Collector: support EnvFilter directives from config file

### DIFF
--- a/crates/collector/config_udpnotif_telemetry.yaml
+++ b/crates/collector/config_udpnotif_telemetry.yaml
@@ -3,7 +3,8 @@ runtime:
   threads: 4
 
 logging:
-  level: info
+  level: netgauze_collector=trace,netgauze_yang_push=trace,info
+  ansi: true
 
 telemetry:
   url: http://localhost:4317/v1/metrics

--- a/crates/collector/src/main.rs
+++ b/crates/collector/src/main.rs
@@ -40,14 +40,16 @@ fn init_tracing(level: &'_ str, use_ansi: bool) {
 
     // default to configured level from config file
     // override via RUST_LOG env var at runtime
-    let env_filter = EnvFilter::builder()
-        .with_default_directive(level.parse().expect(
-            "Invalid log level in config file. Expected: trace, debug, info, warn, or error",
-        ))
-        .from_env()
-        .expect(
-          "Invalid RUST_LOG environment variable. Use valid filter directives like 'debug' or 'my_crate=trace'"
-        );
+    let rust_log = env::var("RUST_LOG").unwrap_or_default();
+    let env_filter = if !rust_log.is_empty() {
+        EnvFilter::builder().parse(&rust_log).expect(
+            "Invalid RUST_LOG environment variable. Use valid filter directives like 'debug' or 'netgauze_collector=trace'",
+        )
+    } else {
+        EnvFilter::builder().parse(level).expect(
+            "Invalid log level in config file. Expected: trace, debug, info, warn, error, or filter directives like 'netgauze_collector=debug'",
+        )
+    };
 
     tracing_subscriber::registry()
         .with(env_filter)


### PR DESCRIPTION
# Summary
This PR enhances logging flexibility by supporting complex `EnvFilter` directives in the configuration as well. Preceded on the one provided from RUST_LOG env var remains.

## Changes
- refactored `init_tracing` to allow full filter strings (e.g., `netgauze_collector=trace,info`) in both the config file and `RUST_LOG` environment variable.
- still prioritizes `RUST_LOG` environment variable over the configuration file setting.
- added an example to the udpnotif config file