### PR TITLE
collector: add pmacct schema model and conversion logic from native BmpMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
 dependencies = [
+ "apache-avro-derive",
  "bigdecimal",
  "bon",
  "digest 0.10.7",
@@ -174,6 +175,19 @@ dependencies = [
  "strum_macros",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "apache-avro-derive"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5f1d2499ae9ad7eda0d283bac50140ec75b4d07784124b36dfa21d0b3649cf"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -469,7 +483,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1033,12 +1047,35 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1056,11 +1093,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -2764,6 +2812,7 @@ dependencies = [
  "netgauze-flow-service",
  "netgauze-iana",
  "netgauze-netconf-proto",
+ "netgauze-serde-macros",
  "netgauze-udp-notif-pkt",
  "netgauze-udp-notif-service",
  "netgauze-yang-push",
@@ -4941,7 +4990,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/crates/collector/Cargo.toml
+++ b/crates/collector/Cargo.toml
@@ -46,6 +46,7 @@ netgauze-bgp-pkt = { workspace = true }
 netgauze-udp-notif-service = { workspace = true }
 netgauze-udp-notif-pkt = { workspace = true }
 netgauze-yang-push = { workspace = true }
+netgauze-serde-macros = { workspace = true }
 netgauze-iana = { workspace = true }
 netgauze-netconf-proto = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["net", "io-util", "sync", "time", "rt-multi-thread", "macros", "tracing"] }
@@ -79,7 +80,7 @@ opentelemetry-otlp = { workspace = true, features = [
     "logs",
     "grpc-tonic",
 ] }
-apache-avro = { workspace = true }
+apache-avro = { workspace = true, features = ["derive"] }
 indexmap = { workspace = true, features = ["serde"] }
 serde_json = { workspace = true }
 schema_registry_converter = { workspace = true, default-features = false, features = [

--- a/crates/collector/config_bmp.yaml
+++ b/crates/collector/config_bmp.yaml
@@ -18,8 +18,12 @@ bmp:
   listeners:
     - address: "[::]:1790"
       workers: 1
+    - address: "[::]:1791"
+      workers: 1
     - address: "[::]:1792"
       workers: 1
+    - address: "[::]:1793"
+      worker: 1
   publishers:
     raw-json:
       endpoints:
@@ -27,4 +31,14 @@ bmp:
           topic: netgauze-bmp-raw-json
           producer_config:
             bootstrap.servers: localhost:49092
-          writer_id: writer1
+          writer_id: bmp-raw-json
+    pmacct-avro:
+      endpoints:
+        main: !BmpKafkaAvro
+          topic: netgauze-bmp-avro
+          schema_registry_url: http://localhost:48081
+          producer_config:
+            bootstrap.servers: localhost:49092
+          writer_id: bmp-avro
+          avro_converter:
+            schema_type: union

--- a/crates/collector/src/bmp/config.rs
+++ b/crates/collector/src/bmp/config.rs
@@ -1,0 +1,145 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! BMP Avro Serialization Configuration
+//!
+//! This module defines configuration structures and enums for controlling
+//! how BMP messages are serialized to Avro for publishing (e.g., to Kafka).
+//! It allows selecting the Avro schema strategy and provides integration
+//! with the AvroConverter trait for flexible serialization and publishing
+//! workflows.
+
+use crate::bmp::pmacct_schema::{
+    EventType, PmacctBmpConversionError, PmacctBmpMessage, PmacctConversionContext,
+};
+use crate::publishers::kafka_avro::{AvroConverter, KafkaAvroPublisherActorError};
+use apache_avro::AvroSchema;
+use apache_avro::types::Value as AvroValue;
+use netgauze_bmp_service::BmpRequest;
+use schema_registry_converter::avro_common::get_supplied_schema;
+use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use smallvec::SmallVec;
+use std::sync::Arc;
+
+#[derive(Debug, strum_macros::Display)]
+pub enum BmpAvroConverterError {
+    ConversionError(PmacctBmpConversionError),
+    AvroError(apache_avro::Error),
+    #[strum(to_string = "Serialization error: {0}")]
+    SerializationError(serde_json::Error),
+}
+
+impl std::error::Error for BmpAvroConverterError {}
+
+impl From<PmacctBmpConversionError> for BmpAvroConverterError {
+    fn from(e: PmacctBmpConversionError) -> Self {
+        Self::ConversionError(e)
+    }
+}
+
+impl From<apache_avro::Error> for BmpAvroConverterError {
+    fn from(e: apache_avro::Error) -> Self {
+        Self::AvroError(e)
+    }
+}
+
+impl From<BmpAvroConverterError> for KafkaAvroPublisherActorError {
+    fn from(e: BmpAvroConverterError) -> Self {
+        Self::TransformationError(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for BmpAvroConverterError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::SerializationError(e)
+    }
+}
+/// Specifies the Avro schema type for BMP messages. Supported:
+///
+/// - `Union`: All BMP message types are represented as a single Avro union
+///   schema.
+///
+/// Future variants may include separate schemas per BMP message type.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BmpAvroSchemaType {
+    #[default]
+    Union,
+}
+
+/// Configuration for BMP Avro serialization and publishing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BmpAvroConfig {
+    #[serde(default)]
+    pub schema_type: BmpAvroSchemaType,
+
+    #[serde(skip)]
+    pub writer_id: String,
+}
+impl AvroConverter<Arc<BmpRequest>, BmpAvroConverterError> for BmpAvroConfig {
+    fn get_avro_schema(&self) -> Result<String, BmpAvroConverterError> {
+        serde_json::to_string(&PmacctBmpMessage::get_schema()).map_err(BmpAvroConverterError::from)
+    }
+
+    fn get_subject_name_strategy(
+        &self,
+        topic: &str,
+    ) -> Result<SubjectNameStrategy, BmpAvroConverterError> {
+        let schema = apache_avro::Schema::parse_str(&self.get_avro_schema()?)
+            .map_err(BmpAvroConverterError::from)?;
+        Ok(SubjectNameStrategy::TopicNameStrategyWithSchema(
+            topic.to_string(),
+            false, // is_key = false (this is for the value, not the key)
+            get_supplied_schema(&schema),
+        ))
+    }
+
+    fn get_key(&self, input: &Arc<BmpRequest>) -> Option<JsonValue> {
+        let (addr_info, _) = input.as_ref();
+        Some(JsonValue::String(
+            addr_info.remote_socket().ip().to_string(),
+        ))
+    }
+
+    type AvroValues = SmallVec<[AvroValue; 16]>;
+    fn get_avro_values(
+        &self,
+        input: Arc<BmpRequest>,
+    ) -> Result<Self::AvroValues, BmpAvroConverterError> {
+        let current_time = chrono::Utc::now();
+        let timestamp_arrival = format!(
+            "{}.{:06}",
+            current_time.timestamp(),
+            current_time.timestamp_subsec_micros()
+        );
+
+        let ctx = PmacctConversionContext {
+            writer_id: self.writer_id.clone(),
+            event_type: EventType::Log,
+            timestamp_arrival,
+            label: None,
+            tag: None,
+        };
+
+        // Convert into PmacctBmpMessages
+        let msgs = PmacctBmpMessage::try_from_bmp_request(input.as_ref(), &ctx)?;
+
+        msgs.into_iter()
+            .map(|msg| msg.get_avro_value().map_err(BmpAvroConverterError::from))
+            .collect()
+    }
+}

--- a/crates/collector/src/bmp/mod.rs
+++ b/crates/collector/src/bmp/mod.rs
@@ -1,0 +1,17 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod config;
+pub mod pmacct_schema;

--- a/crates/collector/src/bmp/pmacct_schema.rs
+++ b/crates/collector/src/bmp/pmacct_schema.rs
@@ -1,0 +1,1907 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Flattened pmacct-compatible Avro schema for BMP messages.
+//!
+//! This module defines the data structures and conversion logic required to
+//! transform hierarchical NetGauze [`BmpRequest`] objects into flat,
+//! serialization-ready structures that match the schema used by the
+//! [pmacct](https://github.com/pmacct/pmacct) project.
+//!
+//! The main entry point is [`PmacctBmpMessage::try_from_bmp_request`].
+
+use apache_avro::types::Value;
+use apache_avro::{AvroSchema, Schema};
+use chrono::{DateTime, Utc};
+use netgauze_bgp_pkt::BgpMessage;
+use netgauze_bgp_pkt::nlri::{MplsLabel, RouteDistinguisher};
+use netgauze_bgp_pkt::path_attribute::{
+    Aigp, As4Path, AsPath, AsPathSegmentType, BgpSidAttribute, Communities, ExtendedCommunities,
+    LargeCommunities, MpReach, MpUnreach, Origin, PathAttributeValue,
+};
+use netgauze_bmp_pkt::{BmpMessage, BmpPeerType, PeerHeader, v3, v4};
+use netgauze_bmp_service::{AddrInfo, BmpRequest};
+use netgauze_iana::address_family::AddressType;
+use serde::de::Error;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Represents a single flattened BMP message
+///
+/// Use [`PmacctBmpMessage::try_from_bmp_request`] to convert a raw NetGauze
+/// [`BmpRequest`] into one or more of these messages.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum PmacctBmpMessage {
+    RouteMonitoring(PmacctRouteMonitoringMessage),
+    StatisticsReport(PmacctStatisticsReportMessage),
+    PeerDownNotification(PmacctPeerDownNotificationMessage),
+    PeerUpNotification(PmacctPeerUpNotificationMessage),
+    Initiation(PmacctInitiationMessage),
+    Termination(PmacctTerminationMessage),
+}
+
+impl AvroSchema for PmacctBmpMessage {
+    /// Generates the Avro schema union for all possible pmacct BMP message
+    /// types.
+    fn get_schema() -> Schema {
+        let schemas = vec![
+            PmacctRouteMonitoringMessage::get_schema(),
+            PmacctStatisticsReportMessage::get_schema(),
+            PmacctPeerDownNotificationMessage::get_schema(),
+            PmacctPeerUpNotificationMessage::get_schema(),
+            PmacctInitiationMessage::get_schema(),
+            PmacctTerminationMessage::get_schema(),
+        ];
+        Schema::Union(apache_avro::schema::UnionSchema::new(schemas).expect("valid union schema"))
+    }
+}
+
+impl PmacctBmpMessage {
+    pub fn get_avro_schema(&self) -> Schema {
+        PmacctBmpMessage::get_schema()
+    }
+
+    pub fn get_avro_value(self) -> Result<Value, apache_avro::Error> {
+        match self {
+            PmacctBmpMessage::RouteMonitoring(msg) => {
+                let v = apache_avro::to_value(msg)?;
+                Ok(Value::Union(0, Box::new(v)))
+            }
+            PmacctBmpMessage::StatisticsReport(msg) => {
+                let v = apache_avro::to_value(msg)?;
+                Ok(Value::Union(1, Box::new(v)))
+            }
+            PmacctBmpMessage::PeerDownNotification(msg) => {
+                let v = apache_avro::to_value(msg)?;
+                Ok(Value::Union(2, Box::new(v)))
+            }
+            PmacctBmpMessage::PeerUpNotification(msg) => {
+                let v = apache_avro::to_value(msg)?;
+                Ok(Value::Union(3, Box::new(v)))
+            }
+            PmacctBmpMessage::Initiation(msg) => {
+                let v = apache_avro::to_value(msg)?;
+                Ok(Value::Union(4, Box::new(v)))
+            }
+            PmacctBmpMessage::Termination(msg) => {
+                let v = apache_avro::to_value(msg)?;
+                Ok(Value::Union(5, Box::new(v)))
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn from_avro_value(value: &Value) -> Result<Self, apache_avro::Error> {
+        if let Value::Union(idx, inner) = value {
+            match *idx {
+                0 => {
+                    if let Ok(msg) = apache_avro::from_value::<PmacctRouteMonitoringMessage>(inner)
+                    {
+                        return Ok(PmacctBmpMessage::RouteMonitoring(msg));
+                    }
+                }
+                1 => {
+                    if let Ok(msg) = apache_avro::from_value::<PmacctStatisticsReportMessage>(inner)
+                    {
+                        return Ok(PmacctBmpMessage::StatisticsReport(msg));
+                    }
+                }
+                2 => {
+                    if let Ok(msg) =
+                        apache_avro::from_value::<PmacctPeerDownNotificationMessage>(inner)
+                    {
+                        return Ok(PmacctBmpMessage::PeerDownNotification(msg));
+                    }
+                }
+                3 => {
+                    if let Ok(msg) =
+                        apache_avro::from_value::<PmacctPeerUpNotificationMessage>(inner)
+                    {
+                        return Ok(PmacctBmpMessage::PeerUpNotification(msg));
+                    }
+                }
+                4 => {
+                    if let Ok(msg) = apache_avro::from_value::<PmacctInitiationMessage>(inner) {
+                        return Ok(PmacctBmpMessage::Initiation(msg));
+                    }
+                }
+                5 => {
+                    if let Ok(msg) = apache_avro::from_value::<PmacctTerminationMessage>(inner) {
+                        return Ok(PmacctBmpMessage::Termination(msg));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if let Ok(msg) = apache_avro::from_value::<PmacctRouteMonitoringMessage>(value) {
+            return Ok(PmacctBmpMessage::RouteMonitoring(msg));
+        }
+        if let Ok(msg) = apache_avro::from_value::<PmacctStatisticsReportMessage>(value) {
+            return Ok(PmacctBmpMessage::StatisticsReport(msg));
+        }
+        if let Ok(msg) = apache_avro::from_value::<PmacctPeerDownNotificationMessage>(value) {
+            return Ok(PmacctBmpMessage::PeerDownNotification(msg));
+        }
+        if let Ok(msg) = apache_avro::from_value::<PmacctPeerUpNotificationMessage>(value) {
+            return Ok(PmacctBmpMessage::PeerUpNotification(msg));
+        }
+        if let Ok(msg) = apache_avro::from_value::<PmacctInitiationMessage>(value) {
+            return Ok(PmacctBmpMessage::Initiation(msg));
+        }
+        if let Ok(msg) = apache_avro::from_value::<PmacctTerminationMessage>(value) {
+            return Ok(PmacctBmpMessage::Termination(msg));
+        }
+        Err(apache_avro::Error::custom(
+            "Could not match Avro value to any PmacctBmpMessage variant",
+        ))
+    }
+
+    pub fn set_seq(&mut self, seq: u32) {
+        match self {
+            PmacctBmpMessage::RouteMonitoring(m) => m.seq = seq,
+            PmacctBmpMessage::StatisticsReport(m) => m.seq = seq,
+            PmacctBmpMessage::PeerDownNotification(m) => m.seq = seq,
+            PmacctBmpMessage::PeerUpNotification(m) => m.seq = seq,
+            PmacctBmpMessage::Initiation(m) => m.seq = seq,
+            PmacctBmpMessage::Termination(m) => m.seq = seq,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, AvroSchema, PartialEq, Clone)]
+#[avro(name = "bmp_msglog_rm")]
+pub struct PmacctRouteMonitoringMessage {
+    log_type: LogType,
+    seq: u32,
+    timestamp: String,
+    event_type: EventType,
+    writer_id: String,
+    tag: Option<i64>,
+    label: Option<HashMap<String, String>>,
+    afi: u16,
+    safi: u8,
+    ip_prefix: Option<String>,
+    rd: Option<String>,
+    rd_origin: Option<RdOrigin>,
+    bgp_nexthop: Option<String>,
+    as_path: Option<String>,
+    as_path_id: Option<u32>,
+    comms: Option<String>,
+    ecomms: Option<String>,
+    lcomms: Option<String>,
+    origin: Option<BgpOrigin>,
+    local_pref: Option<u32>,
+    med: Option<u32>,
+    aigp: Option<i64>,
+    psid_li: Option<u32>,
+    otc: Option<u32>,
+    mpls_label: Option<String>,
+    peer_ip: String,
+    peer_asn: u32,
+    peer_type: u8,
+    peer_type_str: Option<String>,
+    peer_tcp_port: Option<u16>,
+    timestamp_arrival: Option<String>,
+    bmp_router: String,
+    bmp_router_port: Option<u16>,
+    bmp_msg_type: BmpMsgType,
+    bmp_rib_type: BmpRibType,
+    bgp_id: String,
+    is_filtered: u8,
+    is_in: Option<u8>,
+    is_loc: Option<u8>,
+    is_post: Option<u8>,
+    is_out: Option<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize, AvroSchema, PartialEq, Clone)]
+#[avro(name = "bmp_stats")]
+pub struct PmacctStatisticsReportMessage {
+    seq: u32,
+    timestamp: String,
+    timestamp_event: Option<String>,
+    timestamp_arrival: Option<String>,
+    event_type: EventType,
+    bmp_router: String,
+    bmp_router_port: Option<u16>,
+    bmp_msg_type: BmpMsgType,
+    writer_id: String,
+    tag: Option<i64>,
+    label: Option<HashMap<String, String>>,
+    peer_ip: String,
+    peer_asn: u32,
+    peer_type: u8,
+    peer_type_str: String,
+    bmp_rib_type: BmpRibType,
+    is_filtered: u8,
+    is_in: Option<u8>,
+    is_loc: Option<u8>,
+    is_post: Option<u8>,
+    is_out: Option<u8>,
+    rd: Option<String>,
+    rd_origin: Option<RdOrigin>,
+    bgp_id: String,
+    counter_type: u16,
+    counter_type_str: String,
+    counter_value: i64,
+    afi: Option<u16>,
+    safi: Option<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize, AvroSchema, PartialEq, Clone)]
+#[avro(name = "bmp_peer_down")]
+pub struct PmacctPeerDownNotificationMessage {
+    seq: u32,
+    timestamp: String,
+    timestamp_event: Option<String>,
+    timestamp_arrival: Option<String>,
+    event_type: EventType,
+    bmp_router: String,
+    bmp_router_port: Option<u16>,
+    bmp_msg_type: BmpMsgType,
+    writer_id: String,
+    tag: Option<i64>,
+    label: Option<HashMap<String, String>>,
+    peer_ip: String,
+    peer_asn: u32,
+    peer_type: u8,
+    peer_type_str: Option<String>,
+    bmp_rib_type: BmpRibType,
+    is_filtered: u8,
+    is_in: Option<u8>,
+    is_loc: Option<u8>,
+    is_post: Option<u8>,
+    is_out: Option<u8>,
+    rd: Option<String>,
+    rd_origin: Option<RdOrigin>,
+    bgp_id: String,
+    reason_type: u8,
+    reason_str: Option<String>,
+    reason_loc_code: Option<u16>,
+}
+
+#[derive(Debug, Serialize, Deserialize, AvroSchema, PartialEq, Clone)]
+#[avro(name = "bmp_peer_up")]
+pub struct PmacctPeerUpNotificationMessage {
+    seq: u32,
+    timestamp: String,
+    timestamp_event: Option<String>,
+    timestamp_arrival: Option<String>,
+    event_type: EventType,
+    bmp_router: String,
+    bmp_router_port: Option<u16>,
+    bmp_msg_type: BmpMsgType,
+    writer_id: String,
+    tag: Option<i64>,
+    label: Option<HashMap<String, String>>,
+    peer_ip: String,
+    peer_asn: u32,
+    peer_type: u8,
+    peer_type_str: Option<String>,
+    bmp_rib_type: BmpRibType,
+    is_filtered: u8,
+    is_in: Option<u8>,
+    is_loc: Option<u8>,
+    is_post: Option<u8>,
+    is_out: Option<u8>,
+    rd: Option<String>,
+    rd_origin: Option<RdOrigin>,
+    bgp_id: String,
+    local_port: u16,
+    remote_port: u16,
+    local_ip: String,
+    bmp_peer_up_info_string: Option<String>,
+    bmp_peer_up_info_vrf_table_name: Option<String>,
+    bmp_peer_up_info_admin_label: Option<String>,
+    bmp_peer_up_info_reserved: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, AvroSchema, PartialEq, Clone)]
+#[avro(name = "bmp_init")]
+pub struct PmacctInitiationMessage {
+    seq: u32,
+    timestamp: String,
+    timestamp_event: Option<String>,
+    timestamp_arrival: Option<String>,
+    event_type: EventType,
+    bmp_router: String,
+    bmp_router_port: Option<u16>,
+    bmp_msg_type: BmpMsgType,
+    writer_id: String,
+    tag: Option<i64>,
+    label: Option<HashMap<String, String>>,
+    bmp_init_info_string: Option<String>,
+    bmp_init_info_sysdescr: Option<String>,
+    bmp_init_info_sysname: Option<String>,
+    bmp_init_info_reserved: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, AvroSchema, PartialEq, Clone)]
+#[avro(name = "bmp_term")]
+pub struct PmacctTerminationMessage {
+    seq: u32,
+    timestamp: String,
+    timestamp_event: Option<String>,
+    timestamp_arrival: Option<String>,
+    event_type: EventType,
+    bmp_router: String,
+    bmp_router_port: Option<u16>,
+    bmp_msg_type: BmpMsgType,
+    writer_id: String,
+    tag: Option<i64>,
+    label: Option<HashMap<String, String>>,
+    bmp_term_info_string: Option<String>,
+    bmp_term_info_reason: Option<String>,
+}
+
+/// Classifies the type of route activity for a
+/// [`PmacctRouteMonitoringMessage`].
+#[derive(
+    strum_macros::Display,
+    strum_macros::EnumString,
+    Debug,
+    PartialEq,
+    Clone,
+    netgauze_serde_macros::StringBackedEnum,
+)]
+#[strum(serialize_all = "kebab-case")]
+pub enum LogType {
+    Update,
+    Withdraw,
+    Delete,
+    EndOfRib,
+}
+
+/// Classifies the high-level event context (e.g., real-time log vs. state
+/// dump).
+#[derive(
+    strum_macros::Display,
+    strum_macros::EnumString,
+    Debug,
+    PartialEq,
+    Clone,
+    netgauze_serde_macros::StringBackedEnum,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum EventType {
+    Log,
+    LogInit,
+    LogClose,
+    Dump,
+    DumpInit,
+    DumpClose,
+}
+
+/// Values for the BGP `Origin` path attribute.
+#[derive(
+    strum_macros::Display,
+    strum_macros::EnumString,
+    Debug,
+    PartialEq,
+    Clone,
+    netgauze_serde_macros::StringBackedEnum,
+)]
+pub enum BgpOrigin {
+    #[strum(to_string = "i")]
+    IGP,
+    #[strum(to_string = "e")]
+    EGP,
+    #[strum(to_string = "u")]
+    Unknown,
+}
+
+/// The origin of the Route Distinguisher (RD)
+#[derive(
+    strum_macros::Display,
+    strum_macros::EnumString,
+    Debug,
+    PartialEq,
+    Clone,
+    netgauze_serde_macros::StringBackedEnum,
+)]
+#[strum(serialize_all = "lowercase")]
+pub enum RdOrigin {
+    Unknown,
+    Bgp,
+    Bmp,
+    Flow,
+    Map,
+}
+
+/// Identifies the BMP message type.
+#[derive(
+    strum_macros::Display,
+    strum_macros::EnumString,
+    Debug,
+    PartialEq,
+    Clone,
+    netgauze_serde_macros::StringBackedEnum,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum BmpMsgType {
+    RouteMonitor,
+    Stats,
+    PeerDown,
+    PeerUp,
+    Init,
+    Term,
+    Internal,
+}
+
+/// Identifies which Routing Information Base (RIB) the routes belongs to.
+#[derive(
+    strum_macros::Display,
+    strum_macros::EnumString,
+    Debug,
+    PartialEq,
+    Clone,
+    netgauze_serde_macros::StringBackedEnum,
+)]
+pub enum BmpRibType {
+    #[strum(to_string = "Unknown")]
+    Unknown,
+    #[strum(to_string = "Adj-Rib-In Pre-Policy")]
+    AdjRibInPre,
+    #[strum(to_string = "Adj-Rib-In Post-Policy")]
+    AdjRibInPost,
+    #[strum(to_string = "Loc-Rib")]
+    LocRib,
+    #[strum(to_string = "Adj-Rib-Out Pre-Policy")]
+    AdjRibOutPre,
+    #[strum(to_string = "Adj-Rib-Out Post-Policy")]
+    AdjRibOutPost,
+}
+
+// ===== Conversion between BmpRequest and PmacctBmpMessage(s) ===============
+
+/// Additional metadata that is required to produce a [`PmacctBmpMessage`] but
+/// is not present in the BMP wire format.
+#[derive(Debug, Clone)]
+pub struct PmacctConversionContext {
+    /// Identifies the publisher instance (e.g. `"collector01 2025-01.1"`).
+    pub writer_id: String,
+    /// The event classification (e.g. [`EventType::Log`] or
+    /// [`EventType::Dump`]).
+    pub event_type: EventType,
+    /// Arrival time in the same `"<seconds>.<microseconds>"` format.
+    pub timestamp_arrival: String,
+    /// Optional tag value to attach to all produced messages.
+    pub tag: Option<i64>,
+    /// Optional label map (e.g. `node_id`, `platform_id`) to attach to all
+    /// produced messages.
+    pub label: Option<HashMap<String, String>>,
+}
+
+/// Errors produced during [`BmpRequest`] → [`PmacctBmpMessage`] conversion.
+#[derive(Debug, Clone, strum_macros::Display)]
+pub enum PmacctBmpConversionError {
+    /// The BMP message has no pmacct schema equivalent (e.g. RouteMirroring).
+    #[strum(to_string = "BMP message type '{0}' has no pmacct schema equivalent")]
+    UnsupportedMessageType(String),
+    /// A peer header was required but was not present in the message.
+    #[strum(to_string = "expected peer header not found in BMP message")]
+    MissingPeerHeader,
+    /// The peer header carries no timestamp.
+    #[strum(to_string = "peer header lacks a timestamp required by pmacct")]
+    MissingTimestamp,
+}
+
+impl std::error::Error for PmacctBmpConversionError {}
+
+// ----- Helpers -------------------------------------------------------------
+
+/// Safely casts a `u64` to an `i64`, clamping at `i64::MAX` on overflow.
+///
+/// This is necessary because Avro supports up to signed 64-bit integers
+/// (`long`), while BMP/BGP counters are often unsigned 64-bit integers.
+fn u64_to_i64_clamp(v: u64) -> i64 {
+    use std::convert::TryFrom;
+    i64::try_from(v).unwrap_or(i64::MAX)
+}
+
+/// Format a [`DateTime`] as the `"<unix_seconds>.<microseconds>"` string that
+/// pmacct uses for its `timestamp` and `timestamp_arrival` fields.
+fn fmt_ts(ts: &DateTime<Utc>) -> String {
+    format!("{}.{:06}", ts.timestamp(), ts.timestamp_subsec_micros())
+}
+
+/// Extract and format the timestamp from a [`PeerHeader`].
+fn peer_header_ts(ph: &PeerHeader) -> Result<String, PmacctBmpConversionError> {
+    ph.timestamp()
+        .map(fmt_ts)
+        .ok_or(PmacctBmpConversionError::MissingTimestamp)
+}
+
+/// Derive `(bmp_rib_type, is_filtered, is_in, is_loc, is_post, is_out)` from
+/// a [`BmpPeerType`].
+fn rib_type_and_flags(
+    pt: BmpPeerType,
+) -> (
+    BmpRibType,
+    u8,
+    Option<u8>,
+    Option<u8>,
+    Option<u8>,
+    Option<u8>,
+) {
+    match pt {
+        BmpPeerType::LocRibInstancePeer { filtered } => (
+            BmpRibType::LocRib,
+            if filtered { 1 } else { 0 },
+            None,
+            Some(1),
+            None,
+            None,
+        ),
+        BmpPeerType::GlobalInstancePeer {
+            post_policy,
+            adj_rib_out,
+            ..
+        }
+        | BmpPeerType::RdInstancePeer {
+            post_policy,
+            adj_rib_out,
+            ..
+        }
+        | BmpPeerType::LocalInstancePeer {
+            post_policy,
+            adj_rib_out,
+            ..
+        } => {
+            let rib = match (adj_rib_out, post_policy) {
+                (false, false) => BmpRibType::AdjRibInPre,
+                (false, true) => BmpRibType::AdjRibInPost,
+                (true, false) => BmpRibType::AdjRibOutPre,
+                (true, true) => BmpRibType::AdjRibOutPost,
+            };
+            let (is_in, is_loc, is_post, is_out) = match (adj_rib_out, post_policy) {
+                (false, false) => (Some(1u8), None, None, None),
+                (false, true) => (Some(1u8), None, Some(1u8), None),
+                (true, false) => (None, None, None, Some(1u8)),
+                (true, true) => (None, None, Some(1u8), Some(1u8)),
+            };
+            (rib, 0, is_in, is_loc, is_post, is_out)
+        }
+        _ => (BmpRibType::Unknown, 0, None, None, None, None),
+    }
+}
+
+/// Derive `(peer_type_code, peer_type_string)` from a [`BmpPeerType`].
+fn peer_type_fields(pt: BmpPeerType) -> (u8, String) {
+    let code = pt.get_type();
+    (code.into(), code.to_string())
+}
+
+/// Format a [`RouteDistinguisher`] according to pmacct format
+fn rd_and_origin(
+    rd: Option<RouteDistinguisher>,
+    rd_origin: RdOrigin,
+) -> (Option<String>, Option<RdOrigin>) {
+    match rd {
+        None => (None, None),
+        Some(RouteDistinguisher::As2Administrator { asn2, number }) => {
+            (Some(format!("0:{asn2}:{number}")), Some(rd_origin))
+        }
+        Some(RouteDistinguisher::Ipv4Administrator { ip, number }) => {
+            (Some(format!("1:{ip}:{number}")), Some(rd_origin))
+        }
+        Some(RouteDistinguisher::As4Administrator { asn4, number }) => {
+            (Some(format!("2:{asn4}:{number}")), Some(rd_origin))
+        }
+        Some(RouteDistinguisher::LeafAdRoutes) => {
+            (Some("3:leaf-A-D-route".to_string()), Some(rd_origin))
+        }
+    }
+}
+
+/// Extract `(counter_value_as_i64, optional_address_type)` from a
+/// [`v3::StatisticsCounter`].
+fn counter_value_and_addr_type(c: &v3::StatisticsCounter) -> (i64, Option<AddressType>) {
+    use v3::StatisticsCounter::*;
+    match c {
+        NumberOfPrefixesRejectedByInboundPolicy(v) => (**v as i64, None),
+        NumberOfDuplicatePrefixAdvertisements(v) => (**v as i64, None),
+        NumberOfDuplicateWithdraws(v) => (**v as i64, None),
+        NumberOfUpdatesInvalidatedDueToClusterListLoop(v) => (**v as i64, None),
+        NumberOfUpdatesInvalidatedDueToAsPathLoop(v) => (**v as i64, None),
+        NumberOfUpdatesInvalidatedDueToOriginatorId(v) => (**v as i64, None),
+        NumberOfUpdatesInvalidatedDueToAsConfederationLoop(v) => (**v as i64, None),
+        NumberOfRoutesInAdjRibIn(v) => (u64_to_i64_clamp(**v), None),
+        NumberOfRoutesInLocRib(v) => (u64_to_i64_clamp(**v), None),
+        NumberOfRoutesInPerAfiSafiAdjRibIn(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfRoutesInPerAfiSafiLocRib(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfUpdatesSubjectedToTreatAsWithdraw(v) => (**v as i64, None),
+        NumberOfPrefixesSubjectedToTreatAsWithdraw(v) => (**v as i64, None),
+        NumberOfDuplicateUpdateMessagesReceived(v) => (**v as i64, None),
+        NumberOfRoutesInPrePolicyAdjRibOut(v) => (u64_to_i64_clamp(**v), None),
+        NumberOfRoutesInPostPolicyAdjRibOut(v) => (u64_to_i64_clamp(**v), None),
+        NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOut(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOut(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfRoutesInPrePolicyAdjRibIn(v) => (u64_to_i64_clamp(**v), None),
+        NumberOfRoutesInPerAfiSafiPrePolicyAdjRibIn(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfRoutesInPostPolicyAdjRibIn(v) => (u64_to_i64_clamp(**v), None),
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibIn(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejected(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInAccepted(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiSuppressedByDamping(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfRoutesInPerAfiSafiMarkedStaleByGr(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfRoutesInPerAfiSafiMarkedStaleByLlgr(at, v) => (u64_to_i64_clamp(**v), Some(*at)),
+        NumberOfRoutesInPostPolicyAdjRibInBeforeThreshold(v) => (u64_to_i64_clamp(**v), None),
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInBeforeThreshold(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(v) => {
+            (u64_to_i64_clamp(**v), None)
+        }
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInOrLocRibBeforeLicenseThreshold(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPrePolicyAdjRibInRejectedDueToAsPathLength(v) => {
+            (u64_to_i64_clamp(**v), None)
+        }
+        NumberOfRoutesInPerAfiSafiPrePolicyAdjRibInRejectedDueToAsPathLength(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInInvalidatedByRpki(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInValidatedByRpki(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibInRpkiNotFound(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutRejected(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPrePolicyAdjRibOutFilteredDueToAsPathLength(v) => {
+            (u64_to_i64_clamp(**v), None)
+        }
+        NumberOfRoutesInPerAfiSafiPrePolicyAdjRibOutFilteredDueToAsPathLength(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound(at, v) => {
+            (u64_to_i64_clamp(**v), Some(*at))
+        }
+        Experimental65531(_) | Experimental65532(_) | Experimental65533(_)
+        | Experimental65534(_) => (0, None),
+        Unknown(_, _) => (0, None),
+    }
+}
+
+// TODO: add this as getter in the native type
+/// Compute the 20-bit MPLS label value from a 3-byte [`MplsLabel`].
+fn mpls_label_value(label: &MplsLabel) -> u32 {
+    let b = label.value();
+    ((b[0] as u32) << 12) | ((b[1] as u32) << 4) | ((b[2] as u32) >> 4)
+}
+
+/// Count the number of AS numbers in an [`AsPath`].
+/// - Each AS_SEQUENCE member counts as 1 per ASN.
+/// - Each AS_SET counts as 1, regardless of the number of ASNs in the set.
+fn count_as_path_asns(ap: &AsPath) -> usize {
+    match ap {
+        AsPath::As2PathSegments(segs) => segs
+            .iter()
+            .map(|s| match s.segment_type() {
+                AsPathSegmentType::AsSequence => s.as_numbers().len(),
+                AsPathSegmentType::AsSet => 1,
+            })
+            .sum(),
+        AsPath::As4PathSegments(segs) => segs
+            .iter()
+            .map(|s| match s.segment_type() {
+                AsPathSegmentType::AsSequence => s.as_numbers().len(),
+                AsPathSegmentType::AsSet => 1,
+            })
+            .sum(),
+    }
+}
+
+/// Count the number of AS numbers in an [`As4Path`].
+/// - Each AS_SEQUENCE member counts as 1 per ASN.
+/// - Each AS_SET counts as 1, regardless of the number of ASNs in the set.
+fn count_as4_path_asns(ap: &As4Path) -> usize {
+    ap.segments()
+        .iter()
+        .map(|s| match s.segment_type() {
+            AsPathSegmentType::AsSequence => s.as_numbers().len(),
+            AsPathSegmentType::AsSet => 1,
+        })
+        .sum()
+}
+
+/// Format an [`AsPath`] as a space-separated string of AS numbers.
+/// `AsSet` segments are wrapped in braces: `{A B C}`
+fn fmt_as_path(ap: &AsPath) -> String {
+    match ap {
+        AsPath::As2PathSegments(segs) => segs
+            .iter()
+            .map(|s| match s.segment_type() {
+                AsPathSegmentType::AsSet => {
+                    let inner = s
+                        .as_numbers()
+                        .iter()
+                        .map(|n| n.to_string())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    format!("{{{inner}}}")
+                }
+                _ => s
+                    .as_numbers()
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            })
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join(" "),
+        AsPath::As4PathSegments(segs) => segs
+            .iter()
+            .map(|s| match s.segment_type() {
+                AsPathSegmentType::AsSet => {
+                    let inner = s
+                        .as_numbers()
+                        .iter()
+                        .map(|n| n.to_string())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    format!("{{{inner}}}")
+                }
+                _ => s
+                    .as_numbers()
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            })
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join(" "),
+    }
+}
+
+/// Format an [`As4Path`] (the supplementary 4-byte AS_PATH attribute) the
+/// same way as [`fmt_as_path`].
+fn fmt_as4_path(ap: &As4Path) -> String {
+    ap.segments()
+        .iter()
+        .map(|s| match s.segment_type() {
+            AsPathSegmentType::AsSet => {
+                let inner = s
+                    .as_numbers()
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                format!("{{{inner}}}")
+            }
+            _ => s
+                .as_numbers()
+                .iter()
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+                .join(" "),
+        })
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Format only the leading `n` AS numbers from an [`AsPath`] as a string,
+/// preserving segment structure. AS_SET segments are counted as 1.
+/// Used for merging AS_PATH and AS4_PATH per RFC 4893.
+fn fmt_as_path_prefix(ap: &AsPath, mut n: usize) -> String {
+    let mut parts = Vec::new();
+    match ap {
+        AsPath::As2PathSegments(segs) => {
+            for seg in segs {
+                if n == 0 {
+                    break;
+                }
+                match seg.segment_type() {
+                    AsPathSegmentType::AsSet => {
+                        let inner = seg
+                            .as_numbers()
+                            .iter()
+                            .map(|v| v.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        parts.push(format!("{{{inner}}}"));
+                        n -= 1;
+                    }
+                    AsPathSegmentType::AsSequence => {
+                        let take = n.min(seg.as_numbers().len());
+                        let chunk = seg.as_numbers()[..take]
+                            .iter()
+                            .map(|v| v.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        if !chunk.is_empty() {
+                            parts.push(chunk);
+                        }
+                        n -= take;
+                    }
+                }
+            }
+        }
+        AsPath::As4PathSegments(segs) => {
+            for seg in segs {
+                if n == 0 {
+                    break;
+                }
+                match seg.segment_type() {
+                    AsPathSegmentType::AsSet => {
+                        let inner = seg
+                            .as_numbers()
+                            .iter()
+                            .map(|v| v.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        parts.push(format!("{{{inner}}}"));
+                        n -= 1;
+                    }
+                    AsPathSegmentType::AsSequence => {
+                        let take = n.min(seg.as_numbers().len());
+                        let chunk = seg.as_numbers()[..take]
+                            .iter()
+                            .map(|v| v.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        if !chunk.is_empty() {
+                            parts.push(chunk);
+                        }
+                        n -= take;
+                    }
+                }
+            }
+        }
+    }
+    parts
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// TODO: this needs to be verified and tested
+/// Merge [`AsPath`] and [`As4Path`] per RFC 4893.
+/// - If only AS_PATH is present, formats and returns that one.
+/// - If both are present, reconstructs the full path by taking the leading
+///   (AS_PATH.len - AS4_PATH.len) ASNs from AS_PATH, then appending AS4_PATH.
+/// - If AS_PATH is shorter than AS4_PATH, returns AS_PATH (cannot reconstruct).
+/// - If only AS4_PATH is present (should not happen in valid BGP), returns it
+///   defensively.
+fn merge_as_path(as_path: Option<&AsPath>, as4_path: Option<&As4Path>) -> Option<String> {
+    match (as_path, as4_path) {
+        (None, None) => None,
+        (Some(ap), None) => Some(fmt_as_path(ap)),
+        (None, Some(a4p)) => Some(fmt_as4_path(a4p)),
+        (Some(ap), Some(a4p)) => {
+            let n_aspath = count_as_path_asns(ap);
+            let n_as4path = count_as4_path_asns(a4p);
+            if n_aspath < n_as4path {
+                Some(fmt_as_path(ap))
+            } else {
+                let prefix_count = n_aspath - n_as4path;
+                let prefix = fmt_as_path_prefix(ap, prefix_count);
+                let tail = fmt_as4_path(a4p);
+                match (prefix.is_empty(), tail.is_empty()) {
+                    (true, _) => Some(tail),
+                    (_, true) => Some(prefix),
+                    _ => Some(format!("{prefix} {tail}")),
+                }
+            }
+        }
+    }
+}
+
+/// Format a [`Communities`] attribute as a space-separated `ASN:value` string.
+fn fmt_comms(c: &Communities) -> String {
+    c.communities()
+        .iter()
+        .map(|c| c.to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Format an [`ExtendedCommunities`] attribute as a space-separated uppercase
+/// string (e.g. `RT:64497:1 RT:64498:2`).
+fn fmt_ecomms(ec: &ExtendedCommunities) -> String {
+    ec.communities()
+        .iter()
+        .map(|c| c.to_string().to_uppercase())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Format a [`LargeCommunities`] attribute as a space-separated
+/// `GA:LD1:LD2` string.
+fn fmt_lcomms(lc: &LargeCommunities) -> String {
+    lc.communities()
+        .iter()
+        .map(|c| c.to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ----- Per-Type Converters -------------------------------------------------
+
+/// Converts a BMP Initiation message into a [`PmacctBmpMessage::Initiation`].
+fn convert_initiation(
+    addr_info: &AddrInfo,
+    msg: &v3::InitiationMessage,
+    ctx: &PmacctConversionContext,
+) -> Result<PmacctBmpMessage, PmacctBmpConversionError> {
+    let bmp_router = addr_info.remote_socket().ip().to_string();
+    let bmp_router_port = Some(addr_info.remote_socket().port());
+
+    let mut bmp_init_info_string = None;
+    let mut bmp_init_info_sysdescr = None;
+    let mut bmp_init_info_sysname = None;
+    let mut bmp_init_info_reserved: Option<String> = None;
+
+    for info in msg.information() {
+        match info {
+            v3::InitiationInformation::String(s) => bmp_init_info_string = Some(s.clone()),
+            v3::InitiationInformation::SystemDescription(s) => {
+                bmp_init_info_sysdescr = Some(s.clone())
+            }
+            v3::InitiationInformation::SystemName(s) => bmp_init_info_sysname = Some(s.clone()),
+            other => {
+                let reserved = bmp_init_info_reserved.get_or_insert_with(String::new);
+                if !reserved.is_empty() {
+                    reserved.push(' ');
+                }
+                reserved.push_str(&format!("{other:?}"));
+            }
+        }
+    }
+
+    Ok(PmacctBmpMessage::Initiation(PmacctInitiationMessage {
+        seq: 0,
+        timestamp: ctx.timestamp_arrival.clone(), // fallback (since no timestamp in Init msg)
+        timestamp_event: None,
+        timestamp_arrival: Some(ctx.timestamp_arrival.clone()),
+        event_type: ctx.event_type.clone(),
+        bmp_router,
+        bmp_router_port,
+        bmp_msg_type: BmpMsgType::Init,
+        writer_id: ctx.writer_id.clone(),
+        tag: ctx.tag,
+        label: ctx.label.clone(),
+        bmp_init_info_string,
+        bmp_init_info_sysdescr,
+        bmp_init_info_sysname,
+        bmp_init_info_reserved,
+    }))
+}
+
+/// Converts a BMP Termination message into a [`PmacctBmpMessage::Termination`].
+fn convert_termination(
+    addr_info: &AddrInfo,
+    msg: &v3::TerminationMessage,
+    ctx: &PmacctConversionContext,
+) -> Result<PmacctBmpMessage, PmacctBmpConversionError> {
+    let bmp_router = addr_info.remote_socket().ip().to_string();
+    let bmp_router_port = Some(addr_info.remote_socket().port());
+
+    let mut bmp_term_info_string = None;
+    let mut bmp_term_info_reason = None;
+
+    for info in msg.information() {
+        match info {
+            v3::TerminationInformation::String(s) => bmp_term_info_string = Some(s.clone()),
+            v3::TerminationInformation::Reason(code) => {
+                bmp_term_info_reason = Some(code.to_string())
+            }
+            _ => {}
+        }
+    }
+
+    Ok(PmacctBmpMessage::Termination(PmacctTerminationMessage {
+        seq: 0,
+        timestamp: ctx.timestamp_arrival.clone(), // fallback (since no timestamp in Term msg)
+        timestamp_event: None,
+        timestamp_arrival: Some(ctx.timestamp_arrival.clone()),
+        event_type: ctx.event_type.clone(),
+        bmp_router,
+        bmp_router_port,
+        bmp_msg_type: BmpMsgType::Term,
+        writer_id: ctx.writer_id.clone(),
+        tag: ctx.tag,
+        label: ctx.label.clone(),
+        bmp_term_info_string,
+        bmp_term_info_reason,
+    }))
+}
+
+/// Converts a BMP Peer Up message into a
+/// [`PmacctBmpMessage::PeerUpNotification`].
+fn convert_peer_up(
+    addr_info: &AddrInfo,
+    msg: &v3::PeerUpNotificationMessage,
+    ctx: &PmacctConversionContext,
+) -> Result<PmacctBmpMessage, PmacctBmpConversionError> {
+    let ph = msg.peer_header();
+    let timestamp = peer_header_ts(ph)?;
+    let bmp_router = addr_info.remote_socket().ip().to_string();
+    let bmp_router_port = Some(addr_info.remote_socket().port());
+
+    let (peer_type, peer_type_str) = peer_type_fields(ph.peer_type());
+    let (bmp_rib_type, is_filtered, is_in, is_loc, is_post, is_out) =
+        rib_type_and_flags(ph.peer_type());
+    let (rd, rd_origin) = rd_and_origin(ph.rd(), RdOrigin::Bmp);
+
+    let mut bmp_peer_up_info_string = None;
+    let mut bmp_peer_up_info_vrf_table_name = None;
+    let mut bmp_peer_up_info_admin_label = None;
+    let mut bmp_peer_up_info_reserved: Option<String> = None;
+
+    for info in msg.information() {
+        match info {
+            v3::InitiationInformation::String(s) => bmp_peer_up_info_string = Some(s.clone()),
+            v3::InitiationInformation::VrfTableName(s) => {
+                bmp_peer_up_info_vrf_table_name = Some(s.clone())
+            }
+            v3::InitiationInformation::AdminLabel(s) => {
+                bmp_peer_up_info_admin_label = Some(s.clone())
+            }
+            other => {
+                let reserved = bmp_peer_up_info_reserved.get_or_insert_with(String::new);
+                if !reserved.is_empty() {
+                    reserved.push(' ');
+                }
+                reserved.push_str(&format!("{other:?}"));
+            }
+        }
+    }
+
+    Ok(PmacctBmpMessage::PeerUpNotification(
+        PmacctPeerUpNotificationMessage {
+            seq: 0,
+            timestamp: timestamp.clone(),
+            timestamp_event: Some(timestamp),
+            timestamp_arrival: Some(ctx.timestamp_arrival.clone()),
+            event_type: ctx.event_type.clone(),
+            bmp_router,
+            bmp_router_port,
+            bmp_msg_type: BmpMsgType::PeerUp,
+            writer_id: ctx.writer_id.clone(),
+            tag: ctx.tag,
+            label: ctx.label.clone(),
+            peer_ip: ph
+                .address()
+                .map_or_else(|| "0.0.0.0".to_string(), |ip| ip.to_string()),
+            peer_asn: ph.peer_as(),
+            peer_type,
+            peer_type_str: Some(peer_type_str),
+            bmp_rib_type,
+            is_filtered,
+            is_in,
+            is_loc,
+            is_post,
+            is_out,
+            rd,
+            rd_origin,
+            bgp_id: ph.bgp_id().to_string(),
+            local_port: msg.local_port().unwrap_or(0),
+            remote_port: msg.remote_port().unwrap_or(0),
+            local_ip: msg
+                .local_address()
+                .map_or_else(|| "0.0.0.0".to_string(), |ip| ip.to_string()),
+            bmp_peer_up_info_string,
+            bmp_peer_up_info_vrf_table_name,
+            bmp_peer_up_info_admin_label,
+            bmp_peer_up_info_reserved,
+        },
+    ))
+}
+
+/// Converts a BMP Peer Down message into a
+/// [`PmacctBmpMessage::PeerDownNotification`].
+fn convert_peer_down(
+    addr_info: &AddrInfo,
+    ph: &PeerHeader,
+    reason: &v3::PeerDownNotificationReason,
+    ctx: &PmacctConversionContext,
+) -> Result<PmacctBmpMessage, PmacctBmpConversionError> {
+    let timestamp = peer_header_ts(ph)?;
+    let bmp_router = addr_info.remote_socket().ip().to_string();
+    let bmp_router_port = Some(addr_info.remote_socket().port());
+
+    let (peer_type, peer_type_str) = peer_type_fields(ph.peer_type());
+    let (bmp_rib_type, is_filtered, is_in, is_loc, is_post, is_out) =
+        rib_type_and_flags(ph.peer_type());
+    let (rd, rd_origin) = rd_and_origin(ph.rd(), RdOrigin::Bmp);
+
+    let reason_type = u8::from(reason.get_type());
+    let reason_str = Some(reason.get_type().to_string());
+    let reason_loc_code = match reason {
+        v3::PeerDownNotificationReason::LocalSystemClosedFsmEventFollows(code) => Some(*code),
+        _ => None,
+    };
+
+    Ok(PmacctBmpMessage::PeerDownNotification(
+        PmacctPeerDownNotificationMessage {
+            seq: 0,
+            timestamp: timestamp.clone(),
+            timestamp_event: Some(timestamp),
+            timestamp_arrival: Some(ctx.timestamp_arrival.clone()),
+            event_type: ctx.event_type.clone(),
+            bmp_router,
+            bmp_router_port,
+            bmp_msg_type: BmpMsgType::PeerDown,
+            writer_id: ctx.writer_id.clone(),
+            tag: ctx.tag,
+            label: ctx.label.clone(),
+            peer_ip: ph
+                .address()
+                .map_or_else(|| "0.0.0.0".to_string(), |ip| ip.to_string()),
+            peer_asn: ph.peer_as(),
+            peer_type,
+            peer_type_str: Some(peer_type_str),
+            bmp_rib_type,
+            is_filtered,
+            is_in,
+            is_loc,
+            is_post,
+            is_out,
+            rd,
+            rd_origin,
+            bgp_id: ph.bgp_id().to_string(),
+            reason_type,
+            reason_str,
+            reason_loc_code,
+        },
+    ))
+}
+
+/// Converts a BMP Statistics Report into multiple
+/// [`PmacctBmpMessage::StatisticsReport`] messages, one per counter.
+fn convert_statistics_report(
+    addr_info: &AddrInfo,
+    msg: &v3::StatisticsReportMessage,
+    ctx: &PmacctConversionContext,
+) -> Result<Vec<PmacctBmpMessage>, PmacctBmpConversionError> {
+    let ph = msg.peer_header();
+    let timestamp = peer_header_ts(ph)?;
+    let bmp_router = addr_info.remote_socket().ip().to_string();
+    let bmp_router_port = Some(addr_info.remote_socket().port());
+
+    let (peer_type, peer_type_str) = peer_type_fields(ph.peer_type());
+    let (bmp_rib_type, is_filtered, is_in, is_loc, is_post, is_out) =
+        rib_type_and_flags(ph.peer_type());
+    let (rd, rd_origin) = rd_and_origin(ph.rd(), RdOrigin::Bmp);
+
+    let mut out = Vec::with_capacity(msg.counters().len());
+    for counter in msg.counters() {
+        let (counter_type, counter_type_str) = match counter.get_type() {
+            Ok(t) => (u16::from(t), t.to_string()),
+            Err(code) => (code, format!("Unknown({code})")),
+        };
+        let (counter_value, addr_type) = counter_value_and_addr_type(counter);
+        let afi = addr_type.map(|at| u16::from(at.address_family()));
+        let safi = addr_type.map(|at| u8::from(at.subsequent_address_family()));
+
+        out.push(PmacctBmpMessage::StatisticsReport(
+            PmacctStatisticsReportMessage {
+                seq: 0,
+                timestamp: timestamp.clone(),
+                timestamp_event: Some(timestamp.clone()),
+                timestamp_arrival: Some(ctx.timestamp_arrival.clone()),
+                event_type: ctx.event_type.clone(),
+                bmp_router: bmp_router.clone(),
+                bmp_router_port,
+                bmp_msg_type: BmpMsgType::Stats,
+                writer_id: ctx.writer_id.clone(),
+                tag: ctx.tag,
+                label: ctx.label.clone(),
+                peer_ip: ph
+                    .address()
+                    .map_or_else(|| "0.0.0.0".to_string(), |ip| ip.to_string()),
+                peer_asn: ph.peer_as(),
+                peer_type,
+                peer_type_str: peer_type_str.clone(),
+                bmp_rib_type: bmp_rib_type.clone(),
+                is_filtered,
+                is_in,
+                is_loc,
+                is_post,
+                is_out,
+                rd: rd.clone(),
+                rd_origin: rd_origin.clone(),
+                bgp_id: ph.bgp_id().to_string(),
+                counter_type,
+                counter_type_str,
+                counter_value,
+                afi,
+                safi,
+            },
+        ));
+    }
+    Ok(out)
+}
+
+/// Converts a BMP Route Monitoring message into multiple
+/// [`PmacctBmpMessage::RouteMonitoring`] messages.
+///
+/// This handles:
+/// - Iterating over all NLRI (announced prefixes) and generating an "Update"
+///   message for each.
+/// - Iterating over all withdrawn routes and generating a "Withdraw" message
+///   for each.
+/// - Flattening path attributes (AS Path, Communities, etc.) into the struct
+///   fields.
+fn convert_route_monitoring(
+    addr_info: &AddrInfo,
+    ph: &PeerHeader,
+    bgp_update: &BgpMessage,
+    ctx: &PmacctConversionContext,
+) -> Result<Vec<PmacctBmpMessage>, PmacctBmpConversionError> {
+    // Only BGP Update messages are valid inside a Route Monitoring message.
+    let update = match bgp_update {
+        BgpMessage::Update(u) => u,
+        _ => return Ok(vec![]),
+    };
+
+    let timestamp = peer_header_ts(ph)?;
+    let bmp_router = addr_info.remote_socket().ip().to_string();
+    let bmp_router_port = Some(addr_info.remote_socket().port());
+
+    let (peer_type, peer_type_str) = peer_type_fields(ph.peer_type());
+    let (bmp_rib_type, is_filtered, is_in, is_loc, is_post, is_out) =
+        rib_type_and_flags(ph.peer_type());
+
+    let peer_ip = ph
+        .address()
+        .map_or_else(|| "0.0.0.0".to_string(), |ip| ip.to_string());
+    let peer_asn = ph.peer_as();
+    let peer_tcp_port = None;
+    let bgp_id = ph.bgp_id().to_string();
+
+    // RD from peer header; for VPN NLRI variants this will be overridden
+    // per-prefix.
+    let (peer_rd, peer_rd_origin) = rd_and_origin(ph.rd(), RdOrigin::Bmp);
+
+    // ---- Extract shared path attributes ------------------------------------
+    let mut origin: Option<BgpOrigin> = None;
+    let mut as_path_attr: Option<&AsPath> = None;
+    let mut as4_path_attr: Option<&As4Path> = None;
+    let mut next_hop_ipv4: Option<String> = None;
+    let mut local_pref: Option<u32> = None;
+    let mut med: Option<u32> = None;
+    let mut comms: Option<String> = None;
+    let mut ecomms: Option<String> = None;
+    let mut lcomms: Option<String> = None;
+    let mut aigp: Option<i64> = None;
+    let mut otc: Option<u32> = None;
+    let mut psid_li: Option<u32> = None;
+    let mut mp_reach: Option<&MpReach> = None;
+    let mut mp_unreach: Option<&MpUnreach> = None;
+
+    for attr in update.path_attributes() {
+        match attr.value() {
+            PathAttributeValue::Origin(o) => {
+                origin = Some(match o {
+                    Origin::IGP => BgpOrigin::IGP,
+                    Origin::EGP => BgpOrigin::EGP,
+                    Origin::Incomplete => BgpOrigin::Unknown,
+                });
+            }
+            PathAttributeValue::AsPath(ap) => {
+                as_path_attr = Some(ap);
+            }
+            PathAttributeValue::As4Path(ap) => {
+                as4_path_attr = Some(ap);
+            }
+            PathAttributeValue::NextHop(nh) => {
+                next_hop_ipv4 = Some(nh.next_hop().to_string());
+            }
+            PathAttributeValue::LocalPreference(lp) => {
+                local_pref = Some(lp.metric());
+            }
+            PathAttributeValue::MultiExitDiscriminator(m) => {
+                med = Some(m.metric());
+            }
+            PathAttributeValue::Communities(c) => {
+                comms = Some(fmt_comms(c));
+            }
+            PathAttributeValue::ExtendedCommunities(ec) => {
+                ecomms = Some(fmt_ecomms(ec));
+            }
+            PathAttributeValue::LargeCommunities(lc) => {
+                lcomms = Some(fmt_lcomms(lc));
+            }
+            PathAttributeValue::Aigp(Aigp::AccumulatedIgpMetric(v)) => {
+                aigp = Some(u64_to_i64_clamp(*v));
+            }
+            PathAttributeValue::OnlyToCustomer(o) => {
+                otc = Some(o.asn());
+            }
+            PathAttributeValue::PrefixSegmentIdentifier(p) => {
+                for tlv in p.tlvs() {
+                    if let BgpSidAttribute::LabelIndex { label_index, .. } = tlv {
+                        psid_li = Some(*label_index);
+                        break;
+                    }
+                }
+            }
+            PathAttributeValue::MpReach(mr) => {
+                mp_reach = Some(mr);
+            }
+            PathAttributeValue::MpUnreach(mu) => {
+                mp_unreach = Some(mu);
+            }
+            _ => {}
+        }
+    }
+
+    let as_path_str = merge_as_path(as_path_attr, as4_path_attr);
+
+    // ---- Per-prefix closure ------------------------------------------------
+    // Captures the shared fields; per-NLRI parameters are passed as arguments.
+    let build_msg = |log_type: LogType,
+                     afi: u16,
+                     safi: u8,
+                     ip_prefix: Option<String>,
+                     rd: Option<String>,
+                     rd_origin: Option<RdOrigin>,
+                     bgp_nexthop: Option<String>,
+                     as_path_id: Option<u32>,
+                     mpls_label: Option<String>| {
+        PmacctBmpMessage::RouteMonitoring(PmacctRouteMonitoringMessage {
+            log_type,
+            seq: 0,
+            timestamp: timestamp.clone(),
+            event_type: ctx.event_type.clone(),
+            writer_id: ctx.writer_id.clone(),
+            tag: ctx.tag,
+            label: ctx.label.clone(),
+            afi,
+            safi,
+            ip_prefix,
+            rd,
+            rd_origin,
+            bgp_nexthop,
+            as_path: as_path_str.clone(),
+            as_path_id,
+            comms: comms.clone(),
+            ecomms: ecomms.clone(),
+            lcomms: lcomms.clone(),
+            origin: origin.clone(),
+            local_pref,
+            med,
+            aigp,
+            psid_li,
+            otc,
+            mpls_label,
+            peer_ip: peer_ip.clone(),
+            peer_asn,
+            peer_type,
+            peer_type_str: Some(peer_type_str.clone()),
+            peer_tcp_port,
+            timestamp_arrival: Some(ctx.timestamp_arrival.clone()),
+            bmp_router: bmp_router.clone(),
+            bmp_router_port,
+            bmp_msg_type: BmpMsgType::RouteMonitor,
+            bmp_rib_type: bmp_rib_type.clone(),
+            bgp_id: bgp_id.clone(),
+            is_filtered,
+            is_in,
+            is_loc,
+            is_post,
+            is_out,
+        })
+    };
+
+    // ---- End-of-RIB shortcut -----------------------------------------------
+    if let Some(addr_type) = update.end_of_rib() {
+        let afi = u16::from(addr_type.address_family());
+        let safi = u8::from(addr_type.subsequent_address_family());
+        return Ok(vec![build_msg(
+            LogType::EndOfRib,
+            afi,
+            safi,
+            None,
+            peer_rd,
+            peer_rd_origin,
+            None,
+            None,
+            None,
+        )]);
+    }
+
+    let mut out: Vec<PmacctBmpMessage> = Vec::new();
+
+    // ---- IPv4 unicast body withdrawals ------------------------------------
+    for e in update.withdraw_routes() {
+        let afi = u16::from(AddressType::Ipv4Unicast.address_family());
+        let safi = u8::from(AddressType::Ipv4Unicast.subsequent_address_family());
+        out.push(build_msg(
+            LogType::Withdraw,
+            afi,
+            safi,
+            Some(e.network().to_string()),
+            peer_rd.clone(),
+            peer_rd_origin.clone(),
+            None,
+            e.path_id(),
+            None,
+        ));
+    }
+
+    // ---- IPv4 unicast body NLRI (reachable) --------------------------------
+    for e in update.nlri() {
+        let afi = u16::from(AddressType::Ipv4Unicast.address_family());
+        let safi = u8::from(AddressType::Ipv4Unicast.subsequent_address_family());
+        out.push(build_msg(
+            LogType::Update,
+            afi,
+            safi,
+            Some(e.network().to_string()),
+            peer_rd.clone(),
+            peer_rd_origin.clone(),
+            next_hop_ipv4.clone(),
+            e.path_id(),
+            None,
+        ));
+    }
+
+    // ---- MP_REACH_NLRI -----------------------------------------------------
+    if let Some(mr) = mp_reach {
+        let afi = u16::from(mr.afi());
+        let safi = u8::from(mr.safi());
+        match mr {
+            MpReach::Ipv4Unicast { next_hop, nlri, .. } => {
+                let nh = Some(next_hop.to_string());
+                for e in nlri {
+                    out.push(build_msg(
+                        LogType::Update,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        nh.clone(),
+                        e.path_id(),
+                        None,
+                    ));
+                }
+            }
+            MpReach::Ipv4Multicast { next_hop, nlri, .. } => {
+                let nh = Some(next_hop.to_string());
+                for e in nlri {
+                    out.push(build_msg(
+                        LogType::Update,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        nh.clone(),
+                        e.path_id(),
+                        None,
+                    ));
+                }
+            }
+            MpReach::Ipv4NlriMplsLabels { next_hop, nlri, .. } => {
+                let nh = Some(next_hop.to_string());
+                for e in nlri {
+                    let label = e.labels().first().map(|l| mpls_label_value(l).to_string());
+                    out.push(build_msg(
+                        LogType::Update,
+                        afi,
+                        safi,
+                        Some(e.prefix().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        nh.clone(),
+                        e.path_id(),
+                        label,
+                    ));
+                }
+            }
+            MpReach::Ipv4MplsVpnUnicast { next_hop, nlri } => {
+                let nh = Some(next_hop.next_hop().to_string());
+                for e in nlri {
+                    let (nlri_rd, nlri_rd_origin) = rd_and_origin(Some(e.rd()), RdOrigin::Bgp);
+                    let label = e
+                        .label_stack()
+                        .first()
+                        .map(|l| mpls_label_value(l).to_string());
+                    out.push(build_msg(
+                        LogType::Update,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        nlri_rd,
+                        nlri_rd_origin,
+                        nh.clone(),
+                        e.path_id(),
+                        label,
+                    ));
+                }
+            }
+            MpReach::Ipv6Unicast {
+                next_hop_global,
+                nlri,
+                ..
+            } => {
+                let nh = Some(next_hop_global.to_string());
+                for e in nlri {
+                    out.push(build_msg(
+                        LogType::Update,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        nh.clone(),
+                        e.path_id(),
+                        None,
+                    ));
+                }
+            }
+            MpReach::Ipv6Multicast {
+                next_hop_global,
+                nlri,
+                ..
+            } => {
+                let nh = Some(next_hop_global.to_string());
+                for e in nlri {
+                    out.push(build_msg(
+                        LogType::Update,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        nh.clone(),
+                        e.path_id(),
+                        None,
+                    ));
+                }
+            }
+            MpReach::Ipv6NlriMplsLabels { next_hop, nlri, .. } => {
+                let nh = Some(next_hop.to_string());
+                for e in nlri {
+                    let label = e.labels().first().map(|l| mpls_label_value(l).to_string());
+                    out.push(build_msg(
+                        LogType::Update,
+                        afi,
+                        safi,
+                        Some(e.prefix().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        nh.clone(),
+                        e.path_id(),
+                        label,
+                    ));
+                }
+            }
+            MpReach::Ipv6MplsVpnUnicast { next_hop, nlri } => {
+                let nh = Some(next_hop.next_hop().to_string());
+                for e in nlri {
+                    let (nlri_rd, nlri_rd_origin) = rd_and_origin(Some(e.rd()), RdOrigin::Bgp);
+                    let label = e
+                        .label_stack()
+                        .first()
+                        .map(|l| mpls_label_value(l).to_string());
+                    out.push(build_msg(
+                        LogType::Update,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        nlri_rd,
+                        nlri_rd_origin,
+                        nh.clone(),
+                        e.path_id(),
+                        label,
+                    ));
+                }
+            }
+            _ => {
+                // L2Evpn, RouteTargetMembership, BgpLs, BgpLsVpn, Unknown –
+                // emit a single placeholder without per-prefix detail
+                out.push(build_msg(
+                    LogType::Update,
+                    afi,
+                    safi,
+                    None,
+                    peer_rd.clone(),
+                    peer_rd_origin.clone(),
+                    None,
+                    None,
+                    None,
+                ));
+            }
+        }
+    }
+
+    // ---- MP_UNREACH_NLRI ---------------------------------------------------
+    if let Some(mu) = mp_unreach {
+        let afi = u16::from(mu.afi());
+        let safi = u8::from(mu.safi());
+        match mu {
+            MpUnreach::Ipv4Unicast { nlri } => {
+                for e in nlri {
+                    out.push(build_msg(
+                        LogType::Withdraw,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        None,
+                        e.path_id(),
+                        None,
+                    ));
+                }
+            }
+            MpUnreach::Ipv4Multicast { nlri } => {
+                for e in nlri {
+                    out.push(build_msg(
+                        LogType::Withdraw,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        None,
+                        e.path_id(),
+                        None,
+                    ));
+                }
+            }
+            MpUnreach::Ipv4NlriMplsLabels { nlri } => {
+                for e in nlri {
+                    let label = e.labels().first().map(|l| mpls_label_value(l).to_string());
+                    out.push(build_msg(
+                        LogType::Withdraw,
+                        afi,
+                        safi,
+                        Some(e.prefix().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        None,
+                        e.path_id(),
+                        label,
+                    ));
+                }
+            }
+            MpUnreach::Ipv4MplsVpnUnicast { nlri } => {
+                for e in nlri {
+                    let (nlri_rd, nlri_rd_origin) = rd_and_origin(Some(e.rd()), RdOrigin::Bgp);
+                    let label = e
+                        .label_stack()
+                        .first()
+                        .map(|l| mpls_label_value(l).to_string());
+                    out.push(build_msg(
+                        LogType::Withdraw,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        nlri_rd,
+                        nlri_rd_origin,
+                        None,
+                        e.path_id(),
+                        label,
+                    ));
+                }
+            }
+            MpUnreach::Ipv6Unicast { nlri } => {
+                for e in nlri {
+                    out.push(build_msg(
+                        LogType::Withdraw,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        None,
+                        e.path_id(),
+                        None,
+                    ));
+                }
+            }
+            MpUnreach::Ipv6Multicast { nlri } => {
+                for e in nlri {
+                    out.push(build_msg(
+                        LogType::Withdraw,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        None,
+                        e.path_id(),
+                        None,
+                    ));
+                }
+            }
+            MpUnreach::Ipv6NlriMplsLabels { nlri } => {
+                for e in nlri {
+                    let label = e.labels().first().map(|l| mpls_label_value(l).to_string());
+                    out.push(build_msg(
+                        LogType::Withdraw,
+                        afi,
+                        safi,
+                        Some(e.prefix().to_string()),
+                        peer_rd.clone(),
+                        peer_rd_origin.clone(),
+                        None,
+                        e.path_id(),
+                        label,
+                    ));
+                }
+            }
+            MpUnreach::Ipv6MplsVpnUnicast { nlri } => {
+                for e in nlri {
+                    let (nlri_rd, nlri_rd_origin) = rd_and_origin(Some(e.rd()), RdOrigin::Bgp);
+                    let label = e
+                        .label_stack()
+                        .first()
+                        .map(|l| mpls_label_value(l).to_string());
+                    out.push(build_msg(
+                        LogType::Withdraw,
+                        afi,
+                        safi,
+                        Some(e.network().to_string()),
+                        nlri_rd,
+                        nlri_rd_origin,
+                        None,
+                        e.path_id(),
+                        label,
+                    ));
+                }
+            }
+            _ => {
+                // L2Evpn, RouteTargetMembership, BgpLs, BgpLsVpn, Unknown.
+                out.push(build_msg(
+                    LogType::Withdraw,
+                    afi,
+                    safi,
+                    None,
+                    peer_rd.clone(),
+                    peer_rd_origin.clone(),
+                    None,
+                    None,
+                    None,
+                ));
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+impl PmacctBmpMessage {
+    /// Convert a [`BmpRequest`] into one or more [`PmacctBmpMessage`]s using
+    /// the supplied [`PmacctConversionContext`].
+    ///
+    /// Returns a [`Vec`] because:
+    /// - A Statistics Report with *N* counters produces *N* messages.
+    /// - A Route Monitoring message covering *K* NLRI prefixes produces *K*
+    ///   messages
+    ///
+    /// Fails with [`PmacctBmpConversionError::UnsupportedMessageType`] for
+    /// BMP message types that are not yet supported (RouteMirroring,
+    /// Experimental251–254).
+    pub fn try_from_bmp_request(
+        request: &BmpRequest,
+        ctx: &PmacctConversionContext,
+    ) -> Result<Vec<Self>, PmacctBmpConversionError> {
+        let (addr_info, message) = request;
+        match message {
+            BmpMessage::V3(v3_msg) => match v3_msg {
+                v3::BmpMessageValue::RouteMonitoring(rm) => {
+                    convert_route_monitoring(addr_info, rm.peer_header(), rm.update_message(), ctx)
+                }
+                v3::BmpMessageValue::StatisticsReport(stats) => {
+                    convert_statistics_report(addr_info, stats, ctx)
+                }
+                v3::BmpMessageValue::PeerDownNotification(pd) => {
+                    convert_peer_down(addr_info, pd.peer_header(), pd.reason(), ctx)
+                        .map(|m| vec![m])
+                }
+                v3::BmpMessageValue::PeerUpNotification(pu) => {
+                    convert_peer_up(addr_info, pu, ctx).map(|m| vec![m])
+                }
+                v3::BmpMessageValue::Initiation(init) => {
+                    convert_initiation(addr_info, init, ctx).map(|m| vec![m])
+                }
+                v3::BmpMessageValue::Termination(term) => {
+                    convert_termination(addr_info, term, ctx).map(|m| vec![m])
+                }
+                v3::BmpMessageValue::RouteMirroring(_) => Err(
+                    PmacctBmpConversionError::UnsupportedMessageType("RouteMirroring".to_string()),
+                ),
+                v3::BmpMessageValue::Experimental251(_)
+                | v3::BmpMessageValue::Experimental252(_)
+                | v3::BmpMessageValue::Experimental253(_)
+                | v3::BmpMessageValue::Experimental254(_) => Err(
+                    PmacctBmpConversionError::UnsupportedMessageType("Experimental".to_string()),
+                ),
+            },
+            BmpMessage::V4(v4_msg) => match v4_msg {
+                v4::BmpMessageValue::RouteMonitoring(rm) => {
+                    convert_route_monitoring(addr_info, rm.peer_header(), rm.update_message(), ctx)
+                }
+                v4::BmpMessageValue::StatisticsReport(stats) => {
+                    convert_statistics_report(addr_info, stats, ctx)
+                }
+                v4::BmpMessageValue::PeerDownNotification(pd) => {
+                    convert_peer_down(addr_info, pd.peer_header(), pd.reason(), ctx)
+                        .map(|m| vec![m])
+                }
+                v4::BmpMessageValue::PeerUpNotification(pu) => {
+                    convert_peer_up(addr_info, pu, ctx).map(|m| vec![m])
+                }
+                v4::BmpMessageValue::Initiation(init) => {
+                    convert_initiation(addr_info, init, ctx).map(|m| vec![m])
+                }
+                v4::BmpMessageValue::Termination(term) => {
+                    convert_termination(addr_info, term, ctx).map(|m| vec![m])
+                }
+                v4::BmpMessageValue::RouteMirroring(_) => Err(
+                    PmacctBmpConversionError::UnsupportedMessageType("RouteMirroring".to_string()),
+                ),
+                v4::BmpMessageValue::Experimental251(_)
+                | v4::BmpMessageValue::Experimental252(_)
+                | v4::BmpMessageValue::Experimental253(_)
+                | v4::BmpMessageValue::Experimental254(_) => Err(
+                    PmacctBmpConversionError::UnsupportedMessageType("Experimental".to_string()),
+                ),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/collector/src/bmp/pmacct_schema/tests.rs
+++ b/crates/collector/src/bmp/pmacct_schema/tests.rs
@@ -1,0 +1,414 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::bmp::pmacct_schema::*;
+use apache_avro::{Reader, Writer};
+
+use netgauze_bmp_pkt::BmpMessage;
+use netgauze_bmp_service::{AddrInfo, BmpRequest};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+#[test]
+fn test_pmacct_route_monitoring_serialization() {
+    // Create a route monitoring message
+    let msg = PmacctBmpMessage::RouteMonitoring(PmacctRouteMonitoringMessage {
+        log_type: LogType::Update,
+        seq: 8165641,
+        timestamp: "1771423519.973399".to_string(),
+        event_type: EventType::Log,
+        writer_id: "devcolleft02nfacctdbmpleft06c 20251010.1.b58aa7d-1.el8".to_string(),
+        tag: None,
+        label: Some(HashMap::from([(
+            "nkey".to_string(),
+            "daisy-43".to_string(),
+        )])),
+        afi: 1,
+        safi: 128,
+        ip_prefix: Some("10.0.5.64/28".to_string()),
+        rd: Some("2:4200137734:1003".to_string()),
+        rd_origin: Some(RdOrigin::Bgp),
+        bgp_nexthop: Some("10.3.72.2".to_string()),
+        as_path: Some("4200136804 4200137732 4200073286 4200073286".to_string()),
+        as_path_id: None,
+        comms: Some("60633:204 60633:208 60633:1009 60633:1033".to_string()),
+        ecomms: Some("RT:60663:60153 RT:60663:60154".to_string()),
+        lcomms: Some("65002:0:998".to_string()),
+        origin: Some(BgpOrigin::IGP),
+        local_pref: None,
+        med: None,
+        aigp: None,
+        psid_li: None,
+        otc: None,
+        mpls_label: Some("85147".to_string()),
+        peer_ip: "0.0.0.0".to_string(),
+        peer_asn: 4200137732,
+        peer_type: 3,
+        peer_type_str: Some("Loc-RIB Instance Peer".to_string()),
+        peer_tcp_port: Some(0),
+        timestamp_arrival: Some("1771423520.065485".to_string()),
+        bmp_router: "100.71.14.43".to_string(),
+        bmp_router_port: Some(40205),
+        bmp_msg_type: BmpMsgType::RouteMonitor,
+        bmp_rib_type: BmpRibType::LocRib,
+        bgp_id: "10.71.14.43".to_string(),
+        is_filtered: 0,
+        is_in: None,
+        is_loc: Some(1),
+        is_post: None,
+        is_out: None,
+    });
+
+    let expected_json = r#"{"log_type":"update","seq":8165641,"timestamp":"1771423519.973399","event_type":"log","writer_id":"devcolleft02nfacctdbmpleft06c 20251010.1.b58aa7d-1.el8","tag":null,"label":{"nkey":"daisy-43"},"afi":1,"safi":128,"ip_prefix":"10.0.5.64/28","rd":"2:4200137734:1003","rd_origin":"bgp","bgp_nexthop":"10.3.72.2","as_path":"4200136804 4200137732 4200073286 4200073286","as_path_id":null,"comms":"60633:204 60633:208 60633:1009 60633:1033","ecomms":"RT:60663:60153 RT:60663:60154","lcomms":"65002:0:998","origin":"i","local_pref":null,"med":null,"aigp":null,"psid_li":null,"otc":null,"mpls_label":"85147","peer_ip":"0.0.0.0","peer_asn":4200137732,"peer_type":3,"peer_type_str":"Loc-RIB Instance Peer","peer_tcp_port":0,"timestamp_arrival":"1771423520.065485","bmp_router":"100.71.14.43","bmp_router_port":40205,"bmp_msg_type":"route_monitor","bmp_rib_type":"Loc-Rib","bgp_id":"10.71.14.43","is_filtered":0,"is_in":null,"is_loc":1,"is_post":null,"is_out":null}"#;
+
+    // JSON serialization
+    let serialized_json = serde_json::to_string(&msg).expect("Failed to serialize msg");
+    assert_eq!(serialized_json, expected_json);
+
+    // JSON deserialization
+    let deserialized_msg: PmacctBmpMessage =
+        serde_json::from_str(&serialized_json).expect("Failed to deserialize msg");
+    assert_eq!(deserialized_msg, msg);
+
+    // Avro encode
+    let schema = msg.get_avro_schema();
+    let mut writer = Writer::new(&schema, Vec::new());
+
+    let avro_val = msg
+        .clone()
+        .get_avro_value()
+        .expect("Failed to convert to avro value");
+    writer.append(avro_val).expect("Failed to append to writer");
+
+    let encoded = writer.into_inner().expect("Failed to get inner buffer");
+
+    // Avro decode
+    let reader = Reader::new(&encoded[..]).expect("Failed to create reader");
+    let mut decoded_msgs: Vec<PmacctBmpMessage> = Vec::new();
+    for value in reader {
+        let value = value.expect("Failed to read value");
+        let decoded = PmacctBmpMessage::from_avro_value(&value).expect("Failed to resolve message");
+        decoded_msgs.push(decoded);
+    }
+
+    assert_eq!(decoded_msgs.len(), 1);
+    assert_eq!(decoded_msgs[0], msg);
+}
+
+#[test]
+fn test_pmacct_peer_up_avro_union_encode_decode() {
+    let msg = PmacctBmpMessage::PeerUpNotification(PmacctPeerUpNotificationMessage {
+        seq: 42,
+        timestamp: "1771584618.100129".to_string(),
+        timestamp_event: Some("1771584618.100129".to_string()),
+        timestamp_arrival: Some("1771584618.200000".to_string()),
+        event_type: EventType::Log,
+        bmp_router: "2001:db8:90::1".to_string(),
+        bmp_router_port: Some(33725),
+        bmp_msg_type: BmpMsgType::PeerUp,
+        writer_id: "test-writer 1.0".to_string(),
+        tag: None,
+        label: None,
+        peer_ip: "203.0.113.44".to_string(),
+        peer_asn: 64496,
+        peer_type: 0,
+        peer_type_str: Some("Global Instance Peer".to_string()),
+        bmp_rib_type: BmpRibType::AdjRibInPre,
+        is_filtered: 0,
+        is_in: Some(1),
+        is_loc: None,
+        is_post: None,
+        is_out: None,
+        rd: None,
+        rd_origin: None,
+        bgp_id: "203.0.113.44".to_string(),
+        local_port: 179,
+        remote_port: 54321,
+        local_ip: "10.0.0.1".to_string(),
+        bmp_peer_up_info_string: Some("peer-up-info".to_string()),
+        bmp_peer_up_info_vrf_table_name: Some("vrf-red".to_string()),
+        bmp_peer_up_info_admin_label: None,
+        bmp_peer_up_info_reserved: None,
+    });
+
+    // --- JSON round-trip ---
+    let json = serde_json::to_string(&msg).expect("JSON serialization failed");
+    let from_json: PmacctBmpMessage =
+        serde_json::from_str(&json).expect("JSON deserialization failed");
+    assert_eq!(from_json, msg);
+
+    // --- Avro round-trip using the Union schema ---
+    let schema = msg.get_avro_schema();
+
+    let avro_val = msg
+        .clone()
+        .get_avro_value()
+        .expect("Fail to convert to avro value");
+
+    // Validate that PeerUpNotification is variant index 3 in the union.
+    match &avro_val {
+        apache_avro::types::Value::Union(idx, _) => assert_eq!(*idx, 3),
+        other => panic!("expected Value::Union, got {other:?}"),
+    }
+
+    // Avro encode
+    let mut writer = Writer::new(&schema, Vec::new());
+    writer.append(avro_val).expect("Failed to append to writer");
+    let encoded = writer.into_inner().expect("Failed to get inner buffer");
+
+    // Avro decode
+    let reader = Reader::new(&encoded[..]).expect("Failed to create reader");
+    let mut decoded_msgs: Vec<PmacctBmpMessage> = Vec::new();
+    for value in reader {
+        let value = value.expect("Failed to read value");
+        let decoded = PmacctBmpMessage::from_avro_value(&value).expect("Failed to decode value");
+        decoded_msgs.push(decoded);
+    }
+
+    assert_eq!(decoded_msgs.len(), 1);
+    assert_eq!(decoded_msgs[0], msg);
+}
+
+#[test]
+fn test_convert_route_monitoring_loc_rib_ipv6_mpls_vpn() {
+    let bmp_json = r#"{"V3":{"RouteMonitoring":{"peer_header":{"peer_type":{"LocRibInstancePeer":{"filtered":false}},"rd":null,"address":null,"peer_as":4226809946,"bgp_id":"203.0.113.90","timestamp":"2026-02-20T10:50:18.100129Z"},"update_message":{"Update":{"withdrawn_routes":[],"path_attributes":[{"optional":true,"transitive":false,"partial":false,"extended_length":true,"value":{"MpReach":{"Ipv6MplsVpnUnicast":{"next_hop":{"Ipv6":{"rd":{"As2Administrator":{"asn2":0,"number":0}},"next_hop":"::ffff:203.0.113.24","next_hop_local":null}},"nlri":[{"path_id":null,"rd":{"As4Administrator":{"asn4":4226809946,"number":9010}},"label_stack":[[16,3,193]],"network":"2001:db8::24/128"}]}}}},{"optional":false,"transitive":true,"partial":false,"extended_length":false,"value":{"Origin":"IGP"}},{"optional":false,"transitive":true,"partial":false,"extended_length":false,"value":{"AsPath":{"As4PathSegments":[{"segment_type":"AsSequence","as_numbers":[64496,4226809880]}]}}},{"optional":false,"transitive":true,"partial":false,"extended_length":false,"value":{"LocalPreference":{"metric":100}}},{"optional":true,"transitive":true,"partial":false,"extended_length":false,"value":{"Communities":{"communities":[4226810155,4226810857,4226875393,4227006488]}}},{"optional":true,"transitive":true,"partial":false,"extended_length":false,"value":{"ExtendedCommunities":{"communities":[{"TransitiveTwoOctet":{"RouteTarget":{"global_admin":64497,"local_admin":1}}}]}}}],"nlri":[]}}}}}"#;
+
+    let bmp_msg: BmpMessage =
+        serde_json::from_str(bmp_json).expect("Failed to deserialize BmpMessage from JSON");
+
+    let local_addr: SocketAddr = "[::]:1792".parse().unwrap();
+    let peer_addr: SocketAddr = "[2001:db8:90::1]:33725".parse().unwrap();
+    let addr_info = AddrInfo::new(local_addr, peer_addr);
+
+    let request: BmpRequest = (addr_info, bmp_msg);
+
+    let ctx = PmacctConversionContext {
+        writer_id: "test-writer 1.0".to_string(),
+        event_type: EventType::Log,
+        timestamp_arrival: "1771584618.200000".to_string(),
+        label: None,
+        tag: Some(100),
+    };
+
+    let msgs =
+        PmacctBmpMessage::try_from_bmp_request(&request, &ctx).expect("conversion must succeed");
+
+    let expected_msg = PmacctBmpMessage::RouteMonitoring(PmacctRouteMonitoringMessage {
+        log_type: LogType::Update,
+        seq: 0,
+        timestamp: "1771584618.100129".to_string(),
+        event_type: EventType::Log,
+        writer_id: "test-writer 1.0".to_string(),
+        tag: Some(100),
+        label: None,
+        afi: 2,
+        safi: 128,
+        ip_prefix: Some("2001:db8::24/128".to_string()),
+        rd: Some("2:4226809946:9010".to_string()),
+        rd_origin: Some(RdOrigin::Bgp),
+        bgp_nexthop: Some("::ffff:203.0.113.24".to_string()),
+        as_path: Some("64496 4226809880".to_string()),
+        as_path_id: None,
+        comms: Some("64496:299 64496:1001 64497:1 64499:24".to_string()),
+        ecomms: Some("RT:64497:1".to_string()),
+        lcomms: None,
+        origin: Some(BgpOrigin::IGP),
+        local_pref: Some(100),
+        med: None,
+        aigp: None,
+        psid_li: None,
+        otc: None,
+        mpls_label: Some("65596".to_string()),
+        peer_ip: "0.0.0.0".to_string(),
+        peer_asn: 4226809946,
+        peer_type: 3,
+        peer_type_str: Some("Loc-RIB Instance Peer".to_string()),
+        peer_tcp_port: None,
+        timestamp_arrival: Some("1771584618.200000".to_string()),
+        bmp_router: "2001:db8:90::1".to_string(),
+        bmp_router_port: Some(33725),
+        bmp_msg_type: BmpMsgType::RouteMonitor,
+        bmp_rib_type: BmpRibType::LocRib,
+        bgp_id: "203.0.113.90".to_string(),
+        is_filtered: 0,
+        is_in: None,
+        is_loc: Some(1),
+        is_post: None,
+        is_out: None,
+    });
+
+    assert_eq!(msgs, vec![expected_msg]);
+
+    // Avro encode
+    let schema = PmacctBmpMessage::get_schema();
+    let mut writer = Writer::new(&schema, Vec::new());
+
+    for msg in &msgs {
+        let avro_val = msg
+            .clone()
+            .get_avro_value()
+            .expect("Failed to convert to avro value");
+        writer.append(avro_val).expect("Failed to append to writer");
+    }
+
+    let encoded = writer.into_inner().expect("Failed to get inner buffer");
+
+    // Avro decode
+    let reader = Reader::new(&encoded[..]).expect("Failed to create reader");
+    let mut decoded_msgs: Vec<PmacctBmpMessage> = Vec::new();
+    for value in reader {
+        let value = value.expect("Failed to read value");
+        let decoded = PmacctBmpMessage::from_avro_value(&value).expect("Failed to resolve message");
+        decoded_msgs.push(decoded);
+    }
+
+    assert_eq!(decoded_msgs, msgs);
+}
+
+#[test]
+fn test_convert_statistics_report_global_instance_peer() {
+    let bmp_json = r#"{"V3":{"StatisticsReport":{"peer_header":{"peer_type":{"GlobalInstancePeer":{"ipv6":false,"post_policy":false,"asn2":false,"adj_rib_out":false}},"rd":null,"address":"203.0.113.44","peer_as":64496,"bgp_id":"203.0.113.44","timestamp":"2026-02-20T10:50:19.346838Z"},"counters":[{"NumberOfDuplicateWithdraws":51},{"NumberOfUpdatesInvalidatedDueToAsPathLoop":22},{"NumberOfRoutesInAdjRibIn":39},{"NumberOfRoutesInPerAfiSafiAdjRibIn":["Ipv4MplsLabeledVpn",30]},{"NumberOfRoutesInPerAfiSafiAdjRibIn":["Ipv6MplsLabeledVpn",9]},{"NumberOfRoutesInLocRib":34},{"NumberOfRoutesInPerAfiSafiLocRib":["Ipv4MplsLabeledVpn",25]},{"NumberOfRoutesInPerAfiSafiLocRib":["Ipv6MplsLabeledVpn",9]}]}}}"#;
+
+    let bmp_msg: BmpMessage =
+        serde_json::from_str(bmp_json).expect("Failed to deserialize BmpMessage from JSON");
+
+    let local_addr: SocketAddr = "[::]:1792".parse().unwrap();
+    let peer_addr: SocketAddr = "[2001:db8:90::1]:33725".parse().unwrap();
+    let addr_info = AddrInfo::new(local_addr, peer_addr);
+
+    let request: BmpRequest = (addr_info, bmp_msg);
+
+    let ctx = PmacctConversionContext {
+        writer_id: "test-writer 1.0".to_string(),
+        event_type: EventType::Log,
+        timestamp_arrival: "1771584619.400000".to_string(),
+        label: None,
+        tag: None,
+    };
+
+    let msgs =
+        PmacctBmpMessage::try_from_bmp_request(&request, &ctx).expect("conversion must succeed");
+
+    // 8 counters → 8 messages
+    assert_eq!(msgs.len(), 8);
+
+    // Common fields shared by all 8 messages — build a helper closure to
+    // avoid repeating every field 8 times.
+    let base = |counter_type: u16,
+                counter_type_str: &str,
+                counter_value: i64,
+                afi: Option<u16>,
+                safi: Option<u8>| {
+        PmacctBmpMessage::StatisticsReport(PmacctStatisticsReportMessage {
+            seq: 0,
+            timestamp: "1771584619.346838".to_string(),
+            timestamp_event: Some("1771584619.346838".to_string()),
+            timestamp_arrival: Some("1771584619.400000".to_string()),
+            event_type: EventType::Log,
+            bmp_router: "2001:db8:90::1".to_string(),
+            bmp_router_port: Some(33725),
+            bmp_msg_type: BmpMsgType::Stats,
+            writer_id: "test-writer 1.0".to_string(),
+            tag: None,
+            label: None,
+            peer_ip: "203.0.113.44".to_string(),
+            peer_asn: 64496,
+            peer_type: 0,
+            peer_type_str: "Global Instance Peer".to_string(),
+            bmp_rib_type: BmpRibType::AdjRibInPre,
+            is_filtered: 0,
+            is_in: Some(1),
+            is_loc: None,
+            is_post: None,
+            is_out: None,
+            rd: None,
+            rd_origin: None,
+            bgp_id: "203.0.113.44".to_string(),
+            counter_type,
+            counter_type_str: counter_type_str.to_string(),
+            counter_value,
+            afi,
+            safi,
+        })
+    };
+
+    let expected = vec![
+        base(2, "Number of (known) duplicate withdraws", 51, None, None),
+        base(
+            4,
+            "Number of updates invalidated due to AS_PATH loop",
+            22,
+            None,
+            None,
+        ),
+        base(7, "Number of routes in Adj-RIBs-In", 39, None, None),
+        base(
+            9,
+            "Number of routes in per-AFI/SAFI Adj-RIB-In",
+            30,
+            Some(1),
+            Some(128),
+        ),
+        base(
+            9,
+            "Number of routes in per-AFI/SAFI Adj-RIB-In",
+            9,
+            Some(2),
+            Some(128),
+        ),
+        base(8, "Number of routes in Loc-RIB", 34, None, None),
+        base(
+            10,
+            "Number of routes in per-AFI/SAFI Loc-RIB",
+            25,
+            Some(1),
+            Some(128),
+        ),
+        base(
+            10,
+            "Number of routes in per-AFI/SAFI Loc-RIB",
+            9,
+            Some(2),
+            Some(128),
+        ),
+    ];
+
+    assert_eq!(msgs, expected);
+
+    // Avro encode/decode test for all statistics report messages
+    let schema = PmacctBmpMessage::get_schema();
+    let mut writer = Writer::new(&schema, Vec::new());
+
+    for msg in &msgs {
+        let avro_val = msg
+            .clone()
+            .get_avro_value()
+            .expect("Failed to convert to avro value");
+        writer.append(avro_val).expect("Failed to append to writer");
+    }
+
+    let encoded = writer.into_inner().expect("Failed to get inner buffer");
+
+    // Avro decode
+    let reader = Reader::new(&encoded[..]).expect("Failed to create reader");
+    let mut decoded_msgs: Vec<PmacctBmpMessage> = Vec::new();
+    for value in reader {
+        let value = value.expect("Failed to read value");
+        let decoded = PmacctBmpMessage::from_avro_value(&value).expect("Failed to resolve message");
+        decoded_msgs.push(decoded);
+    }
+
+    assert_eq!(decoded_msgs, msgs);
+}

--- a/crates/collector/src/config.rs
+++ b/crates/collector/src/config.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::bmp::config::BmpAvroConfig;
 use crate::flow::aggregation::AggregationConfig;
 use crate::flow::config::FlowOutputConfig;
 use crate::flow::enrichment::EnrichmentConfig;
@@ -330,4 +331,7 @@ pub enum PublisherEndpoint {
     /// (for validated yang-push telemetry messages and YANG schema
     /// registration)
     TelemetryKafkaYang(kafka_yang::KafkaConfig<TelemetryYangConverter>),
+
+    /// Kafka AVRO publisher endpoint (for BMP messages)
+    BmpKafkaAvro(kafka_avro::KafkaConfig<BmpAvroConfig>),
 }

--- a/crates/collector/src/lib.rs
+++ b/crates/collector/src/lib.rs
@@ -49,6 +49,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
+pub mod bmp;
 pub mod config;
 pub mod flow;
 pub mod inputs;
@@ -350,6 +351,11 @@ pub async fn init_flow_collection(
                         "Telemetry KafkaYang publisher not supported for Flow"
                     ));
                 }
+                PublisherEndpoint::BmpKafkaAvro(_) => {
+                    return Err(anyhow::anyhow!(
+                        "BMP KafkaAvro publisher not supported for Flow"
+                    ));
+                }
             }
         }
 
@@ -435,6 +441,7 @@ pub async fn init_bmp_collection(
 
     let mut join_set = FuturesUnordered::new();
     let mut kafka_json_handles = Vec::new();
+    let mut kafka_avro_handles = Vec::new();
 
     for (group_name, publisher_config) in bmp_config.publishers {
         info!("Starting publishers group '{group_name}'");
@@ -468,9 +475,27 @@ pub async fn init_bmp_collection(
                         kafka_json_handles.push(handle);
                     }
                 }
+                PublisherEndpoint::BmpKafkaAvro(config) => {
+                    for bmp_recv in &bmp_recvs {
+                        // pass writer_id to the converter
+                        // (workaround until we have an enrichment actor for bmp)
+                        let mut config = config.clone();
+                        config.avro_converter.writer_id = config.writer_id.clone();
+
+                        let (kafka_join, kafka_handle) =
+                            KafkaAvroPublisherActorHandle::from_config(
+                                config.clone(),
+                                bmp_recv.clone(),
+                                either::Left(meter.clone()),
+                            )
+                            .await?;
+                        join_set.push(kafka_join);
+                        kafka_avro_handles.push(kafka_handle);
+                    }
+                }
                 _ => {
                     return Err(anyhow::anyhow!(
-                        "Only KafkaJson publisher is currently supported for BMP"
+                        "Only KafkaJson and BmpKafkaAvro publishers are currently supported for BMP"
                     ));
                 }
             }
@@ -483,6 +508,9 @@ pub async fn init_bmp_collection(
             for handle in kafka_json_handles {
                 let _ = handle.shutdown().await;
             }
+            for handle in kafka_avro_handles {
+                let _ = handle.shutdown().await;
+            }
             match supervisor_ret {
                 Ok(_) => Ok(()),
                 Err(err) => Err(anyhow::anyhow!(err)),
@@ -492,6 +520,9 @@ pub async fn init_bmp_collection(
             warn!("BMP publisher exited, shutting down BMP collection and publishers");
             let _ = tokio::time::timeout(std::time::Duration::from_secs(1), supervisor_handle.shutdown()).await;
             for handle in kafka_json_handles {
+                let _ = handle.shutdown().await;
+            }
+            for handle in kafka_avro_handles {
                 let _ = handle.shutdown().await;
             }
             match join_ret {
@@ -732,6 +763,11 @@ pub async fn init_udp_notif_collection(
                             }
                         }
                     }
+                }
+                PublisherEndpoint::BmpKafkaAvro(_) => {
+                    return Err(anyhow::anyhow!(
+                        "Bmp KafkaAvro publisher not supported for UDP Notif"
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## Dependencies
This PR depends on #470.

## Summary
It introduces pmacct-compatible Avro conversion for BMP messages and integrates a Kafka AVRO publisher path for BMP in the collector.

## Changes
- Add flat message model `PmacctBmpMessage` and per-type structs.
- Implement conversion helpers and per-message converters (`convert_` functions).
- Add `PmacctBmpMessage::try_from_bmp_request` to produce one-or-more messages from a `BmpRequest`.
- Add `BmpAvroConfig` and Avro converter implementation for BMP publishing.
- Add publisher wiring for a new `BmpKafkaAvro` endpoint and graceful producer shutdown handling.
- Add comprehensive unit tests exercising JSON/Avro round-trips and conversion logic.