### PR TITLE
Refactor schema registration logic for kafka-avro publisher

### DIFF
--- a/crates/collector/src/flow/config.rs
+++ b/crates/collector/src/flow/config.rs
@@ -37,6 +37,8 @@ use netgauze_flow_pkt::ie::{
     self, FieldConversionError, HasIE, IE, InformationElementDataType, InformationElementTemplate,
 };
 use rustc_hash::FxHashMap;
+use schema_registry_converter::avro_common::get_supplied_schema;
+use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use smallvec::SmallVec;
@@ -103,7 +105,7 @@ impl FlowOutputConfig {
     fn get_avro_value_from_fields(
         &self,
         fields_slice: &[ie::Field],
-    ) -> Result<AvroValue, FunctionError> {
+    ) -> Result<AvroValue, FlowAvroConverterError> {
         let mut fields = Vec::<(String, AvroValue)>::with_capacity(self.fields.len());
         let mut custom_primitives = IndexMap::new();
 
@@ -126,7 +128,7 @@ impl FlowOutputConfig {
                 } else if let Some(value) = value {
                     value
                 } else {
-                    return Err(FunctionError::FieldIsNull(name.to_string()));
+                    return Err(FlowAvroConverterError::FieldIsNull(name.to_string()));
                 };
                 fields.push((name.clone(), value));
             }
@@ -143,8 +145,8 @@ impl FlowOutputConfig {
     }
 }
 
-impl AvroConverter<(IpAddr, FlowInfo), FunctionError> for FlowOutputConfig {
-    fn get_avro_schema(&self) -> String {
+impl AvroConverter<(IpAddr, FlowInfo), FlowAvroConverterError> for FlowOutputConfig {
+    fn get_avro_schema(&self) -> Result<String, FlowAvroConverterError> {
         let indent = 2usize;
 
         // Initialize schema
@@ -163,7 +165,19 @@ impl AvroConverter<(IpAddr, FlowInfo), FunctionError> for FlowOutputConfig {
         schema.push_str(format!("{}\n", fields_schema.join(",\n")).as_str());
         schema.push_str(format!("{:indent$}]\n", "").as_str());
         schema.push('}');
-        schema
+        Ok(schema)
+    }
+
+    fn get_subject_name_strategy(
+        &self,
+        topic: &str,
+    ) -> Result<SubjectNameStrategy, FlowAvroConverterError> {
+        let schema = apache_avro::Schema::parse_str(&self.get_avro_schema()?)
+            .map_err(|e| FlowAvroConverterError::AvroSchemaError(e.to_string()))?;
+        Ok(SubjectNameStrategy::TopicRecordNameStrategyWithSchema(
+            topic.to_string(),
+            get_supplied_schema(&schema),
+        ))
     }
 
     fn get_key(&self, input: &(IpAddr, FlowInfo)) -> Option<JsonValue> {
@@ -175,7 +189,7 @@ impl AvroConverter<(IpAddr, FlowInfo), FunctionError> for FlowOutputConfig {
     fn get_avro_values(
         &self,
         input: (IpAddr, FlowInfo),
-    ) -> Result<Self::AvroValues, FunctionError> {
+    ) -> Result<Self::AvroValues, FlowAvroConverterError> {
         match input.1 {
             FlowInfo::IPFIX(pkt) => pkt
                 .sets()
@@ -518,7 +532,7 @@ impl FieldConfig {
     pub fn avro_value(
         &self,
         flow: &FxHashMap<SingleFieldSelect, &ie::Field>,
-    ) -> Result<Option<AvroValue>, FunctionError> {
+    ) -> Result<Option<AvroValue>, FlowAvroConverterError> {
         let selected = self.select.apply(flow);
         let transformed = self.transform.apply(selected)?;
         let value = match transformed {
@@ -531,7 +545,7 @@ impl FieldConfig {
     pub fn json_value(
         &self,
         flow: &FxHashMap<SingleFieldSelect, &ie::Field>,
-    ) -> Result<Option<JsonValue>, FunctionError> {
+    ) -> Result<Option<JsonValue>, FlowAvroConverterError> {
         let selected = self.select.apply(flow);
         let transformed = self.transform.apply(selected)?;
         let value = match transformed {
@@ -779,7 +793,7 @@ fn ie_avro_type(ie: IE) -> AvroValueKind {
 }
 
 #[derive(Debug, Clone, strum_macros::Display)]
-pub enum FunctionError {
+pub enum FlowAvroConverterError {
     #[strum(to_string = "Field conversion error: {0}")]
     FieldConversionError(FieldConversionError),
     #[strum(to_string = "Field index not found: {0}")]
@@ -790,18 +804,20 @@ pub enum FunctionError {
     FieldIsNull(String),
     #[strum(to_string = "Unsupported flow type: {0}")]
     UnsupportedFlowType(String),
+    #[strum(to_string = "Avro schema error: {0}")]
+    AvroSchemaError(String),
 }
 
-impl From<FieldConversionError> for FunctionError {
+impl From<FieldConversionError> for FlowAvroConverterError {
     fn from(value: FieldConversionError) -> Self {
         Self::FieldConversionError(value)
     }
 }
 
-impl std::error::Error for FunctionError {}
+impl std::error::Error for FlowAvroConverterError {}
 
-impl From<FunctionError> for KafkaAvroPublisherActorError {
-    fn from(value: FunctionError) -> Self {
+impl From<FlowAvroConverterError> for KafkaAvroPublisherActorError {
+    fn from(value: FlowAvroConverterError) -> Self {
         Self::TransformationError(value.to_string())
     }
 }
@@ -869,7 +885,10 @@ impl FieldTransformFunction {
         }
     }
 
-    pub fn apply(&self, fields: Option<Vec<ie::Field>>) -> Result<Option<RawValue>, FunctionError> {
+    pub fn apply(
+        &self,
+        fields: Option<Vec<ie::Field>>,
+    ) -> Result<Option<RawValue>, FlowAvroConverterError> {
         let fields = match fields {
             Some(fields) => fields,
             None => return Ok(None),
@@ -970,7 +989,7 @@ impl FieldTransformFunction {
                         ie::Field::mplsLabelStackSection8(v) => ret.push(format_mpls(8, &v)),
                         ie::Field::mplsLabelStackSection9(v) => ret.push(format_mpls(9, &v)),
                         ie::Field::mplsLabelStackSection10(v) => ret.push(format_mpls(10, &v)),
-                        _ => return Err(FunctionError::UnexpectedField(field)),
+                        _ => return Err(FlowAvroConverterError::UnexpectedField(field)),
                     }
                 }
                 Ok(Some(RawValue::StringArray(ret)))

--- a/crates/collector/src/flow/config/tests.rs
+++ b/crates/collector/src/flow/config/tests.rs
@@ -403,7 +403,7 @@ fn test_flow_output_config_get_avro_schema() {
     );
 
     let config = FlowOutputConfig { fields };
-    let schema = config.get_avro_schema();
+    let schema = config.get_avro_schema().unwrap();
 
     // Verify schema structure
     assert!(schema.contains("\"type\": \"record\""));

--- a/crates/collector/src/publishers/kafka_avro.rs
+++ b/crates/collector/src/publishers/kafka_avro.rs
@@ -22,7 +22,7 @@ use schema_registry_converter::async_impl::avro::AvroEncoder;
 use schema_registry_converter::async_impl::schema_registry::{SrSettings, post_schema};
 use schema_registry_converter::avro_common::get_supplied_schema;
 use schema_registry_converter::error::SRCError;
-use schema_registry_converter::schema_registry_common::{SubjectNameStrategy, SuppliedSchema};
+use schema_registry_converter::schema_registry_common::SubjectNameStrategy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -35,7 +35,9 @@ use tracing::{debug, error, info, warn};
 const MAX_POLLING_INTERVAL: Duration = Duration::from_secs(5);
 
 pub trait AvroConverter<T, E: std::error::Error> {
-    fn get_avro_schema(&self) -> String;
+    fn get_avro_schema(&self) -> Result<String, E>;
+
+    fn get_subject_name_strategy(&self, topic: &str) -> Result<SubjectNameStrategy, E>;
 
     fn get_key(&self, input: &T) -> Option<JsonValue>;
 
@@ -201,13 +203,19 @@ where
     ) -> Result<Self, KafkaAvroPublisherActorError> {
         let sr_settings = SrSettings::new(config.schema_registry_url.clone());
         let avro_encoder = AvroEncoder::new(sr_settings.clone());
-        let schema_str = config.avro_converter.get_avro_schema();
-        let supplied_schema =
-            Self::get_schema(config.topic.clone(), schema_str, sr_settings).await?;
-        let subject_name_strategy = SubjectNameStrategy::TopicRecordNameStrategyWithSchema(
-            config.topic.clone(),
-            supplied_schema.clone(),
-        );
+        let schema_str = config.avro_converter.get_avro_schema()?;
+        let subject_name_strategy = config
+            .avro_converter
+            .get_subject_name_strategy(&config.topic)?;
+
+        // Register schema already at producer startup
+        Self::register_schema(
+            schema_str,
+            &subject_name_strategy,
+            &config.topic,
+            sr_settings,
+        )
+        .await?;
         let producer = Self::get_producer(&stats, &config)?;
 
         Ok(Self {
@@ -222,11 +230,12 @@ where
         })
     }
 
-    async fn get_schema(
-        topic: String,
+    async fn register_schema(
         schema_str: String,
+        subject_name_strategy: &SubjectNameStrategy,
+        topic: &str,
         sr_settings: SrSettings,
-    ) -> Result<SuppliedSchema, KafkaAvroPublisherActorError> {
+    ) -> Result<(), KafkaAvroPublisherActorError> {
         let parse_schema = match apache_avro::schema::Schema::parse_str(&schema_str) {
             Ok(schema) => schema,
             Err(err) => {
@@ -234,23 +243,20 @@ where
                 return Err(err)?;
             }
         };
-        let supplied_schema = get_supplied_schema(&parse_schema);
-        info!(
+        debug!(
             "Starting Kafka AVRO publisher to topic: `{topic}` with schema: `{}`",
             parse_schema.canonical_form()
         );
-
-        let subject_strategy =
-            SubjectNameStrategy::TopicRecordNameStrategyWithSchema(topic, supplied_schema.clone());
-        let subject = match subject_strategy.get_subject() {
+        let supplied_schema = get_supplied_schema(&parse_schema);
+        let subject = match subject_name_strategy.get_subject() {
             Ok(subject) => subject,
             Err(err) => {
                 error!("Error getting a subject {err}");
                 return Err(err)?;
             }
         };
-        info!("Registering schema with schema registry");
-        match post_schema(&sr_settings, subject.clone(), supplied_schema.clone()).await {
+        debug!("Registering schema with subject {subject} to schema registry");
+        match post_schema(&sr_settings, subject.clone(), supplied_schema).await {
             Ok(schema) => {
                 info!(
                     "Registered schema with subject {subject} and id {}",
@@ -262,7 +268,7 @@ where
                 return Err(err)?;
             }
         }
-        Ok(supplied_schema)
+        Ok(())
     }
 
     pub fn get_producer(


### PR DESCRIPTION
This PR refactors the schema registration logic in the Kafka Avro publisher to support more subject name strategies.

### Changes
- Extended the `AvroConverter` trait with a new `get_subject_name_strategy` method, enabling publishers to define custom strategies for schema subject naming.
- Updated the `FlowOutputConfig` implementation to use the new trait method and to return a `Result` for schema generation, improving error handling and flexibility.
- Replaced the generic `FunctionError` enum with a more specific `FlowAvroConverterError`, including a new variant for Avro schema errors, for clearer and more maintainable error reporting.
- Updated all relevant code and tests to use the new error type and trait methods.

