### PR TITLE
Update quick xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,9 +3928,9 @@ checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e3bf4aa9d243beeb01a7b3bc30b77cfe2c44e24ec02d751a7104a53c2c49a1"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ smallvec = { version = "1.15" }
 rustc-hash = { version = "2.1" }
 yang4 = { version = "0.1", features = ["bundled"] }
 tempfile = { version = "3.23.0" }
-quick-xml = { version = "=0.39.0" }
+quick-xml = { version = "0.39" }
 russh = { version = "0.57" }
 secrecy = { version = "0.10" }
 notify = { version = "8.2" }


### PR DESCRIPTION
quick-xml released a new version 0.39.2 which fixed the regressions in 0.39.1