### PR TITLE
Add Huawei IPFIX Registry Support

### DIFF
--- a/crates/flow-pkt/build.rs
+++ b/crates/flow-pkt/build.rs
@@ -150,6 +150,22 @@ fn get_nokia_config(registry_path: &Path) -> SourceConfig {
     )
 }
 
+fn get_huawei_config(registry_path: &Path) -> SourceConfig {
+    let huawei_path = registry_path
+        .join("huawei.xml")
+        .into_os_string()
+        .into_string()
+        .expect("Couldn't load huawei registry file");
+    SourceConfig::new(
+        RegistrySource::File(huawei_path),
+        RegistryType::IanaXML,
+        2011,
+        "huawei".to_string(),
+        "Huawei".to_string(),
+        None,
+    )
+}
+
 fn get_netgauze_config(registry_path: &Path) -> SourceConfig {
     let netgauze_path = registry_path
         .join("netgauze.xml")
@@ -251,14 +267,15 @@ fn main() {
         &sub_registry_path,
     );
     let nokia_source = get_nokia_config(&registry_path);
-    let netgauze_config = get_netgauze_config(&registry_path);
+    let huawei_source = get_huawei_config(&registry_path);
+    let netgauze_source = get_netgauze_config(&registry_path);
     let vmware_source = get_vmware_config(
         cfg!(feature = "iana-upstream-build"),
         &registry_path,
         &sub_registry_path,
     );
 
-    let mut vendors = vec![nokia_source, netgauze_config, vmware_source];
+    let mut vendors = vec![nokia_source, huawei_source, netgauze_source, vmware_source];
 
     if cfg!(feature = "custom-upstream-build") {
         let paths_and_pens = env::var("NETGAUZE_CUSTOM_XML_PATHS").expect("custom-upstream-build feature is enabled but couldn't find NETGAUZE_CUSTOM_XML_PATHS in OS env variables");

--- a/crates/flow-pkt/registry/huawei.xml
+++ b/crates/flow-pkt/registry/huawei.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-stylesheet type="text/xsl" href="ipfix.xsl"?>
+<?xml-model href="ipfix.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<registry xmlns="http://www.iana.org/assignments" id="ipfix">
+  <registry id="ipfix-information-elements">
+    <title>Huawei IPFIX Information Elements</title>
+
+    <record>
+      <name>ingressGponGemPortId</name>
+      <dataType>unsigned16</dataType>
+      <dataTypeSemantics>identifier</dataTypeSemantics>
+      <elementId>1</elementId>
+      <applicability>data</applicability>
+      <status>current</status>
+      <description>
+        <paragraph> Huawei PEN field: ingressGponGemPortId </paragraph>
+      </description>
+      <revision>0</revision>
+      <date>2026-04-17</date>
+    </record>
+
+    <record>
+      <name>egressGponGemPortId</name>
+      <dataType>unsigned16</dataType>
+      <dataTypeSemantics>identifier</dataTypeSemantics>
+      <elementId>2</elementId>
+      <applicability>data</applicability>
+      <status>current</status>
+      <description>
+        <paragraph> Huawei PEN field: egressGponGemPortId </paragraph>
+      </description>
+      <revision>0</revision>
+      <date>2026-04-17</date>
+    </record>
+
+  </registry>
+</registry>
+

--- a/crates/flow-pkt/src/wire/tests/ipfix.rs
+++ b/crates/flow-pkt/src/wire/tests/ipfix.rs
@@ -1065,7 +1065,7 @@ fn test_with_unknown_pen() -> Result<(), IpfixPacketWritingError> {
 }
 
 #[test]
-fn test_with_unknown_pen_complex() -> Result<(), IpfixPacketWritingError> {
+fn test_with_vendor_unknown_field_complex() -> Result<(), IpfixPacketWritingError> {
     let good_template_wire = [
         0x00, 0x0a, 0x00, 0xd8, 0x68, 0xad, 0x74, 0xec, 0x00, 0x00, 0x08, 0xb6, 0x80, 0x1e, 0x81,
         0x01, 0x00, 0x02, 0x00, 0xc8, 0x0a, 0x27, 0x00, 0x2f, 0x00, 0x1b, 0x00, 0x10, 0x00, 0x1c,
@@ -1138,7 +1138,8 @@ fn test_with_unknown_pen_complex() -> Result<(), IpfixPacketWritingError> {
                 FieldSpecifier::new(ie::IE::destinationTransportPort, 2).unwrap(),
                 FieldSpecifier::new(ie::IE::vlanId, 2).unwrap(),
                 FieldSpecifier::new(ie::IE::postVlanId, 2).unwrap(),
-                FieldSpecifier::new(ie::IE::Unknown { pen: 2011, id: 232 }, 2).unwrap(),
+                FieldSpecifier::new(ie::IE::Huawei(ie::huawei::IE::Unknown { id: 232 }), 2)
+                    .unwrap(),
                 FieldSpecifier::new(ie::IE::tcpControlBits, 1).unwrap(),
                 FieldSpecifier::new(ie::IE::protocolIdentifier, 1).unwrap(),
                 FieldSpecifier::new(ie::IE::ipClassOfService, 1).unwrap(),
@@ -1203,11 +1204,10 @@ fn test_with_unknown_pen_complex() -> Result<(), IpfixPacketWritingError> {
                         ie::Field::destinationTransportPort(64299),
                         ie::Field::vlanId(0),
                         ie::Field::postVlanId(0),
-                        ie::Field::Unknown {
-                            pen: 2011,
+                        ie::Field::Huawei(ie::huawei::Field::Unknown {
                             id: 232,
                             value: Box::new([0, 0]),
-                        },
+                        }),
                         ie::Field::tcpControlBits(TCPHeaderFlags::new(
                             false, false, false, false, true, false, false, false,
                         )),
@@ -1265,11 +1265,10 @@ fn test_with_unknown_pen_complex() -> Result<(), IpfixPacketWritingError> {
                         ie::Field::destinationTransportPort(61351),
                         ie::Field::vlanId(0),
                         ie::Field::postVlanId(0),
-                        ie::Field::Unknown {
-                            pen: 2011,
+                        ie::Field::Huawei(ie::huawei::Field::Unknown {
                             id: 232,
                             value: Box::new([0, 1]),
-                        },
+                        }),
                         ie::Field::tcpControlBits(TCPHeaderFlags::new(
                             false, false, false, true, true, false, false, false,
                         )),


### PR DESCRIPTION
### Description

- Introduced a new Huawei IPFIX registry XML file at `crates/flow-pkt/registry/huawei.xml` containing Huawei-specific information elements.
- Added a `get_huawei_config` function in `crates/flow-pkt/build.rs` to load the Huawei registry.
- Updated the vendor registry list in `build.rs` to include the Huawei source alongside Nokia, NetGauze, and VMware.

This enables parsing and support for Huawei-specific IPFIX information elements in the flow-pkt crate.