### PR TITLE
Collector: allow string transforms for mplsVpnRouteDistinguisher in flow config validation

### DIFF
--- a/crates/collector/src/flow/config.rs
+++ b/crates/collector/src/flow/config.rs
@@ -388,14 +388,17 @@ impl FieldConfig {
                 }
             }
 
-            // String transforms require TryInto<String> (implemented for all types except Bytes)
+            // String transforms require TryInto<String>
+            // - Generally implemented for all types except Bytes
+            // - Exception: also implemented for IE::mplsVpnRouteDistinguisher (octetArray with
+            //   custom string conversion)
             FieldTransformFunction::String
             | FieldTransformFunction::TrimmedString
             | FieldTransformFunction::LowercaseString
             | FieldTransformFunction::Rename(_)
             | FieldTransformFunction::StringArrayAgg
             | FieldTransformFunction::StringMapAgg(_) => {
-                if ie_avro_type(ie) == AvroValueKind::Bytes {
+                if ie_avro_type(ie) == AvroValueKind::Bytes && ie != IE::mplsVpnRouteDistinguisher {
                     return Err(FieldConfigValidationError::InvalidTransform(format!(
                         "{:?} requires String conversion, but {} is Bytes type ({:?})",
                         self.transform,


### PR DESCRIPTION
### Summary

This PR updates the flow configuration validation logic to allow string-based transforms for the `mplsVpnRouteDistinguisher` Information Element (IE), even though it is of type `octetArray`. This is possible because a custom `TryInto<String>` implementation exists for this IE.

### Details

- The validation previously blocked all `octetArray` (Avro `Bytes`) IEs from using string transforms, even if a custom conversion existed.
- Now, the validation allows string transforms for `IE::mplsVpnRouteDistinguisher` by special-casing it in the check.