### PR TITLE
feat: IPFIX supports a locally defined custom registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings --cfg docsrs
       TRYBUILD: overwrite
+      NETGAUZE_CUSTOM_XML_PATHS:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/crates/flow-pkt/Cargo.toml
+++ b/crates/flow-pkt/Cargo.toml
@@ -59,6 +59,7 @@ codec = ["tracing", "tokio-util", "bytes"]
 bench = ["criterion"]
 fuzz = ["arbitrary", "arbitrary_ext", "ordered-float/arbitrary"]
 iana-upstream-build = ["serde"]
+custom-upstream-build = ["default"]
 
 [dev-dependencies]
 netgauze-pcap-reader = { workspace = true }

--- a/crates/flow-pkt/README.md
+++ b/crates/flow-pkt/README.md
@@ -13,7 +13,7 @@
    When the IANA registry introduces changes, such as a new data type, generation may fail.
    If your project depends on this crate and requires stable generation, you can enable the
    backwards-compatibility-snapshot feature in your Cargo.toml file. This feature uses a snapshot of registry
-   files taken at the time of the crate's release, ensuring reliable generation even if the registry is updated.
+   files taken at the time of the crate's release, ensuring reliable generation even if the registry is updated. In addition to this, users can define a single custom local registry or multiple custom local registries, allowing NetGauze to generate the necessary code at build time. To use this functionality, the `custom-upstream-build` feature must be enabled and the environment variable `NETGAUZE_CUSTOM_XML_PATHS` must be set. `NETGAUZE_CUSTOM_XML_PATHS` takes the paths and PENs with the format `NETGAUZE_CUSTOM_XML_PATHS="path=pen"` or to specify more registries `NETGAUZE_CUSTOM_XML_PATHS="path=pen,path2=pen2,path3=pen3"`.
 
 ## Examples
 


### PR DESCRIPTION
For the issue #405 I came up with this implementation.

## Implementation
I added a feature that's just a flag. If the feature is set, I read from 1 environment variable at build time. In the environment variable are specified paths to XML and a number that will be the PEN number. The tuples `path=pen` are separated by commas.

## Extension
~~I'd like to have an array of XMLs but I don't know how to handle different PENs and~~ feedback is appreciated.

## Example of a Cargo.toml
```
netgauze_flow_pkt = { version = "0.x.y", features = ["custom-upstream-build"] }
```