### PR TITLE
Extract YANG-Push and extend types from udp-notif-pkt into netconf-proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,7 +3000,6 @@ name = "netgauze-netconf-proto"
 version = "0.11.0"
 dependencies = [
  "anyhow",
- "bytes",
  "chrono",
  "clap",
  "futures-util",
@@ -3011,6 +3010,7 @@ dependencies = [
  "schema-registry-client",
  "secrecy",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "strum",
  "strum_macros",
@@ -3081,6 +3081,7 @@ dependencies = [
  "ciborium",
  "either",
  "netgauze-locate",
+ "netgauze-netconf-proto",
  "netgauze-parse-utils",
  "netgauze-pcap-reader",
  "netgauze-serde-macros",

--- a/crates/collector/src/yang_push/enrichment.rs
+++ b/crates/collector/src/yang_push/enrichment.rs
@@ -34,9 +34,10 @@ use crate::yang_push::{
     DeleteAllPayload, DeletePayload, EnrichmentOperation, UpsertPayload, Weight,
 };
 use chrono::Utc;
+use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_udp_notif_pkt::decoded::{UdpNotifPacketDecoded, UdpNotifPayload};
 use netgauze_udp_notif_pkt::notification::{
-    NotificationVariant, SubscriptionId, SubscriptionStartedModified, SubscriptionTerminated,
+    NotificationVariant, SubscriptionStartedModified, SubscriptionTerminated,
 };
 use netgauze_udp_notif_service::OTL_UDP_NOTIF_PUBLISHER_ID_KEY;
 use netgauze_yang_push::cache::storage::SubscriptionInfo;
@@ -865,10 +866,11 @@ impl EnrichmentHandle<EnrichmentOperation> for YangPushEnrichmentActorHandle {
 mod tests {
     use super::*;
     use bytes::Bytes;
+    use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
+    use netgauze_netconf_proto::yang_push::subscription::UpdateTrigger;
+    use netgauze_netconf_proto::yang_push::types::CentiSeconds;
     use netgauze_udp_notif_pkt::decoded::UdpNotifPacketDecoded;
-    use netgauze_udp_notif_pkt::notification::{
-        CentiSeconds, Encoding, Target, Transport, UpdateTrigger,
-    };
+    use netgauze_udp_notif_pkt::notification::Target;
     use netgauze_udp_notif_pkt::raw::{MediaType, UdpNotifPacket};
     use netgauze_yang_push::model::telemetry::{Label, LabelValue};
     use serde_json::json;

--- a/crates/netconf-proto/Cargo.toml
+++ b/crates/netconf-proto/Cargo.toml
@@ -21,7 +21,6 @@ quick-xml = { workspace = true, features = ["serialize", "async-tokio"] }
 strum_macros = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 chrono = { workspace = true, default-features = false, features = ["serde"] }
-bytes = { workspace = true }
 tokio-util = { workspace = true, default-features = false, features = ["codec"] }
 tokio = { workspace = true, default-features = false }
 tracing = { workspace = true }
@@ -37,3 +36,4 @@ schema-registry-client = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/netconf-proto/src/lib.rs
+++ b/crates/netconf-proto/src/lib.rs
@@ -30,6 +30,7 @@ pub mod client;
 pub mod codec;
 pub mod protocol;
 pub mod xml_utils;
+pub mod yang_push;
 pub mod yanglib;
 pub mod yangparser;
 

--- a/crates/netconf-proto/src/yang_push/filters.rs
+++ b/crates/netconf-proto/src/yang_push/filters.rs
@@ -1,0 +1,699 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Filter types for YANG-Push and Subscribed Notifications.
+//!
+//! Provides datastore selection filters ([RFC 8641]) and stream event filters
+//! ([RFC 8639]) in both XPath 1.0 and subtree variants, as well as the
+//! top-level [`Filters`] container that holds reusable named filters.
+//!
+//! Each filter type implements [XmlSerialize] and [XmlDeserialize] for NETCONF
+//! XML round-tripping.
+
+use crate::xml_utils::{ParsingError, XmlDeserialize, XmlParser, XmlSerialize, XmlWriter};
+use crate::yang_push::{SUBSCRIBED_NOTIFICATIONS_NS, YANG_PUSH_NS};
+use indexmap::map::IndexMap;
+use quick_xml::events::{BytesText, Event};
+use quick_xml::name::Namespace;
+use serde::{Deserialize, Serialize};
+use std::io;
+
+/// Contains a list of configurable filters that can be applied to
+/// subscriptions. This facilitates the reuse of complex filters once defined.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename = "ietf-subscribed-notifications:filters")]
+pub struct Filters {
+    #[serde(rename = "ietf-subscribed-notifications:stream-filters")]
+    pub stream_filters: IndexMap<Box<str>, StreamFilter>,
+
+    #[serde(rename = "ietf-yang-push:selection-filters")]
+    pub selection_filters: IndexMap<Box<str>, SelectionFilter>,
+}
+
+impl Filters {
+    pub fn new<D: IntoIterator<Item = SelectionFilter>, S: IntoIterator<Item = StreamFilter>>(
+        stream_filters: S,
+        selection_filters: D,
+    ) -> Self {
+        let selection_filters = selection_filters
+            .into_iter()
+            .map(|f| (f.filter_id.clone(), f))
+            .collect();
+        let stream_filters = stream_filters
+            .into_iter()
+            .map(|f| (f.name.clone(), f))
+            .collect();
+        Self {
+            stream_filters,
+            selection_filters,
+        }
+    }
+}
+
+impl XmlSerialize for Filters {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        if writer
+            .get_namespace_prefix(SUBSCRIBED_NOTIFICATIONS_NS)
+            .is_none()
+        {
+            ns_added = true;
+            writer.push_namespace_binding(IndexMap::from([(
+                SUBSCRIBED_NOTIFICATIONS_NS,
+                "".to_string(),
+            )]))?;
+        }
+        let elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "filters")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+        for v in self.stream_filters.values() {
+            v.xml_serialize(writer)?;
+        }
+        for v in self.selection_filters.values() {
+            v.xml_serialize(writer)?;
+        }
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl XmlDeserialize<'_, Filters> for Filters {
+    fn xml_deserialize(parser: &mut XmlParser<'_, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        let filters_start = parser
+            .is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "filters")
+            .then(|| parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "filters"))
+            .ok_or_else(|| ParsingError::WrongToken {
+                expecting: "<filters>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })??;
+        parser.skip_text()?;
+        let mut stream_filters = Vec::new();
+        let mut selection_filters = Vec::new();
+        parser.skip_text()?;
+        while parser.peek() != &Event::End(filters_start.to_end()) {
+            if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-filter") {
+                let stream_filter = StreamFilter::xml_deserialize(parser)?;
+                stream_filters.push(stream_filter);
+            } else if parser.is_tag(Some(YANG_PUSH_NS), "selection-filter") {
+                let selection_filter = SelectionFilter::xml_deserialize(parser)?;
+                selection_filters.push(selection_filter);
+            } else {
+                // Could be an IETF or vendor-specific extension that we don't understand,
+                // skip it
+                parser.skip()?;
+            }
+            parser.skip_text()?;
+        }
+        parser.skip_text()?;
+        parser.close()?;
+        Ok(Self::new(stream_filters, selection_filters))
+    }
+}
+
+/// This grouping defines the types of selectors for objects from a datastore.
+///
+/// See RFC 8641
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename = "ietf-yang-push:selection-filters")]
+pub struct SelectionFilter {
+    #[serde(rename = "filter-id")]
+    pub filter_id: Box<str>,
+
+    #[serde(rename = "filter-spec")]
+    pub filter_spec: DatastoreFilterSpec,
+}
+
+impl XmlSerialize for SelectionFilter {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        if writer.get_namespace_prefix(YANG_PUSH_NS).is_none() {
+            ns_added = true;
+            writer.push_namespace_binding(IndexMap::from([(YANG_PUSH_NS, "".to_string())]))?;
+        }
+        let elem = writer.create_ns_element(YANG_PUSH_NS, "selection-filter")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+
+        let filter_id_elem = writer.create_ns_element(YANG_PUSH_NS, "filter-id")?;
+        writer.write_event(Event::Start(filter_id_elem.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(self.filter_id.as_ref())))?;
+        writer.write_event(Event::End(filter_id_elem.to_end()))?;
+
+        self.filter_spec.xml_serialize(writer)?;
+
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, SelectionFilter> for SelectionFilter {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        let _ = parser
+            .is_tag(Some(YANG_PUSH_NS), "selection-filter")
+            .then(|| parser.open(Some(YANG_PUSH_NS), "selection-filter"))
+            .ok_or_else(|| ParsingError::WrongToken {
+                expecting: "<selection-filter>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })??;
+        parser.skip_text()?;
+        let (filter_id, filter_spec) = if parser.is_tag(Some(YANG_PUSH_NS), "filter-id") {
+            parser.open(Some(YANG_PUSH_NS), "filter-id")?;
+            let filter_id = parser.tag_string()?.trim().into();
+            parser.close()?;
+            parser.skip_text()?;
+            let spec = DatastoreFilterSpec::xml_deserialize(parser)?;
+            (filter_id, spec)
+        } else {
+            let spec = DatastoreFilterSpec::xml_deserialize(parser)?;
+            parser.skip_text()?;
+            parser.open(Some(YANG_PUSH_NS), "filter-id")?;
+            let filter_id = parser.tag_string()?.trim().into();
+            parser.close()?;
+            (filter_id, spec)
+        };
+        parser.skip_text()?;
+        parser.close()?;
+        Ok(Self {
+            filter_id,
+            filter_spec,
+        })
+    }
+}
+
+/// This grouping defines the base for filters applied to event streams.
+///
+/// See RFC 8639
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename = "ietf-subscribed-notifications:stream-filter")]
+pub struct StreamFilter {
+    pub name: Box<str>,
+    #[serde(rename = "filter-spec")]
+    pub filter_spec: StreamFilterSpec,
+}
+
+impl StreamFilter {
+    pub const fn new(name: Box<str>, filter_spec: StreamFilterSpec) -> Self {
+        Self { name, filter_spec }
+    }
+}
+
+impl XmlSerialize for StreamFilter {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        if writer
+            .get_namespace_prefix(SUBSCRIBED_NOTIFICATIONS_NS)
+            .is_none()
+        {
+            ns_added = true;
+            writer.push_namespace_binding(IndexMap::from([(
+                SUBSCRIBED_NOTIFICATIONS_NS,
+                "".to_string(),
+            )]))?;
+        }
+        let elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "stream-filter")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+
+        let name_elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "name")?;
+        writer.write_event(Event::Start(name_elem.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(self.name.as_ref())))?;
+        writer.write_event(Event::End(name_elem.to_end()))?;
+
+        self.filter_spec.xml_serialize(writer)?;
+
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, StreamFilter> for StreamFilter {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        let _ = parser
+            .is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-filter")
+            .then(|| parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-filter"))
+            .ok_or_else(|| ParsingError::WrongToken {
+                expecting: "<stream-filter>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })??;
+        parser.skip_text()?;
+        let (name, filter_spec) = if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "name") {
+            parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "name")?;
+            let name = parser.tag_string()?.trim().into();
+            parser.close()?;
+            parser.skip_text()?;
+            let spec = StreamFilterSpec::xml_deserialize(parser)?;
+            (name, spec)
+        } else {
+            let spec = StreamFilterSpec::xml_deserialize(parser)?;
+            parser.skip_text()?;
+            parser.open(Some(YANG_PUSH_NS), "name")?;
+            let name = parser.tag_string()?.trim().into();
+            parser.close()?;
+            (name, spec)
+        };
+        parser.skip_text()?;
+        parser.close()?;
+        Ok(Self { name, filter_spec })
+    }
+}
+
+/// Datastore filter specification (RFC 8641).
+///
+/// Supports either subtree or XPath filtering.
+///
+/// Note, DatastoreFilterSpec keeps all the namespaces in scope that are used in
+/// the filter along with the prefix mapping.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum DatastoreFilterSpec {
+    Subtree(DatastoreSubtreeFilter),
+    Xpath(DatastoreXPathFilter),
+}
+
+impl XmlSerialize for DatastoreFilterSpec {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        match self {
+            Self::Subtree(subtree) => {
+                subtree.xml_serialize(writer)?;
+            }
+            Self::Xpath(xpath) => {
+                xpath.xml_serialize(writer)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, DatastoreFilterSpec> for DatastoreFilterSpec {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        if parser.is_tag(Some(YANG_PUSH_NS), "datastore-subtree-filter") {
+            let subtree = DatastoreSubtreeFilter::xml_deserialize(parser)?;
+            Ok(Self::Subtree(subtree))
+        } else if parser.is_tag(Some(YANG_PUSH_NS), "datastore-xpath-filter") {
+            let xpath = DatastoreXPathFilter::xml_deserialize(parser)?;
+            Ok(Self::Xpath(xpath))
+        } else {
+            Err(ParsingError::WrongToken {
+                expecting: "<datastore-subtree-filter> or <datastore-xpath-filter>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })
+        }
+    }
+}
+
+/// XPath 1.0 filter expression.
+/// Namespace: prefix → namespace
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename = "ietf-yang-push:datastore-xpath-filter")]
+pub struct DatastoreXPathFilter {
+    pub namespaces: IndexMap<String, String>,
+    pub path: Box<str>,
+}
+
+impl XmlSerialize for DatastoreXPathFilter {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        let mut new_namespaces: IndexMap<Namespace<'_>, String> =
+            IndexMap::with_capacity(self.namespaces.len() + 1);
+        for (prefix, namespace) in &self.namespaces {
+            let ns = Namespace(namespace.as_bytes());
+            new_namespaces.insert(ns, prefix.clone());
+        }
+        if writer.get_namespace_prefix(YANG_PUSH_NS).is_none()
+            && !new_namespaces.contains_key(&YANG_PUSH_NS)
+        {
+            new_namespaces.insert(YANG_PUSH_NS, "".to_string());
+        }
+        if !new_namespaces.is_empty() {
+            ns_added = true;
+            writer.push_namespace_binding(new_namespaces.to_owned())?;
+        }
+        let elem = writer.create_ns_element(YANG_PUSH_NS, "datastore-xpath-filter")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(self.path.as_ref())))?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, DatastoreXPathFilter> for DatastoreXPathFilter {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        parser
+            .is_tag(Some(YANG_PUSH_NS), "datastore-xpath-filter")
+            .then(|| parser.open(Some(YANG_PUSH_NS), "datastore-xpath-filter"))
+            .ok_or_else(|| ParsingError::WrongToken {
+                expecting: "<datastore-xpath-filter>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })??;
+        let (path, namespaces) = parser.read_xpath_with_namespaces()?;
+        parser.close()?;
+        Ok(Self {
+            namespaces,
+            path: path.trim().into(),
+        })
+    }
+}
+
+/// Subtree filter (RFC 6241 Section 6).
+/// Namespace: prefix → namespace
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename = "ietf-yang-push:datastore-subtree-filter")]
+pub struct DatastoreSubtreeFilter {
+    pub namespaces: IndexMap<String, String>,
+    pub subtree: Box<str>,
+}
+
+impl XmlSerialize for DatastoreSubtreeFilter {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        let mut new_namespaces: IndexMap<Namespace<'_>, String> =
+            IndexMap::with_capacity(self.namespaces.len() + 1);
+        for (prefix, namespace) in &self.namespaces {
+            let ns = Namespace(namespace.as_bytes());
+            new_namespaces.insert(ns, prefix.clone());
+        }
+        if writer.get_namespace_prefix(YANG_PUSH_NS).is_none()
+            && !new_namespaces.contains_key(&YANG_PUSH_NS)
+        {
+            new_namespaces.insert(YANG_PUSH_NS, "".to_string());
+        }
+        if !new_namespaces.is_empty() {
+            ns_added = true;
+            writer.push_namespace_binding(new_namespaces.to_owned())?;
+        }
+        let elem = writer.create_ns_element(YANG_PUSH_NS, "datastore-subtree-filter")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+        // For subtree filters, write raw XML content
+        writer.write_all(self.subtree.as_bytes())?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, DatastoreSubtreeFilter> for DatastoreSubtreeFilter {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        parser
+            .is_tag(Some(YANG_PUSH_NS), "datastore-subtree-filter")
+            .then(|| parser.open(Some(YANG_PUSH_NS), "datastore-subtree-filter"))
+            .ok_or_else(|| ParsingError::WrongToken {
+                expecting: "<datastore-subtree-filter>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })??;
+        let subtree = parser.copy_buffer_till_with_namespaces(b"datastore-subtree-filter")?;
+
+        parser.close()?;
+        Ok(Self {
+            namespaces: subtree.namespaces,
+            subtree: subtree.xml.trim().into(),
+        })
+    }
+}
+
+/// Stream filter specification (RFC 8639).
+///
+/// Supports either subtree or XPath filtering.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum StreamFilterSpec {
+    /// Subtree filter (RFC 6241 Section 6)
+    Subtree(StreamSubtreeFilter),
+
+    /// XPath 1.0 filter expression
+    Xpath(StreamXPathFilter),
+}
+
+impl XmlSerialize for StreamFilterSpec {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        match self {
+            Self::Subtree(subtree) => {
+                subtree.xml_serialize(writer)?;
+            }
+            Self::Xpath(xpath) => {
+                xpath.xml_serialize(writer)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, StreamFilterSpec> for StreamFilterSpec {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-subtree-filter") {
+            let subtree = StreamSubtreeFilter::xml_deserialize(parser)?;
+            Ok(Self::Subtree(subtree))
+        } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-xpath-filter") {
+            let xpath = StreamXPathFilter::xml_deserialize(parser)?;
+            Ok(Self::Xpath(xpath))
+        } else {
+            Err(ParsingError::WrongToken {
+                expecting: "<stream-subtree-filter> or <stream-xpath-filter>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })
+        }
+    }
+}
+
+/// XPath 1.0 filter expression.
+/// Namespace: prefix → namespace
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename = "ietf-subscribed-notifications:stream-xpath-filter")]
+pub struct StreamXPathFilter {
+    pub namespaces: IndexMap<String, String>,
+    pub path: Box<str>,
+}
+
+impl XmlSerialize for StreamXPathFilter {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        let mut new_namespaces: IndexMap<Namespace<'_>, String> =
+            IndexMap::with_capacity(self.namespaces.len() + 1);
+        for (prefix, namespace) in &self.namespaces {
+            let ns = Namespace(namespace.as_bytes());
+            new_namespaces.insert(ns, prefix.clone());
+        }
+        if writer
+            .get_namespace_prefix(SUBSCRIBED_NOTIFICATIONS_NS)
+            .is_none()
+            && !new_namespaces.contains_key(&SUBSCRIBED_NOTIFICATIONS_NS)
+        {
+            new_namespaces.insert(SUBSCRIBED_NOTIFICATIONS_NS, "".to_string());
+        }
+        if !new_namespaces.is_empty() {
+            ns_added = true;
+            writer.push_namespace_binding(new_namespaces.to_owned())?;
+        }
+        let elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "stream-xpath-filter")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(self.path.as_ref())))?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, StreamXPathFilter> for StreamXPathFilter {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        parser
+            .is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-xpath-filter")
+            .then(|| parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-xpath-filter"))
+            .ok_or_else(|| ParsingError::WrongToken {
+                expecting: "<stream-xpath-filter>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })??;
+        let (path, namespaces) = parser.read_xpath_with_namespaces()?;
+        parser.close()?;
+        Ok(Self {
+            namespaces,
+            path: path.trim().into(),
+        })
+    }
+}
+
+/// Subtree filter (RFC 6241 Section 6).
+/// Namespace: prefix → namespace
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename = "ietf-subscribed-notifications:stream-subtree-filter")]
+pub struct StreamSubtreeFilter {
+    pub namespaces: IndexMap<String, String>,
+    pub subtree: Box<str>,
+}
+
+impl XmlSerialize for StreamSubtreeFilter {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        let mut new_namespaces: IndexMap<Namespace<'_>, String> =
+            IndexMap::with_capacity(self.namespaces.len() + 1);
+        for (prefix, namespace) in &self.namespaces {
+            let ns = Namespace(namespace.as_bytes());
+            new_namespaces.insert(ns, prefix.clone());
+        }
+        if writer
+            .get_namespace_prefix(SUBSCRIBED_NOTIFICATIONS_NS)
+            .is_none()
+            && !new_namespaces.contains_key(&SUBSCRIBED_NOTIFICATIONS_NS)
+        {
+            new_namespaces.insert(SUBSCRIBED_NOTIFICATIONS_NS, "".to_string());
+        }
+        if !new_namespaces.is_empty() {
+            ns_added = true;
+            writer.push_namespace_binding(new_namespaces.to_owned())?;
+        }
+        let elem =
+            writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "stream-subtree-filter")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+        // For subtree filters, write raw XML content
+        writer.write_all(self.subtree.as_bytes())?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, StreamSubtreeFilter> for StreamSubtreeFilter {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        parser
+            .is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-subtree-filter")
+            .then(|| parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-subtree-filter"))
+            .ok_or_else(|| ParsingError::WrongToken {
+                expecting: "<stream-subtree-filter>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })??;
+        let subtree = parser.copy_buffer_till_with_namespaces(b"stream-subtree-filter")?;
+
+        parser.close()?;
+        Ok(Self {
+            namespaces: subtree.namespaces,
+            subtree: subtree.xml.trim().into(),
+        })
+    }
+}
+
+/// Selection filter objects for stream subscriptions (RFC 8639).
+///
+/// Filters can be specified by reference to a pre-configured filter,
+/// or inline within the subscription.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum StreamSelectionFilterObjects {
+    /// Reference to a pre-configured filter
+    ByReference(Box<str>),
+
+    /// Filter specified within the subscription
+    WithInSubscription(StreamFilterSpec),
+}
+
+impl XmlSerialize for StreamSelectionFilterObjects {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        match self {
+            Self::ByReference(filter_name) => {
+                let mut ns_added = false;
+                if writer
+                    .get_namespace_prefix(SUBSCRIBED_NOTIFICATIONS_NS)
+                    .is_none()
+                {
+                    ns_added = true;
+                    writer.push_namespace_binding(IndexMap::from([(
+                        SUBSCRIBED_NOTIFICATIONS_NS,
+                        "".to_string(),
+                    )]))?;
+                }
+                let elem =
+                    writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "stream-filter-name")?;
+                writer.write_event(Event::Start(elem.clone()))?;
+                writer.write_event(Event::Text(BytesText::new(filter_name.as_ref())))?;
+                writer.write_event(Event::End(elem.to_end()))?;
+                if ns_added {
+                    writer.pop_namespace_binding();
+                }
+            }
+            Self::WithInSubscription(filter_spec) => {
+                filter_spec.xml_serialize(writer)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, StreamSelectionFilterObjects> for StreamSelectionFilterObjects {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+
+        if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-filter-name") {
+            parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-filter-name")?;
+            let filter_name = parser.tag_string()?;
+            parser.close()?;
+            Ok(Self::ByReference(filter_name))
+        } else {
+            Ok(Self::WithInSubscription(StreamFilterSpec::xml_deserialize(
+                parser,
+            )?))
+        }
+    }
+}

--- a/crates/netconf-proto/src/yang_push/identities.rs
+++ b/crates/netconf-proto/src/yang_push/identities.rs
@@ -1,0 +1,210 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! YANG identity enumerations for subscribed notifications.
+//!
+//! This module maps YANG `identityref` values to Rust enums with full XML
+//! serialization/deserialization support.
+//!
+//! * [`ConfiguredSubscriptionState`] – configured subscription lifecycle state
+//!   (`valid`, `invalid`, `concluded`).
+//! * [`Transport`] – notification transport protocol (UDP-Notif, HTTPS-Notif).
+//! * [`Encoding`] – notification payload encoding (XML, JSON, CBOR).
+//! * [`ChangeType`] – on-change update trigger change kinds.
+
+use crate::xml_utils::{ParsingError, XmlDeserialize, XmlParser, XmlSerialize, XmlWriter};
+use crate::yang_push::SUBSCRIBED_NOTIFICATIONS_NS;
+use quick_xml::events::{BytesText, Event};
+use serde::{Deserialize, Serialize};
+use std::io;
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfiguredSubscriptionState {
+    Valid,
+    Invalid,
+    Concluded,
+}
+
+impl XmlSerialize for ConfiguredSubscriptionState {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let value = match self {
+            Self::Valid => "valid",
+            Self::Invalid => "invalid",
+            Self::Concluded => "concluded",
+        };
+        let elem = writer
+            .create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "configured-subscription-state")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(value)))?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, ConfiguredSubscriptionState> for ConfiguredSubscriptionState {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.open(
+            Some(SUBSCRIBED_NOTIFICATIONS_NS),
+            "configured-subscription-state",
+        )?;
+        let value = parser.tag_string()?;
+        parser.close()?;
+        match value.trim() {
+            "valid" => Ok(Self::Valid),
+            "invalid" => Ok(Self::Invalid),
+            "concluded" => Ok(Self::Concluded),
+            other => Err(ParsingError::InvalidValue(other.to_string())),
+        }
+    }
+}
+
+/// Transport protocol used to deliver the notification message to the data
+/// collection.
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Transport {
+    /// UDP-based notification transport
+    /// [ietf-udp-notif-transport](https://datatracker.ietf.org/doc/html/draft-ietf-netconf-udp-notif)
+    #[serde(rename = "ietf-udp-notif-transport:udp-notif")]
+    UDPNotif,
+
+    /// HTTPS-based notification transport
+    /// [draft-ietf-netconf-https-notif](https://datatracker.ietf.org/doc/html/draft-ietf-netconf-https-notif)
+    #[serde(rename = "ietf-https-notif:https")]
+    HTTPSNotif,
+
+    #[default]
+    #[serde(other)]
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+impl XmlSerialize for Transport {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        // `transport` is an identityref leaf. We resolve the prefix:localname
+        // from the identity module namespace.
+        let (identity_ns, local_name) = match self {
+            Transport::UDPNotif => (
+                "urn:ietf:params:xml:ns:yang:ietf-udp-notif-transport",
+                "udp-notif",
+            ),
+            Transport::HTTPSNotif => ("urn:ietf:params:xml:ns:yang:ietf-https-notif", "https"),
+            Transport::Unknown => return Ok(()), // skip unknown
+        };
+        let elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "transport")?;
+        let mut start = elem.clone();
+        start.push_attribute(("xmlns:tns", identity_ns));
+        writer.write_event(Event::Start(start))?;
+        writer.write_event(Event::Text(BytesText::new(&format!("tns:{local_name}"))))?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, Transport> for Transport {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "transport")?;
+        let raw: Box<str> = parser.tag_string()?.trim().into();
+        let (_ns_uri, local_name) = parser.resolve_identity_ref(&raw)?;
+        parser.close()?;
+        match local_name.as_str() {
+            "udp-notif" => Ok(Transport::UDPNotif),
+            "https" => Ok(Transport::HTTPSNotif),
+            _ => Ok(Transport::Unknown),
+        }
+    }
+}
+
+/// Encoding used for the notification payload
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Encoding {
+    #[serde(rename = "ietf-subscribed-notifications:encode-xml")]
+    #[serde(alias = "encode-xml")]
+    Xml,
+
+    #[serde(rename = "ietf-subscribed-notifications:encode-json")]
+    #[serde(alias = "encode-json")]
+    Json,
+
+    #[serde(rename = "ietf-udp-notif-transport:encode-cbor")]
+    #[serde(alias = "encode-cbor")]
+    Cbor,
+
+    #[default]
+    #[serde(other)]
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+impl XmlSerialize for Encoding {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let (identity_ns, local_name) = match self {
+            Encoding::Xml => (
+                "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                "encode-xml",
+            ),
+            Encoding::Json => (
+                "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                "encode-json",
+            ),
+            Encoding::Cbor => (
+                "urn:ietf:params:xml:ns:yang:ietf-udp-notif-transport",
+                "encode-cbor",
+            ),
+            Encoding::Unknown => return Ok(()),
+        };
+        let elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "encoding")?;
+        let mut start = elem.clone();
+        start.push_attribute(("xmlns:enc", identity_ns));
+        writer.write_event(Event::Start(start))?;
+        writer.write_event(Event::Text(BytesText::new(&format!("enc:{local_name}"))))?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, Encoding> for Encoding {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "encoding")?;
+        let raw: Box<str> = parser.tag_string()?.trim().into();
+        let (_ns_uri, local_name) = parser.resolve_identity_ref(&raw)?;
+        parser.close()?;
+        match local_name.as_str() {
+            "encode-xml" => Ok(Encoding::Xml),
+            "encode-json" => Ok(Encoding::Json),
+            "encode-cbor" => Ok(Encoding::Cbor),
+            _ => Ok(Encoding::Unknown),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ChangeType {
+    Create,
+    Delete,
+    Insert,
+    Move,
+    Replace,
+}

--- a/crates/netconf-proto/src/yang_push/mod.rs
+++ b/crates/netconf-proto/src/yang_push/mod.rs
@@ -1,0 +1,49 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! YANG-Push subscription model ([RFC 8641]) and Subscribed Notifications
+//! ([RFC 8639]).
+//!
+//! This module implements the data types, XML serialization/deserialization,
+//! and helper utilities for YANG-Push and Subscribed Notifications as defined
+//! in the following RFCs:
+//!
+//! * [RFC 8639 – Subscription to YANG Notifications](https://datatracker.ietf.org/doc/html/rfc8639)
+//! * [RFC 8641 – Subscription to YANG Notifications for Datastore Updates](https://datatracker.ietf.org/doc/html/rfc8641)
+//!
+//! # Sub-modules
+//!
+//! | Module | Contents |
+//! |---|---|
+//! | [`filters`] | Filter types for stream and datastore subscriptions |
+//! | [`identities`] | YANG identity enumerations (transport, encoding, etc.) |
+//! | [`subscription`] | The core [`Subscription`](subscription::Subscription) type and targets |
+//! | [`types`] | Primitive newtypes (`CentiSeconds`, `SubscriptionId`) |
+
+use quick_xml::name::Namespace;
+
+pub mod filters;
+pub mod identities;
+pub mod subscription;
+#[cfg(test)]
+mod tests;
+pub mod types;
+
+pub const YANG_PUSH_NS: Namespace<'static> =
+    Namespace(b"urn:ietf:params:xml:ns:yang:ietf-yang-push");
+pub const SUBSCRIBED_NOTIFICATIONS_NS: Namespace<'static> =
+    Namespace(b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications");
+pub const DISTRIBUTED_NOTIF_NS: Namespace<'static> =
+    Namespace(b"urn:ietf:params:xml:ns:yang:ietf-distributed-notif");

--- a/crates/netconf-proto/src/yang_push/subscription.rs
+++ b/crates/netconf-proto/src/yang_push/subscription.rs
@@ -1,0 +1,965 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Subscription types for YANG-Push and Subscribed Notifications.
+//!
+//! This module contains the core [`Subscription`] type together with its
+//! constituent parts:
+//!
+//! * [`Target`] – choice between a [`StreamTarget`] ([RFC 8639]) and a
+//!   [`DatastoreTarget`] ([RFC 8641]).
+//! * [`UpdateTrigger`] – periodic or on-change trigger configuration.
+//! * [`DatastoreSelectionFilterObjects`] – inline or by-reference datastore
+//!   filter selection.
+//!
+//! All types implement XML round-trip serialization via
+//! [XmlSerialize]/[XmlDeserialize] and `serde` `Serialize`/`Deserialize`.
+
+use crate::xml_utils::{
+    ParsingError, XmlDeserialize, XmlParser, XmlSerialize, XmlWriter, format_datetime,
+    parse_datetime, xml_write_optional_text_leaf,
+};
+use crate::yang_push::filters::{
+    DatastoreFilterSpec, StreamFilterSpec, StreamSelectionFilterObjects,
+};
+use crate::yang_push::identities::{ChangeType, ConfiguredSubscriptionState, Encoding, Transport};
+use crate::yang_push::types::{CentiSeconds, SubscriptionId};
+use crate::yang_push::{DISTRIBUTED_NOTIF_NS, SUBSCRIBED_NOTIFICATIONS_NS, YANG_PUSH_NS};
+use crate::yanglib::{Datastore, DatastoreName};
+use chrono::{DateTime, Utc};
+use indexmap::IndexMap;
+use quick_xml::events::{BytesText, Event};
+use serde::{Deserialize, Serialize};
+use std::io;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Subscription {
+    pub id: SubscriptionId,
+
+    #[serde(flatten)]
+    pub target: Target,
+
+    #[serde(rename = "stop-time", skip_serializing_if = "Option::is_none")]
+    pub stop_time: Option<DateTime<Utc>>,
+
+    #[serde(rename = "dscp", skip_serializing_if = "Option::is_none")]
+    pub dscp: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weighting: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependency: Option<SubscriptionId>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<Transport>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<Encoding>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<Box<str>>,
+
+    #[serde(
+        rename = "configured-subscription-state",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub configured_subscription_state: Option<ConfiguredSubscriptionState>,
+
+    #[serde(
+        rename = "ietf-distributed-notif:message-publisher-id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub message_publisher_id: Option<u32>,
+
+    #[serde(flatten)]
+    pub update_trigger: Option<UpdateTrigger>,
+}
+
+impl Subscription {
+    /// Create a Subscription with only the required attributes
+    pub fn new(id: SubscriptionId, target: Target) -> Self {
+        Self {
+            id,
+            target,
+            stop_time: None,
+            dscp: None,
+            weighting: None,
+            dependency: None,
+            transport: None,
+            encoding: None,
+            purpose: None,
+            configured_subscription_state: None,
+            message_publisher_id: None,
+            update_trigger: None,
+        }
+    }
+}
+
+/// Subscription target as defined in RFC 8639 and RFC 8641.
+///
+/// A subscription can target either an event stream (RFC 8639) or a datastore
+/// (RFC 8641).
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum Target {
+    Stream(StreamTarget),
+    Datastore(DatastoreTarget),
+}
+
+/// Stream subscription target as defined in RFC 8639.
+///
+/// Specifies which event stream to subscribe to and how to filter events.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct StreamTarget {
+    /// Name of the event stream
+    pub stream: Box<str>,
+
+    /// Selection filter for stream events
+    #[serde(flatten)]
+    pub filter: StreamSelectionFilterObjects,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_start_time: Option<DateTime<Utc>>,
+
+    /// Skipped if value is false
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub configured_reply: bool,
+}
+
+/// Datastore subscription target as defined in RFC 8641.
+///
+/// Specifies which datastore to subscribe to, how to filter the data,
+/// and when/how updates should be triggered.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct DatastoreTarget {
+    /// Datastore, from which to retrieve data (e.g., operational, running)
+    #[serde(
+        rename = "ietf-yang-push:datastore",
+        serialize_with = "datastore_serialize",
+        deserialize_with = "datastore_deserialize"
+    )]
+    pub datastore: Datastore,
+
+    /// Selection filter for datastore nodes
+    #[serde(flatten)]
+    pub selection: DatastoreSelectionFilterObjects,
+}
+
+pub(crate) fn datastore_serialize<S>(
+    datastore: &Datastore,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    const DS_NS: &str = "urn:ietf:params:xml:ns:yang:ietf-datastores";
+    const DS_PREFIX: &str = "ietf-datastores";
+
+    let prefix = if datastore.schema() == DS_NS {
+        DS_PREFIX
+    } else {
+        return Err(serde::ser::Error::custom(format!(
+            "Unsupported datastore namespace: {}",
+            datastore.schema()
+        )));
+    };
+
+    let name = match datastore.name() {
+        DatastoreName::Operational => "operational",
+        DatastoreName::Running => "running",
+        DatastoreName::Candidate => "candidate",
+        DatastoreName::StartUp => "startup",
+        DatastoreName::Intended => "intended",
+        DatastoreName::Unknown { name, .. } => name.as_ref(),
+    };
+
+    serializer.serialize_str(&format!("{prefix}:{name}"))
+}
+
+pub(crate) fn datastore_deserialize<'de, D>(deserializer: D) -> Result<Datastore, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    const DS_NS: &str = "urn:ietf:params:xml:ns:yang:ietf-datastores";
+
+    let s = String::deserialize(deserializer)?;
+    let (prefix, name) = s.split_once(':').ok_or_else(|| {
+        serde::de::Error::custom(format!("Expected 'prefix:name' format, got '{s}'"))
+    })?;
+
+    if prefix != "ietf-datastores" {
+        return Err(serde::de::Error::custom(format!(
+            "Expected 'ietf-datastores' namespace, got '{prefix}'",
+        )));
+    }
+
+    let datastore_name = match name {
+        "operational" => DatastoreName::Operational,
+        "running" => DatastoreName::Running,
+        "candidate" => DatastoreName::Candidate,
+        "startup" => DatastoreName::StartUp,
+        "intended" => DatastoreName::Intended,
+        _ => {
+            return Err(serde::de::Error::custom(format!(
+                "Unknown datastore: {name}",
+            )));
+        }
+    };
+
+    Ok(Datastore::new(datastore_name, DS_NS.into()))
+}
+
+/// Update Trigger
+/// ```text
+/// UpdateTrigger
+/// ├── Periodic
+/// │   ├── period: CentiSeconds (update interval in 1/100 seconds)
+/// │   └── anchor-time: DateTime (optional reference time)
+/// │
+/// └── OnChange
+///     ├── dampening-period: CentiSeconds (minimum time between updates)
+///     ├── sync-on-start: bool (send initial snapshot)
+///     └── excluded-change: Vec<ChangeType> (filter change types)
+///         ├── Create
+///         ├── Delete
+///         ├── Insert
+///         ├── Move
+///         └── Replace
+/// ```
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum UpdateTrigger {
+    #[serde(rename = "ietf-yang-push:periodic")]
+    #[serde(rename_all = "kebab-case")]
+    Periodic {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        period: Option<CentiSeconds>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        anchor_time: Option<DateTime<Utc>>,
+    },
+
+    #[serde(rename = "ietf-yang-push:on-change")]
+    #[serde(rename_all = "kebab-case")]
+    OnChange {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dampening_period: Option<CentiSeconds>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sync_on_start: Option<bool>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        excluded_change: Option<Vec<ChangeType>>,
+    },
+}
+
+// DatastoreTarget XML serialization
+impl XmlSerialize for DatastoreTarget {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        if writer.get_namespace_prefix(YANG_PUSH_NS).is_none() {
+            ns_added = true;
+            writer.push_namespace_binding(IndexMap::from([(YANG_PUSH_NS, "".to_string())]))?;
+        }
+        let (ns, name): (Box<str>, Box<str>) = self.datastore.name().clone().into();
+        let mut elem = writer.create_ns_element(YANG_PUSH_NS, "datastore")?;
+        elem.push_attribute(("xmlns:ds", ns.as_ref()));
+        writer.write_event(Event::Start(elem.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(&format!("ds:{name}"))))?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        self.selection.xml_serialize(writer)?;
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, DatastoreTarget> for DatastoreTarget {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        let datastore = parse_datastore_identity_ref(parser)?;
+        parser.skip_text()?;
+        let selection = DatastoreSelectionFilterObjects::xml_deserialize(parser)?;
+        Ok(Self {
+            datastore,
+            selection,
+        })
+    }
+}
+
+// StreamTarget XML serialization
+impl XmlSerialize for StreamTarget {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        if writer
+            .get_namespace_prefix(SUBSCRIBED_NOTIFICATIONS_NS)
+            .is_none()
+        {
+            ns_added = true;
+            writer.push_namespace_binding(IndexMap::from([(
+                SUBSCRIBED_NOTIFICATIONS_NS,
+                "".to_string(),
+            )]))?;
+        }
+
+        // <stream>
+        let stream_elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "stream")?;
+        writer.write_event(Event::Start(stream_elem.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(self.stream.as_ref())))?;
+        writer.write_event(Event::End(stream_elem.to_end()))?;
+
+        // stream-filter (optional — ByReference or inline)
+        self.filter.xml_serialize(writer)?;
+
+        // <replay-start-time> (optional)
+        if let Some(ref ts) = self.replay_start_time {
+            let elem =
+                writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "replay-start-time")?;
+            writer.write_event(Event::Start(elem.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(&format_datetime(ts))))?;
+            writer.write_event(Event::End(elem.to_end()))?;
+        }
+
+        // <configured-replay/> (optional empty element)
+        if self.configured_reply {
+            let elem =
+                writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "configured-replay")?;
+            writer.write_event(Event::Empty(elem))?;
+        }
+
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, StreamTarget> for StreamTarget {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+
+        // Elements can appear in any order per XML/YANG conventions.
+        let mut stream: Option<Box<str>> = None;
+        let mut filter: Option<StreamSelectionFilterObjects> = None;
+        let mut replay_start_time: Option<DateTime<Utc>> = None;
+        let mut configured_reply = false;
+
+        // We need to parse sibling elements. The caller already opened the
+        // parent container (e.g. <subscription>), so we read children until
+        // we've collected the stream target fields (or hit something we
+        // don't recognise which signals the end of our scope).
+        loop {
+            parser.skip_text()?;
+            if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream")?;
+                stream = Some(parser.tag_string()?.trim().into());
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-filter-name")
+                || parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-subtree-filter")
+                || parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-xpath-filter")
+            {
+                filter = Some(StreamSelectionFilterObjects::xml_deserialize(parser)?);
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "replay-start-time") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "replay-start-time")?;
+                let ts_str = parser.tag_string()?;
+                replay_start_time = Some(
+                    DateTime::parse_from_rfc3339(ts_str.trim())
+                        .map_err(|e| ParsingError::InvalidValue(e.to_string()))?
+                        .with_timezone(&Utc),
+                );
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "configured-replay") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "configured-replay")?;
+                configured_reply = true;
+                parser.close()?;
+            } else {
+                break;
+            }
+        }
+
+        let stream = stream.ok_or_else(|| ParsingError::WrongToken {
+            expecting: "<stream>".to_string(),
+            found: parser.peek().clone().into_owned(),
+        })?;
+
+        Ok(Self {
+            stream,
+            filter: filter.unwrap_or(StreamSelectionFilterObjects::ByReference("".into())),
+            replay_start_time,
+            configured_reply,
+        })
+    }
+}
+
+impl XmlSerialize for UpdateTrigger {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        if writer.get_namespace_prefix(YANG_PUSH_NS).is_none() {
+            ns_added = true;
+            writer.push_namespace_binding(IndexMap::from([(YANG_PUSH_NS, "".to_string())]))?;
+        }
+        match self {
+            Self::Periodic {
+                period,
+                anchor_time,
+            } => {
+                let elem = writer.create_ns_element(YANG_PUSH_NS, "periodic")?;
+                writer.write_event(Event::Start(elem.clone()))?;
+                if let Some(p) = period {
+                    let child = writer.create_ns_element(YANG_PUSH_NS, "period")?;
+                    writer.write_event(Event::Start(child.clone()))?;
+                    writer.write_event(Event::Text(BytesText::new(&p.as_u32().to_string())))?;
+                    writer.write_event(Event::End(child.to_end()))?;
+                }
+                if let Some(ts) = anchor_time {
+                    let child = writer.create_ns_element(YANG_PUSH_NS, "anchor-time")?;
+                    writer.write_event(Event::Start(child.clone()))?;
+                    writer.write_event(Event::Text(BytesText::new(&format_datetime(ts))))?;
+                    writer.write_event(Event::End(child.to_end()))?;
+                }
+                writer.write_event(Event::End(elem.to_end()))?;
+            }
+            Self::OnChange {
+                dampening_period,
+                sync_on_start,
+                excluded_change,
+            } => {
+                let elem = writer.create_ns_element(YANG_PUSH_NS, "on-change")?;
+                writer.write_event(Event::Start(elem.clone()))?;
+                if let Some(dp) = dampening_period {
+                    let child = writer.create_ns_element(YANG_PUSH_NS, "dampening-period")?;
+                    writer.write_event(Event::Start(child.clone()))?;
+                    writer.write_event(Event::Text(BytesText::new(&dp.as_u32().to_string())))?;
+                    writer.write_event(Event::End(child.to_end()))?;
+                }
+                if let Some(sync) = sync_on_start {
+                    let child = writer.create_ns_element(YANG_PUSH_NS, "sync-on-start")?;
+                    writer.write_event(Event::Start(child.clone()))?;
+                    writer.write_event(Event::Text(BytesText::new(if *sync {
+                        "true"
+                    } else {
+                        "false"
+                    })))?;
+                    writer.write_event(Event::End(child.to_end()))?;
+                }
+                if let Some(changes) = excluded_change {
+                    for change in changes {
+                        let child = writer.create_ns_element(YANG_PUSH_NS, "excluded-change")?;
+                        writer.write_event(Event::Start(child.clone()))?;
+                        let val = match change {
+                            ChangeType::Create => "create",
+                            ChangeType::Delete => "delete",
+                            ChangeType::Insert => "insert",
+                            ChangeType::Move => "move",
+                            ChangeType::Replace => "replace",
+                        };
+                        writer.write_event(Event::Text(BytesText::new(val)))?;
+                        writer.write_event(Event::End(child.to_end()))?;
+                    }
+                }
+                writer.write_event(Event::End(elem.to_end()))?;
+            }
+        }
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, UpdateTrigger> for UpdateTrigger {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        if parser.is_tag(Some(YANG_PUSH_NS), "periodic") {
+            parser.open(Some(YANG_PUSH_NS), "periodic")?;
+            let mut period = None;
+            let mut anchor_time = None;
+            loop {
+                parser.skip_text()?;
+                if parser.is_tag(Some(YANG_PUSH_NS), "period") {
+                    parser.open(Some(YANG_PUSH_NS), "period")?;
+                    let v: u32 = parser.tag_string()?.trim().parse().map_err(
+                        |e: std::num::ParseIntError| ParsingError::InvalidValue(e.to_string()),
+                    )?;
+                    period = Some(CentiSeconds::new(v));
+                    parser.close()?;
+                } else if parser.is_tag(Some(YANG_PUSH_NS), "anchor-time") {
+                    parser.open(Some(YANG_PUSH_NS), "anchor-time")?;
+                    anchor_time = Some(parse_datetime(&parser.tag_string()?)?);
+                    parser.close()?;
+                } else {
+                    // Unknown child or end of container — stop
+                    break;
+                }
+            }
+            parser.close()?;
+            Ok(Self::Periodic {
+                period,
+                anchor_time,
+            })
+        } else if parser.is_tag(Some(YANG_PUSH_NS), "on-change") {
+            parser.open(Some(YANG_PUSH_NS), "on-change")?;
+            let mut dampening_period = None;
+            let mut sync_on_start = None;
+            let mut excluded_change: Option<Vec<ChangeType>> = None;
+            loop {
+                parser.skip_text()?;
+                if parser.is_tag(Some(YANG_PUSH_NS), "dampening-period") {
+                    parser.open(Some(YANG_PUSH_NS), "dampening-period")?;
+                    let v: u32 = parser.tag_string()?.trim().parse().map_err(
+                        |e: std::num::ParseIntError| ParsingError::InvalidValue(e.to_string()),
+                    )?;
+                    dampening_period = Some(CentiSeconds::new(v));
+                    parser.close()?;
+                } else if parser.is_tag(Some(YANG_PUSH_NS), "sync-on-start") {
+                    parser.open(Some(YANG_PUSH_NS), "sync-on-start")?;
+                    let val = parser.tag_string()?;
+                    sync_on_start = Some(val.trim() == "true");
+                    parser.close()?;
+                } else if parser.is_tag(Some(YANG_PUSH_NS), "excluded-change") {
+                    parser.open(Some(YANG_PUSH_NS), "excluded-change")?;
+                    let val = parser.tag_string()?;
+                    let change = match val.trim() {
+                        "create" => ChangeType::Create,
+                        "delete" => ChangeType::Delete,
+                        "insert" => ChangeType::Insert,
+                        "move" => ChangeType::Move,
+                        "replace" => ChangeType::Replace,
+                        other => {
+                            return Err(ParsingError::InvalidValue(other.to_string()));
+                        }
+                    };
+                    excluded_change.get_or_insert_with(Vec::new).push(change);
+                    parser.close()?;
+                } else {
+                    break;
+                }
+            }
+            parser.close()?;
+            Ok(Self::OnChange {
+                dampening_period,
+                sync_on_start,
+                excluded_change,
+            })
+        } else {
+            Err(ParsingError::WrongToken {
+                expecting: "<periodic> or <on-change>".to_string(),
+                found: parser.peek().clone().into_owned(),
+            })
+        }
+    }
+}
+
+impl XmlSerialize for Subscription {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        if writer
+            .get_namespace_prefix(SUBSCRIBED_NOTIFICATIONS_NS)
+            .is_none()
+        {
+            ns_added = true;
+            writer.push_namespace_binding(IndexMap::from([(
+                SUBSCRIBED_NOTIFICATIONS_NS,
+                "".to_string(),
+            )]))?;
+        }
+        let elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "subscription")?;
+        writer.write_event(Event::Start(elem.clone()))?;
+
+        // <id> (mandatory)
+        let id_elem = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "id")?;
+        writer.write_event(Event::Start(id_elem.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(&self.id.to_string())))?;
+        writer.write_event(Event::End(id_elem.to_end()))?;
+
+        // target (choice: stream / datastore) — flat children
+        match &self.target {
+            Target::Stream(stream_target) => stream_target.xml_serialize(writer)?,
+            Target::Datastore(ds_target) => ds_target.xml_serialize(writer)?,
+        }
+
+        // <stop-time>
+        if let Some(ref ts) = self.stop_time {
+            let child = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "stop-time")?;
+            writer.write_event(Event::Start(child.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(&format_datetime(ts))))?;
+            writer.write_event(Event::End(child.to_end()))?;
+        }
+
+        // <dscp>
+        if let Some(dscp) = self.dscp {
+            let child = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "dscp")?;
+            writer.write_event(Event::Start(child.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(&dscp.to_string())))?;
+            writer.write_event(Event::End(child.to_end()))?;
+        }
+
+        // <weighting>
+        if let Some(w) = self.weighting {
+            let child = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "weighting")?;
+            writer.write_event(Event::Start(child.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(&w.to_string())))?;
+            writer.write_event(Event::End(child.to_end()))?;
+        }
+
+        // <dependency>
+        if let Some(dep) = self.dependency {
+            let child = writer.create_ns_element(SUBSCRIBED_NOTIFICATIONS_NS, "dependency")?;
+            writer.write_event(Event::Start(child.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(&dep.to_string())))?;
+            writer.write_event(Event::End(child.to_end()))?;
+        }
+
+        // <transport>
+        if let Some(ref t) = self.transport {
+            t.xml_serialize(writer)?;
+        }
+
+        // <encoding>
+        if let Some(ref enc) = self.encoding {
+            enc.xml_serialize(writer)?;
+        }
+
+        // <purpose>
+        xml_write_optional_text_leaf(
+            writer,
+            SUBSCRIBED_NOTIFICATIONS_NS,
+            "purpose",
+            self.purpose.as_deref(),
+        )?;
+
+        // <configured-subscription-state> (read-only)
+        if let Some(ref state) = self.configured_subscription_state {
+            state.xml_serialize(writer)?;
+        }
+
+        // <message-publisher-id> (from ietf-distributed-notif, different NS)
+        if let Some(mpid) = self.message_publisher_id {
+            let mut dn_ns_added = false;
+            if writer.get_namespace_prefix(DISTRIBUTED_NOTIF_NS).is_none() {
+                dn_ns_added = true;
+                writer.push_namespace_binding(IndexMap::from([(
+                    DISTRIBUTED_NOTIF_NS,
+                    "dn".to_string(),
+                )]))?;
+            }
+            let child = writer.create_ns_element(DISTRIBUTED_NOTIF_NS, "message-publisher-id")?;
+            writer.write_event(Event::Start(child.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(&mpid.to_string())))?;
+            writer.write_event(Event::End(child.to_end()))?;
+            if dn_ns_added {
+                writer.pop_namespace_binding();
+            }
+        }
+
+        // update-trigger (choice: periodic / on-change)
+        if let Some(ref trigger) = self.update_trigger {
+            trigger.xml_serialize(writer)?;
+        }
+
+        writer.write_event(Event::End(elem.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, Subscription> for Subscription {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "subscription")?;
+
+        let mut id: Option<SubscriptionId> = None;
+        let mut stop_time = None;
+        let mut dscp = None;
+        let mut weighting = None;
+        let mut dependency = None;
+        let mut transport = None;
+        let mut encoding = None;
+        let mut purpose = None;
+        let mut configured_subscription_state = None;
+        let mut message_publisher_id = None;
+        let mut update_trigger = None;
+
+        // Target pieces — collected separately because XML elements can
+        // appear in any order and the target choice children are interleaved
+        // with other subscription leaves.
+        // Stream target pieces:
+        let mut stream_name: Option<Box<str>> = None;
+        let mut stream_filter: Option<StreamSelectionFilterObjects> = None;
+        let mut replay_start_time: Option<DateTime<Utc>> = None;
+        let mut configured_replay = false;
+        // Datastore target pieces:
+        let mut ds_datastore: Option<Datastore> = None;
+        let mut ds_selection: Option<DatastoreSelectionFilterObjects> = None;
+
+        loop {
+            parser.skip_text()?;
+
+            // Check for closing </subscription>
+            if matches!(parser.peek(), Event::End(_)) {
+                break;
+            }
+            if matches!(parser.peek(), Event::Eof) {
+                return Err(ParsingError::Eof);
+            }
+
+            // ── ietf-subscribed-notifications elements ──────────────────
+            if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "id") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "id")?;
+                id = Some(parser.tag_string()?.trim().parse().map_err(
+                    |e: std::num::ParseIntError| ParsingError::InvalidValue(e.to_string()),
+                )?);
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stop-time") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stop-time")?;
+                stop_time = Some(parse_datetime(&parser.tag_string()?)?);
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "dscp") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "dscp")?;
+                dscp = Some(parser.tag_string()?.trim().parse().map_err(
+                    |e: std::num::ParseIntError| ParsingError::InvalidValue(e.to_string()),
+                )?);
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "weighting") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "weighting")?;
+                weighting = Some(parser.tag_string()?.trim().parse().map_err(
+                    |e: std::num::ParseIntError| ParsingError::InvalidValue(e.to_string()),
+                )?);
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "dependency") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "dependency")?;
+                dependency = Some(parser.tag_string()?.trim().parse().map_err(
+                    |e: std::num::ParseIntError| ParsingError::InvalidValue(e.to_string()),
+                )?);
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "transport") {
+                transport = Some(Transport::xml_deserialize(parser)?);
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "encoding") {
+                encoding = Some(Encoding::xml_deserialize(parser)?);
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "purpose") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "purpose")?;
+                purpose = Some(parser.tag_string()?.trim().into());
+                parser.close()?;
+            } else if parser.is_tag(
+                Some(SUBSCRIBED_NOTIFICATIONS_NS),
+                "configured-subscription-state",
+            ) {
+                configured_subscription_state =
+                    Some(ConfiguredSubscriptionState::xml_deserialize(parser)?);
+            }
+            // ── Stream target children ──────────────────────────────────
+            else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream")?;
+                stream_name = Some(parser.tag_string()?.trim().into());
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-filter-name") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-filter-name")?;
+                stream_filter = Some(StreamSelectionFilterObjects::ByReference(
+                    parser.tag_string()?,
+                ));
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-subtree-filter")
+                || parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "stream-xpath-filter")
+            {
+                stream_filter = Some(StreamSelectionFilterObjects::WithInSubscription(
+                    StreamFilterSpec::xml_deserialize(parser)?,
+                ));
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "replay-start-time") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "replay-start-time")?;
+                replay_start_time = Some(parse_datetime(&parser.tag_string()?)?);
+                parser.close()?;
+            } else if parser.is_tag(Some(SUBSCRIBED_NOTIFICATIONS_NS), "configured-replay") {
+                parser.open(Some(SUBSCRIBED_NOTIFICATIONS_NS), "configured-replay")?;
+                configured_replay = true;
+                parser.close()?;
+            }
+            // ── Datastore target children ───────────────────────────────
+            else if parser.is_tag(Some(YANG_PUSH_NS), "datastore") {
+                ds_datastore = Some(parse_datastore_identity_ref(parser)?);
+            } else if parser.is_tag(Some(YANG_PUSH_NS), "selection-filter-ref") {
+                parser.open(Some(YANG_PUSH_NS), "selection-filter-ref")?;
+                ds_selection = Some(DatastoreSelectionFilterObjects::ByReference(
+                    parser.tag_string()?,
+                ));
+                parser.close()?;
+            } else if parser.is_tag(Some(YANG_PUSH_NS), "datastore-subtree-filter")
+                || parser.is_tag(Some(YANG_PUSH_NS), "datastore-xpath-filter")
+            {
+                ds_selection = Some(DatastoreSelectionFilterObjects::WithInSubscription(
+                    DatastoreFilterSpec::xml_deserialize(parser)?,
+                ));
+            }
+            // ── yang-push update trigger ────────────────────────────────
+            else if parser.is_tag(Some(YANG_PUSH_NS), "periodic")
+                || parser.is_tag(Some(YANG_PUSH_NS), "on-change")
+            {
+                update_trigger = Some(UpdateTrigger::xml_deserialize(parser)?);
+            }
+            // ── ietf-distributed-notif augmentation ─────────────────────
+            else if parser.is_tag(Some(DISTRIBUTED_NOTIF_NS), "message-publisher-id") {
+                parser.open(Some(DISTRIBUTED_NOTIF_NS), "message-publisher-id")?;
+                message_publisher_id = Some(parser.tag_string()?.trim().parse().map_err(
+                    |e: std::num::ParseIntError| ParsingError::InvalidValue(e.to_string()),
+                )?);
+                parser.close()?;
+            }
+            // ── Unknown / augmented element — skip gracefully ───────────
+            else {
+                parser.skip()?;
+            }
+        }
+
+        parser.close()?; // </subscription>
+
+        let id = id.ok_or_else(|| ParsingError::WrongToken {
+            expecting: "<id>".to_string(),
+            found: Event::Eof.into_owned(),
+        })?;
+
+        // Assemble the target from collected pieces.
+        // Determine which target type based on which pieces were collected.
+        let target = if let Some(ds) = ds_datastore {
+            // Datastore target — <datastore> was present
+            Target::Datastore(DatastoreTarget {
+                datastore: ds,
+                selection: ds_selection
+                    .unwrap_or(DatastoreSelectionFilterObjects::ByReference("".into())),
+            })
+        } else if ds_selection.is_some() {
+            // Datastore filter was found but no <datastore> — malformed, but
+            // best-effort: treat as datastore with unknown store.
+            return Err(ParsingError::WrongToken {
+                expecting: "<datastore> (required for datastore target)".to_string(),
+                found: Event::Eof.into_owned(),
+            });
+        } else if let Some(stream) = stream_name {
+            Target::Stream(StreamTarget {
+                stream,
+                filter: stream_filter
+                    .unwrap_or(StreamSelectionFilterObjects::ByReference("".into())),
+                replay_start_time,
+                configured_reply: configured_replay,
+            })
+        } else {
+            return Err(ParsingError::WrongToken {
+                expecting: "<stream> or <datastore> (target choice)".to_string(),
+                found: Event::Eof.into_owned(),
+            });
+        };
+
+        Ok(Self {
+            id,
+            target,
+            stop_time,
+            dscp,
+            weighting,
+            dependency,
+            transport,
+            encoding,
+            purpose,
+            configured_subscription_state,
+            message_publisher_id,
+            update_trigger,
+        })
+    }
+}
+
+/// Selection filter objects for datastore subscriptions (RFC 8641).
+///
+/// Filters can be specified by reference to a pre-configured filter,
+/// or inline within the subscription.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum DatastoreSelectionFilterObjects {
+    /// Reference to a pre-configured filter
+    ByReference(Box<str>),
+
+    /// Filter specified within the subscription
+    WithInSubscription(DatastoreFilterSpec),
+}
+
+// DatastoreSelectionFilterObjects XML serialization
+impl XmlSerialize for DatastoreSelectionFilterObjects {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        match self {
+            Self::ByReference(filter_name) => {
+                let mut ns_added = false;
+                if writer.get_namespace_prefix(YANG_PUSH_NS).is_none() {
+                    ns_added = true;
+                    writer
+                        .push_namespace_binding(IndexMap::from([(YANG_PUSH_NS, "".to_string())]))?;
+                }
+                let elem = writer.create_ns_element(YANG_PUSH_NS, "selection-filter-ref")?;
+                writer.write_event(Event::Start(elem.clone()))?;
+                writer.write_event(Event::Text(BytesText::new(filter_name.as_ref())))?;
+                writer.write_event(Event::End(elem.to_end()))?;
+                if ns_added {
+                    writer.pop_namespace_binding();
+                }
+            }
+            Self::WithInSubscription(filter_spec) => {
+                filter_spec.xml_serialize(writer)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> XmlDeserialize<'a, DatastoreSelectionFilterObjects> for DatastoreSelectionFilterObjects {
+    fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+
+        if parser.is_tag(Some(YANG_PUSH_NS), "selection-filter-ref") {
+            parser.open(Some(YANG_PUSH_NS), "selection-filter-ref")?;
+            let filter_name = parser.tag_string()?;
+            parser.close()?;
+            Ok(Self::ByReference(filter_name))
+        } else {
+            Ok(Self::WithInSubscription(
+                DatastoreFilterSpec::xml_deserialize(parser)?,
+            ))
+        }
+    }
+}
+
+/// Helper: deserialize a `<datastore>` identityref leaf under `YANG_PUSH_NS`.
+fn parse_datastore_identity_ref(
+    parser: &mut XmlParser<'_, impl io::BufRead>,
+) -> Result<Datastore, ParsingError> {
+    parser.open(Some(YANG_PUSH_NS), "datastore")?;
+    let raw: Box<str> = parser.tag_string()?.trim().into();
+    let (ns_uri, local_name) = parser.resolve_identity_ref(&raw)?;
+    let name = DatastoreName::from((ns_uri.as_str(), local_name.as_str()));
+    parser.close()?;
+    Ok(Datastore::new(name, ns_uri.into()))
+}

--- a/crates/netconf-proto/src/yang_push/tests.rs
+++ b/crates/netconf-proto/src/yang_push/tests.rs
@@ -1,0 +1,688 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Unit tests for the `yang_push` module.
+//!
+//! Covers XML round-trip serialization, serde JSON serialization, and
+//! element-reordering robustness for filters, identities, targets, and
+//! the top-level [`Subscription`].
+
+use super::*;
+use crate::tests::test_xml_value;
+use crate::xml_utils::{ParsingError, XmlDeserialize, XmlParser, XmlSerialize, XmlWriter};
+use crate::yang_push::filters::*;
+use crate::yang_push::identities::*;
+use crate::yang_push::subscription::*;
+use crate::yang_push::types::*;
+use crate::yanglib::{Datastore, DatastoreName};
+use chrono::{DateTime, Utc};
+use indexmap::IndexMap;
+use quick_xml::events::Event;
+
+#[test]
+fn test_transport_serialization() {
+    assert_eq!(
+        serde_json::to_string(&Transport::UDPNotif).unwrap(),
+        r#""ietf-udp-notif-transport:udp-notif""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Transport::HTTPSNotif).unwrap(),
+        r#""ietf-https-notif:https""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Transport::Unknown).unwrap(),
+        r#""unknown""#
+    );
+}
+
+#[test]
+fn test_transport_deserialization() {
+    assert_eq!(
+        serde_json::from_str::<Transport>(r#""ietf-udp-notif-transport:udp-notif""#).unwrap(),
+        Transport::UDPNotif
+    );
+    assert_eq!(
+        serde_json::from_str::<Transport>(r#""ietf-https-notif:https""#).unwrap(),
+        Transport::HTTPSNotif
+    );
+    assert_eq!(
+        serde_json::from_str::<Transport>(r#""unknown""#).unwrap(),
+        Transport::Unknown
+    );
+
+    // Test deserialization of unknown/empty values
+    assert_eq!(
+        serde_json::from_str::<Transport>(r#""unsupported-value""#).unwrap(),
+        Transport::Unknown
+    );
+    assert_eq!(
+        serde_json::from_str::<Transport>(r#""""#).unwrap(),
+        Transport::Unknown
+    );
+}
+
+#[test]
+fn test_encoding_serialization() {
+    assert_eq!(
+        serde_json::to_string(&Encoding::Xml).unwrap(),
+        r#""ietf-subscribed-notifications:encode-xml""#
+    );
+
+    assert_eq!(
+        serde_json::to_string(&Encoding::Json).unwrap(),
+        r#""ietf-subscribed-notifications:encode-json""#
+    );
+
+    assert_eq!(
+        serde_json::to_string(&Encoding::Cbor).unwrap(),
+        r#""ietf-udp-notif-transport:encode-cbor""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Encoding::Unknown).unwrap(),
+        r#""unknown""#
+    );
+}
+
+#[test]
+fn test_encoding_deserialization() {
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""ietf-subscribed-notifications:encode-xml""#).unwrap(),
+        Encoding::Xml
+    );
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""encode-xml""#).unwrap(),
+        Encoding::Xml
+    );
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""ietf-subscribed-notifications:encode-json""#).unwrap(),
+        Encoding::Json
+    );
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""encode-json""#).unwrap(),
+        Encoding::Json
+    );
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""ietf-udp-notif-transport:encode-cbor""#).unwrap(),
+        Encoding::Cbor
+    );
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""encode-cbor""#).unwrap(),
+        Encoding::Cbor
+    );
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""unknown""#).unwrap(),
+        Encoding::Unknown
+    );
+
+    // Test deserialization of unknown/empty values
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""unsupported-value""#).unwrap(),
+        Encoding::Unknown
+    );
+    assert_eq!(
+        serde_json::from_str::<Encoding>(r#""""#).unwrap(),
+        Encoding::Unknown
+    );
+}
+
+#[test]
+fn test_datastore_filter_spec() {
+    let namespaces = IndexMap::from([("example".to_string(), "urn:vendor:example".to_string())]);
+    let input_xpath = r#"<datastore-xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push" xmlns:example="urn:vendor:example">/example:example/debug:board-resouce-states</datastore-xpath-filter>"#;
+    let input_subtree = r#"<datastore-subtree-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"  xmlns:example="urn:vendor:example">
+        <example:debug/>
+        </datastore-subtree-filter>"#;
+
+    let expected_xpath = DatastoreFilterSpec::Xpath(DatastoreXPathFilter {
+        namespaces: namespaces.clone(),
+        path: "/example:example/debug:board-resouce-states".into(),
+    });
+    let expected_subtree = DatastoreFilterSpec::Subtree(DatastoreSubtreeFilter {
+        namespaces: namespaces.clone(),
+        subtree: "<example:debug/>".into(),
+    });
+    test_xml_value(input_xpath, expected_xpath).expect("XPath filter serde failed");
+    test_xml_value(input_subtree, expected_subtree).expect("Subtree filter serde failed");
+}
+
+#[test]
+fn test_selection_filter() {
+    let input_xpath = r#"<selection-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+        <filter-id>STATSBOARDRESOURCE</filter-id>
+        <datastore-xpath-filter  xmlns:debug="urn:example:yang:debug">/debug:debug/debug:board-resouce-states/debug:board-resouce-state</datastore-xpath-filter>
+        </selection-filter>"#;
+    let input_xpath_reordered = r#"<selection-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+        <datastore-xpath-filter  xmlns:debug="urn:example:yang:debug">/debug:debug/debug:board-resouce-states/debug:board-resouce-state</datastore-xpath-filter>
+        <filter-id>STATSBOARDRESOURCE</filter-id>
+        </selection-filter>"#;
+
+    let input_subtree = r#"<selection-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+        <filter-id>STATSCPU</filter-id>
+        <datastore-subtree-filter  xmlns:debug="urn:example:yang:debug">
+        <debug:cpu-utilization xmlns:debug="urn:example:yang:debug"/>
+        </datastore-subtree-filter>
+        </selection-filter>"#;
+    let input_subtree_reordered = r#"<selection-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+        <datastore-subtree-filter  xmlns:debug="urn:example:yang:debug">
+            <debug:cpu-utilization xmlns:debug="urn:example:yang:debug"/>
+        </datastore-subtree-filter>
+        <filter-id>STATSCPU</filter-id>
+        </selection-filter>"#;
+
+    let expected_xpath = SelectionFilter {
+        filter_id: "STATSBOARDRESOURCE".into(),
+        filter_spec: DatastoreFilterSpec::Xpath(DatastoreXPathFilter {
+            namespaces: IndexMap::from([(
+                "debug".to_string(),
+                "urn:example:yang:debug".to_string(),
+            )]),
+            path: "/debug:debug/debug:board-resouce-states/debug:board-resouce-state".into(),
+        }),
+    };
+
+    let expected_subtree = SelectionFilter {
+        filter_id: "STATSCPU".into(),
+        filter_spec: DatastoreFilterSpec::Subtree(DatastoreSubtreeFilter {
+            namespaces: IndexMap::from([(
+                "debug".to_string(),
+                "urn:example:yang:debug".to_string(),
+            )]),
+            subtree: "<debug:cpu-utilization xmlns:debug=\"urn:example:yang:debug\"/>".into(),
+        }),
+    };
+
+    test_xml_value(input_xpath, expected_xpath.clone())
+        .expect("XPath selection filter serde failed");
+    test_xml_value(input_xpath_reordered, expected_xpath)
+        .expect("Reordered XPath selection filter serde failed");
+    test_xml_value(input_subtree, expected_subtree.clone())
+        .expect("Subtree selection filter serde failed");
+    test_xml_value(input_subtree_reordered, expected_subtree)
+        .expect("Reordered Subtree selection filter serde failed");
+}
+
+#[test]
+fn test_stream_filter_spec() {
+    let input_xpath = r#"<stream-xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications" xmlns:debug="urn:example:yang:debug">/debug:debug/debug:board-resouce-states/debug:board-resouce-state</stream-xpath-filter>"#;
+    let input_subtree = r#"<stream-subtree-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications"  xmlns:debug="urn:example:yang:debug">
+        <debug:board-resouce-state xmlns:debug="urn:example:yang:debug"/>
+        </stream-subtree-filter>"#;
+    let expected_xpath = StreamFilterSpec::Xpath(StreamXPathFilter {
+        namespaces: IndexMap::from([("debug".to_string(), "urn:example:yang:debug".to_string())]),
+        path: "/debug:debug/debug:board-resouce-states/debug:board-resouce-state".into(),
+    });
+    let expected_subtree = StreamFilterSpec::Subtree(StreamSubtreeFilter {
+        namespaces: IndexMap::from([("debug".to_string(), "urn:example:yang:debug".to_string())]),
+        subtree: "<debug:board-resouce-state xmlns:debug=\"urn:example:yang:debug\"/>".into(),
+    });
+    test_xml_value(input_xpath, expected_xpath).expect("XPath filter serde failed");
+    test_xml_value(input_subtree, expected_subtree).expect("Subtree filter serde failed");
+}
+
+#[test]
+fn test_filters() {
+    let input = r#"<filters xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+      <selection-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+        <filter-id>STATSBOARDRESOURCE</filter-id>
+        <datastore-xpath-filter xmlns:debug="urn:example:yang:debug">/debug:debug/debug:board-resouce-states/debug:board-resouce-state</datastore-xpath-filter>
+      </selection-filter>
+      <stream-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+        <name>high-priority-syslog</name>
+        <stream-xpath-filter xmlns:sl="urn:example:syslog">
+          /sl:syslog-message[sl:severity='critical' or sl:severity='error']
+        </stream-xpath-filter>
+      </stream-filter>
+    </filters>"#;
+
+    let selection_filters = vec![SelectionFilter {
+        filter_id: "STATSBOARDRESOURCE".into(),
+        filter_spec: DatastoreFilterSpec::Xpath(DatastoreXPathFilter {
+            namespaces: IndexMap::from([(
+                "debug".to_string(),
+                "urn:example:yang:debug".to_string(),
+            )]),
+            path: "/debug:debug/debug:board-resouce-states/debug:board-resouce-state".into(),
+        }),
+    }];
+
+    let stream_filters = vec![StreamFilter {
+        name: "high-priority-syslog".into(),
+        filter_spec: StreamFilterSpec::Xpath(StreamXPathFilter {
+            namespaces: IndexMap::from([("sl".to_string(), "urn:example:syslog".to_string())]),
+            path: "/sl:syslog-message[sl:severity='critical' or sl:severity='error']".into(),
+        }),
+    }];
+    let filters = Filters::new(stream_filters, selection_filters);
+    test_xml_value(input, filters).expect("filters serde failed");
+}
+
+// ── StreamTarget / DatastoreTarget ──────────────────────────────────
+//
+// These types serialize as flat sibling elements (no wrapping element
+// of their own), so we test them inside a dummy <subscription> wrapper
+// that mirrors the real YANG structure.
+
+/// Helper: parse a `T` that lives inside an already-opened container.
+fn parse_within_wrapper<'a, T: XmlDeserialize<'a, T> + std::fmt::Debug>(
+    xml: &str,
+    wrapper_ns: Namespace<'a>,
+    wrapper_tag: &str,
+) -> Result<T, ParsingError> {
+    let mut reader = quick_xml::NsReader::from_str(xml);
+    reader.config_mut().trim_text(false);
+    let mut parser = XmlParser::new(reader)?;
+    parser.open(Some(wrapper_ns), wrapper_tag)?;
+    parser.skip_text()?;
+    let value = T::xml_deserialize(&mut parser)?;
+    parser.skip_text()?;
+    parser.close()?; // close wrapper
+    Ok(value)
+}
+
+/// Helper: serialize `T` inside a dummy wrapper, then strip the wrapper
+/// and return just the inner XML.
+fn serialize_within_wrapper<T: XmlSerialize>(
+    value: &T,
+    wrapper_ns: Namespace<'_>,
+    wrapper_tag: &str,
+) -> String {
+    let writer = quick_xml::writer::Writer::new(std::io::Cursor::new(Vec::new()));
+    let mut xml_writer = XmlWriter::new(writer);
+    xml_writer
+        .push_namespace_binding(IndexMap::from([(wrapper_ns, "".to_string())]))
+        .unwrap();
+    let start = xml_writer
+        .create_ns_element(wrapper_ns, wrapper_tag)
+        .unwrap();
+    xml_writer.write_event(Event::Start(start.clone())).unwrap();
+    value.xml_serialize(&mut xml_writer).unwrap();
+    xml_writer.write_event(Event::End(start.to_end())).unwrap();
+    xml_writer.pop_namespace_binding();
+    String::from_utf8(xml_writer.into_inner().into_inner()).unwrap()
+}
+
+/// Round-trip helper for types that must live inside a wrapping element.
+fn roundtrip_within_wrapper<
+    'a,
+    T: XmlDeserialize<'a, T> + XmlSerialize + PartialEq + std::fmt::Debug + Clone,
+>(
+    input_xml: &str,
+    expected: T,
+    wrapper_ns: Namespace<'a>,
+    wrapper_tag: &str,
+) {
+    // 1. Parse from the test XML
+    let parsed: T =
+        parse_within_wrapper(input_xml, wrapper_ns, wrapper_tag).expect("deserialization failed");
+    assert_eq!(
+        parsed, expected,
+        "Deserialized value differs:\n  expected: {expected:#?}\n  parsed:   {parsed:#?}"
+    );
+
+    // 2. Serialize the expected value back out, then re-parse to confirm round-trip
+    let serialized = serialize_within_wrapper(&expected, wrapper_ns, wrapper_tag);
+    let reparsed: T = parse_within_wrapper(&serialized, wrapper_ns, wrapper_tag)
+        .expect("re-deserialization from serialized output failed");
+    assert_eq!(
+        reparsed, expected,
+        "Round-trip mismatch:\n  expected:   {expected:#?}\n  reparsed:   {reparsed:#?}\n  serialized: {serialized}"
+    );
+}
+
+// ── DatastoreTarget tests ───────────────────────────────────────────
+
+#[test]
+fn test_datastore_target_with_xpath_filter() {
+    let xml = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+            <datastore xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"
+                       xmlns:ds="urn:ietf:params:xml:ns:yang:ietf-datastores">ds:operational</datastore>
+            <datastore-xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"
+                                   xmlns:if="urn:example:interfaces">/if:interfaces/if:interface</datastore-xpath-filter>
+        </subscription>"#;
+
+    let expected = DatastoreTarget {
+        datastore: Datastore::new(
+            DatastoreName::Operational,
+            "urn:ietf:params:xml:ns:yang:ietf-datastores".into(),
+        ),
+        selection: DatastoreSelectionFilterObjects::WithInSubscription(DatastoreFilterSpec::Xpath(
+            DatastoreXPathFilter {
+                namespaces: IndexMap::from([(
+                    "if".to_string(),
+                    "urn:example:interfaces".to_string(),
+                )]),
+                path: "/if:interfaces/if:interface".into(),
+            },
+        )),
+    };
+
+    roundtrip_within_wrapper(xml, expected, SUBSCRIBED_NOTIFICATIONS_NS, "subscription");
+}
+
+#[test]
+fn test_datastore_target_with_subtree_filter() {
+    let xml = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+            <datastore xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"
+                       xmlns:ds="urn:ietf:params:xml:ns:yang:ietf-datastores">ds:running</datastore>
+            <datastore-subtree-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"
+                                     xmlns:if="urn:example:interfaces">
+                <if:interfaces/>
+            </datastore-subtree-filter>
+        </subscription>"#;
+
+    let expected = DatastoreTarget {
+        datastore: Datastore::new(
+            DatastoreName::Running,
+            "urn:ietf:params:xml:ns:yang:ietf-datastores".into(),
+        ),
+        selection: DatastoreSelectionFilterObjects::WithInSubscription(
+            DatastoreFilterSpec::Subtree(DatastoreSubtreeFilter {
+                namespaces: IndexMap::from([(
+                    "if".to_string(),
+                    "urn:example:interfaces".to_string(),
+                )]),
+                subtree: "<if:interfaces/>".into(),
+            }),
+        ),
+    };
+
+    roundtrip_within_wrapper(xml, expected, SUBSCRIBED_NOTIFICATIONS_NS, "subscription");
+}
+
+#[test]
+fn test_datastore_target_with_filter_ref() {
+    let xml = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+            <datastore xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"
+                       xmlns:ds="urn:ietf:params:xml:ns:yang:ietf-datastores">ds:operational</datastore>
+            <selection-filter-ref xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">my-cpu-filter</selection-filter-ref>
+        </subscription>"#;
+
+    let expected = DatastoreTarget {
+        datastore: Datastore::new(
+            DatastoreName::Operational,
+            "urn:ietf:params:xml:ns:yang:ietf-datastores".into(),
+        ),
+        selection: DatastoreSelectionFilterObjects::ByReference("my-cpu-filter".into()),
+    };
+
+    roundtrip_within_wrapper(xml, expected, SUBSCRIBED_NOTIFICATIONS_NS, "subscription");
+}
+
+// ── StreamTarget tests ──────────────────────────────────────────────
+
+#[test]
+fn test_stream_target_with_xpath_filter() {
+    let xml = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+            <stream>NETCONF</stream>
+            <stream-xpath-filter xmlns:if="urn:example:interfaces">/if:interfaces/if:interface</stream-xpath-filter>
+        </subscription>"#;
+
+    let expected = StreamTarget {
+        stream: "NETCONF".into(),
+        filter: StreamSelectionFilterObjects::WithInSubscription(StreamFilterSpec::Xpath(
+            StreamXPathFilter {
+                namespaces: IndexMap::from([(
+                    "if".to_string(),
+                    "urn:example:interfaces".to_string(),
+                )]),
+                path: "/if:interfaces/if:interface".into(),
+            },
+        )),
+        replay_start_time: None,
+        configured_reply: false,
+    };
+
+    roundtrip_within_wrapper(xml, expected, SUBSCRIBED_NOTIFICATIONS_NS, "subscription");
+}
+
+#[test]
+fn test_stream_target_with_filter_ref() {
+    let xml = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+            <stream>NETCONF</stream>
+            <stream-filter-name>high-priority-syslog</stream-filter-name>
+        </subscription>"#;
+
+    let expected = StreamTarget {
+        stream: "NETCONF".into(),
+        filter: StreamSelectionFilterObjects::ByReference("high-priority-syslog".into()),
+        replay_start_time: None,
+        configured_reply: false,
+    };
+
+    roundtrip_within_wrapper(xml, expected, SUBSCRIBED_NOTIFICATIONS_NS, "subscription");
+}
+
+#[test]
+fn test_stream_target_with_replay_and_configured_replay() {
+    let xml = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+            <stream>NETCONF</stream>
+            <stream-filter-name>my-filter</stream-filter-name>
+            <replay-start-time>2025-06-01T00:00:00Z</replay-start-time>
+            <configured-replay/>
+        </subscription>"#;
+
+    let expected = StreamTarget {
+        stream: "NETCONF".into(),
+        filter: StreamSelectionFilterObjects::ByReference("my-filter".into()),
+        replay_start_time: Some(
+            DateTime::parse_from_rfc3339("2025-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        ),
+        configured_reply: true,
+    };
+
+    roundtrip_within_wrapper(xml, expected, SUBSCRIBED_NOTIFICATIONS_NS, "subscription");
+}
+
+#[test]
+fn test_stream_target_elements_reordered() {
+    // YANG/XML allows children in any order. Here <stream> comes after
+    // the filter, which must still parse correctly.
+    let xml = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+            <stream-filter-name>my-filter</stream-filter-name>
+            <replay-start-time>2025-06-01T00:00:00Z</replay-start-time>
+            <stream>NETCONF</stream>
+        </subscription>"#;
+
+    let expected = StreamTarget {
+        stream: "NETCONF".into(),
+        filter: StreamSelectionFilterObjects::ByReference("my-filter".into()),
+        replay_start_time: Some(
+            DateTime::parse_from_rfc3339("2025-06-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        ),
+        configured_reply: false,
+    };
+
+    // Only test deserialization (serialization order is deterministic
+    // and may differ from input order).
+    let parsed: StreamTarget =
+        parse_within_wrapper(xml, SUBSCRIBED_NOTIFICATIONS_NS, "subscription")
+            .expect("reordered stream target deserialization failed");
+    assert_eq!(parsed, expected);
+}
+
+#[test]
+fn test_stream_target_with_subtree_filter() {
+    let xml = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+            <stream>NETCONF</stream>
+            <stream-subtree-filter xmlns:if="urn:example:interfaces">
+                <if:interfaces/>
+            </stream-subtree-filter>
+        </subscription>"#;
+
+    let expected = StreamTarget {
+        stream: "NETCONF".into(),
+        filter: StreamSelectionFilterObjects::WithInSubscription(StreamFilterSpec::Subtree(
+            StreamSubtreeFilter {
+                namespaces: IndexMap::from([(
+                    "if".to_string(),
+                    "urn:example:interfaces".to_string(),
+                )]),
+                subtree: "<if:interfaces/>".into(),
+            },
+        )),
+        replay_start_time: None,
+        configured_reply: false,
+    };
+
+    roundtrip_within_wrapper(xml, expected, SUBSCRIBED_NOTIFICATIONS_NS, "subscription");
+}
+
+#[test]
+fn test_subscription() {
+    // Subscription with inline xpath filter, elements in non-canonical
+    // order, plus vendor/unknown children (<receivers>, <source-interface>)
+    // that must be skipped gracefully.
+    let input_by_value = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+        <id>3</id>
+        <datastore-xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+            openconfig-platform:components/component/state
+        </datastore-xpath-filter>
+        <datastore xmlns:idx="urn:ietf:params:xml:ns:yang:ietf-datastores"
+                   xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">idx:operational
+        </datastore>
+        <periodic xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+            <anchor-time>2025-01-01T00:00:30+00:00</anchor-time>
+            <period>360000</period>
+        </periodic>
+        <receivers>
+            <receiver>
+                <name>DAISY</name>
+                <receiver-instance-ref xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">DAISY
+                </receiver-instance-ref>
+            </receiver>
+        </receivers>
+        <source-interface>MgmtEth0/RP0/CPU0/0</source-interface>
+        <encoding xmlns:sn="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">sn:encode-json</encoding>
+        <dscp>0</dscp>
+    </subscription>"#;
+
+    let expected_by_value = Subscription {
+        id: 3,
+        target: Target::Datastore(DatastoreTarget {
+            datastore: Datastore::new(
+                DatastoreName::Operational,
+                "urn:ietf:params:xml:ns:yang:ietf-datastores".into(),
+            ),
+            selection: DatastoreSelectionFilterObjects::WithInSubscription(
+                DatastoreFilterSpec::Xpath(DatastoreXPathFilter {
+                    namespaces: IndexMap::new(), /* no namespace prefixes declared for
+                                                  * "openconfig-platform" */
+                    path: "openconfig-platform:components/component/state".into(),
+                }),
+            ),
+        }),
+        stop_time: None,
+        dscp: Some(0),
+        weighting: None,
+        dependency: None,
+        transport: None,
+        encoding: Some(Encoding::Json),
+        purpose: None,
+        configured_subscription_state: None,
+        message_publisher_id: None,
+        update_trigger: Some(UpdateTrigger::Periodic {
+            period: Some(CentiSeconds::new(360000)),
+            anchor_time: Some(
+                DateTime::parse_from_rfc3339("2025-01-01T00:00:30+00:00")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+        }),
+    };
+
+    // Subscription with filter-by-reference, transport, encoding,
+    // configured-subscription-state, message-publisher-id, and
+    // unknown children (<source-interface>, <receivers>) to skip.
+    let input_by_reference = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+    <id>1</id>
+    <datastore xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"
+               xmlns:ds="urn:ietf:params:xml:ns:yang:ietf-datastores">ds:operational
+    </datastore>
+    <selection-filter-ref xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">STATSBOARDRESOURCE</selection-filter-ref>
+    <dscp>0</dscp>
+    <transport xmlns:unt="urn:ietf:params:xml:ns:yang:ietf-udp-notif-transport">unt:udp-notif</transport>
+    <encoding xmlns:sn="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">sn:encode-json</encoding>
+    <source-interface>GigabitEthernet0/0/0</source-interface>
+    <configured-subscription-state>valid</configured-subscription-state>
+    <receivers>
+        <receiver>
+            <name>DAISY</name>
+            <receiver-instance-ref xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">DAISY
+            </receiver-instance-ref>
+        </receiver>
+    </receivers>
+    <message-publisher-id xmlns="urn:ietf:params:xml:ns:yang:ietf-distributed-notif">16843789</message-publisher-id>
+    <periodic xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+        <period>6000</period>
+        <anchor-time>2025-01-01T00:00:30Z</anchor-time>
+    </periodic>
+</subscription>"#;
+
+    let expected_by_reference = Subscription {
+        id: 1,
+        target: Target::Datastore(DatastoreTarget {
+            datastore: Datastore::new(
+                DatastoreName::Operational,
+                "urn:ietf:params:xml:ns:yang:ietf-datastores".into(),
+            ),
+            selection: DatastoreSelectionFilterObjects::ByReference("STATSBOARDRESOURCE".into()),
+        }),
+        stop_time: None,
+        dscp: Some(0),
+        weighting: None,
+        dependency: None,
+        transport: Some(Transport::UDPNotif),
+        encoding: Some(Encoding::Json),
+        purpose: None,
+        configured_subscription_state: Some(ConfiguredSubscriptionState::Valid),
+        message_publisher_id: Some(16843789),
+        update_trigger: Some(UpdateTrigger::Periodic {
+            period: Some(CentiSeconds::new(6000)),
+            anchor_time: Some(
+                DateTime::parse_from_rfc3339("2025-01-01T00:00:30Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+        }),
+    };
+
+    // Parse-only test for input_by_value (contains unknown elements that
+    // prevent clean round-trip, but deserialization must succeed).
+    let parsed_by_value: Subscription = {
+        let mut reader = quick_xml::NsReader::from_str(input_by_value);
+        reader.config_mut().trim_text(false);
+        let mut parser = XmlParser::new(reader).unwrap();
+        Subscription::xml_deserialize(&mut parser).expect("input_by_value parse failed")
+    };
+    assert_eq!(parsed_by_value, expected_by_value);
+
+    // Parse-only test for input_by_reference (also has unknown elements).
+    let parsed_by_ref: Subscription = {
+        let mut reader = quick_xml::NsReader::from_str(input_by_reference);
+        reader.config_mut().trim_text(false);
+        let mut parser = XmlParser::new(reader).unwrap();
+        Subscription::xml_deserialize(&mut parser).expect("input_by_reference parse failed")
+    };
+    assert_eq!(parsed_by_ref, expected_by_reference);
+
+    // Round-trip the by_reference expected value (no unknown elements to
+    // lose, so full serialize → deserialize → compare works).
+    test_xml_value(input_by_reference, expected_by_reference)
+        .expect("subscription by-reference round-trip failed");
+}

--- a/crates/netconf-proto/src/yang_push/types.rs
+++ b/crates/netconf-proto/src/yang_push/types.rs
@@ -1,0 +1,43 @@
+// Copyright (C) 2026-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Primitive newtypes used across the YANG-Push subscription model.
+//!
+//! * [`CentiSeconds`] – a thin wrapper around `u32` representing time intervals
+//!   in 1/100-second units as defined by the `centiseconds` YANG typedef.
+//! * [`SubscriptionId`] – type alias for `u32` subscription identifiers
+//!   ([RFC 8639 §2.4.1](https://datatracker.ietf.org/doc/html/rfc8639#section-2.4.1)).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CentiSeconds(u32);
+
+impl CentiSeconds {
+    pub const fn new(value: u32) -> Self {
+        CentiSeconds(value)
+    }
+
+    pub const fn as_u32(&self) -> u32 {
+        self.0
+    }
+
+    pub const fn to_milliseconds(&self) -> u32 {
+        self.0 * 10
+    }
+}
+
+/// Subscription ID defined as uint32 in [RFC 8639](https://datatracker.ietf.org/doc/html/rfc8639)
+pub type SubscriptionId = u32;

--- a/crates/udp-notif-pkt/Cargo.toml
+++ b/crates/udp-notif-pkt/Cargo.toml
@@ -20,6 +20,7 @@ categories = ["network-programming", "parsing"]
 netgauze-locate = { workspace = true, optional = true }
 netgauze-parse-utils = { workspace = true, optional = true }
 netgauze-serde-macros = { workspace = true, optional = true }
+netgauze-netconf-proto = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 

--- a/crates/udp-notif-pkt/src/decoded.rs
+++ b/crates/udp-notif-pkt/src/decoded.rs
@@ -210,11 +210,13 @@ impl TryFrom<&UdpNotifPacket> for UdpNotifPacketDecoded {
 mod tests {
     use super::*;
     use crate::notification::{
-        Encoding, NotificationEnvelope, NotificationLegacy, NotificationVariant,
-        SubscriptionStartedModified, Target, UpdateTrigger, YangPushModuleVersion,
+        NotificationEnvelope, NotificationLegacy, NotificationVariant, SubscriptionStartedModified,
+        Target, YangPushModuleVersion,
     };
     use bytes::Bytes;
     use chrono::{DateTime, Utc};
+    use netgauze_netconf_proto::yang_push::identities::Encoding;
+    use netgauze_netconf_proto::yang_push::subscription::UpdateTrigger;
     use serde_json::json;
     use std::collections::HashMap;
 

--- a/crates/udp-notif-pkt/src/notification.rs
+++ b/crates/udp-notif-pkt/src/notification.rs
@@ -207,12 +207,12 @@
 //!   additional fields to ensure compatibility with YANG augmentations
 
 use chrono::{DateTime, Utc};
+use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
+use netgauze_netconf_proto::yang_push::subscription::UpdateTrigger;
+use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum_macros::Display;
-
-/// Subscription ID defined as uint32 in [RFC 8639](https://datatracker.ietf.org/doc/html/rfc8639)
-pub type SubscriptionId = u32;
 
 /// Yang-Push Notification Envelope
 /// [draft-ietf-netconf-notif-envelope](https://datatracker.ietf.org/doc/draft-ietf-netconf-notif-envelope)
@@ -742,100 +742,6 @@ impl std::fmt::Display for Target {
     }
 }
 
-/// Transport protocol used to deliver the notification message to the data
-/// collection.
-#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum Transport {
-    /// UDP-based notification transport
-    /// [ietf-udp-notif-transport](https://datatracker.ietf.org/doc/html/draft-ietf-netconf-udp-notif)
-    #[serde(rename = "ietf-udp-notif-transport:udp-notif")]
-    UDPNotif,
-
-    /// HTTPS-based notification transport
-    /// [draft-ietf-netconf-https-notif](https://datatracker.ietf.org/doc/html/draft-ietf-netconf-https-notif)
-    #[serde(rename = "ietf-https-notif:https")]
-    HTTPSNotif,
-
-    #[default]
-    #[serde(other)]
-    #[serde(rename = "unknown")]
-    Unknown,
-}
-
-/// Encoding used for the notification payload
-#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum Encoding {
-    #[serde(rename = "ietf-subscribed-notifications:encode-xml")]
-    #[serde(alias = "encode-xml")]
-    Xml,
-
-    #[serde(rename = "ietf-subscribed-notifications:encode-json")]
-    #[serde(alias = "encode-json")]
-    Json,
-
-    #[serde(rename = "ietf-udp-notif-transport:encode-cbor")]
-    #[serde(alias = "encode-cbor")]
-    Cbor,
-
-    #[default]
-    #[serde(other)]
-    #[serde(rename = "unknown")]
-    Unknown,
-}
-
-/// Update Trigger
-/// ```text
-/// UpdateTrigger
-/// ├── Periodic
-/// │   ├── period: CentiSeconds (update interval in 1/100 seconds)
-/// │   └── anchor-time: DateTime (optional reference time)
-/// │
-/// └── OnChange
-///     ├── dampening-period: CentiSeconds (minimum time between updates)
-///     ├── sync-on-start: bool (send initial snapshot)
-///     └── excluded-change: Vec<ChangeType> (filter change types)
-///         ├── Create
-///         ├── Delete
-///         ├── Insert
-///         ├── Move
-///         └── Replace
-/// ```
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum UpdateTrigger {
-    #[serde(rename = "ietf-yang-push:periodic")]
-    #[serde(rename_all = "kebab-case")]
-    Periodic {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        period: Option<CentiSeconds>,
-
-        #[serde(skip_serializing_if = "Option::is_none")]
-        anchor_time: Option<DateTime<Utc>>,
-    },
-
-    #[serde(rename = "ietf-yang-push:on-change")]
-    #[serde(rename_all = "kebab-case")]
-    OnChange {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        dampening_period: Option<CentiSeconds>,
-
-        #[serde(skip_serializing_if = "Option::is_none")]
-        sync_on_start: Option<bool>,
-
-        #[serde(skip_serializing_if = "Option::is_none")]
-        excluded_change: Option<Vec<ChangeType>>,
-    },
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum ChangeType {
-    Create,
-    Delete,
-    Insert,
-    Move,
-    Replace,
-}
-
 /// Module Versioning (draft-ietf-netconf-yang-notifications-versioning)
 ///
 /// The `YangPushModuleVersion` structure provides information about YANG
@@ -880,136 +786,14 @@ impl YangPushModuleVersion {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CentiSeconds(u32);
-
-impl CentiSeconds {
-    pub const fn new(value: u32) -> Self {
-        CentiSeconds(value)
-    }
-
-    pub const fn as_u32(&self) -> u32 {
-        self.0
-    }
-
-    pub const fn to_milliseconds(&self) -> u32 {
-        self.0 * 10
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
+
+    use netgauze_netconf_proto::yang_push::identities::ChangeType;
+    use netgauze_netconf_proto::yang_push::types::CentiSeconds;
     use serde_json;
-
-    #[test]
-    fn test_transport_serialization() {
-        assert_eq!(
-            serde_json::to_string(&Transport::UDPNotif).unwrap(),
-            r#""ietf-udp-notif-transport:udp-notif""#
-        );
-        assert_eq!(
-            serde_json::to_string(&Transport::HTTPSNotif).unwrap(),
-            r#""ietf-https-notif:https""#
-        );
-        assert_eq!(
-            serde_json::to_string(&Transport::Unknown).unwrap(),
-            r#""unknown""#
-        );
-    }
-
-    #[test]
-    fn test_transport_deserialization() {
-        assert_eq!(
-            serde_json::from_str::<Transport>(r#""ietf-udp-notif-transport:udp-notif""#).unwrap(),
-            Transport::UDPNotif
-        );
-        assert_eq!(
-            serde_json::from_str::<Transport>(r#""ietf-https-notif:https""#).unwrap(),
-            Transport::HTTPSNotif
-        );
-        assert_eq!(
-            serde_json::from_str::<Transport>(r#""unknown""#).unwrap(),
-            Transport::Unknown
-        );
-
-        // Test deserialization of unknown/empty values
-        assert_eq!(
-            serde_json::from_str::<Transport>(r#""unsupported-value""#).unwrap(),
-            Transport::Unknown
-        );
-        assert_eq!(
-            serde_json::from_str::<Transport>(r#""""#).unwrap(),
-            Transport::Unknown
-        );
-    }
-
-    #[test]
-    fn test_encoding_serialization() {
-        assert_eq!(
-            serde_json::to_string(&Encoding::Xml).unwrap(),
-            r#""ietf-subscribed-notifications:encode-xml""#
-        );
-
-        assert_eq!(
-            serde_json::to_string(&Encoding::Json).unwrap(),
-            r#""ietf-subscribed-notifications:encode-json""#
-        );
-
-        assert_eq!(
-            serde_json::to_string(&Encoding::Cbor).unwrap(),
-            r#""ietf-udp-notif-transport:encode-cbor""#
-        );
-        assert_eq!(
-            serde_json::to_string(&Encoding::Unknown).unwrap(),
-            r#""unknown""#
-        );
-    }
-
-    #[test]
-    fn test_encoding_deserialization() {
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""ietf-subscribed-notifications:encode-xml""#)
-                .unwrap(),
-            Encoding::Xml
-        );
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""encode-xml""#).unwrap(),
-            Encoding::Xml
-        );
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""ietf-subscribed-notifications:encode-json""#)
-                .unwrap(),
-            Encoding::Json
-        );
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""encode-json""#).unwrap(),
-            Encoding::Json
-        );
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""ietf-udp-notif-transport:encode-cbor""#).unwrap(),
-            Encoding::Cbor
-        );
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""encode-cbor""#).unwrap(),
-            Encoding::Cbor
-        );
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""unknown""#).unwrap(),
-            Encoding::Unknown
-        );
-
-        // Test deserialization of unknown/empty values
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""unsupported-value""#).unwrap(),
-            Encoding::Unknown
-        );
-        assert_eq!(
-            serde_json::from_str::<Encoding>(r#""""#).unwrap(),
-            Encoding::Unknown
-        );
-    }
 
     #[test]
     fn test_sub_started_modified_serde() {

--- a/crates/yang-push/src/cache/actor.rs
+++ b/crates/yang-push/src/cache/actor.rs
@@ -222,7 +222,7 @@ use crate::{
 };
 use futures_util::StreamExt;
 use futures_util::stream::FuturesUnordered;
-use netgauze_udp_notif_pkt::notification::SubscriptionId;
+use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use rustc_hash::FxHashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;

--- a/crates/yang-push/src/cache/storage.rs
+++ b/crates/yang-push/src/cache/storage.rs
@@ -94,8 +94,9 @@
 
 use crate::ContentId;
 use netgauze_netconf_proto::xml_utils::{XmlDeserialize, XmlSerialize, XmlWriter};
+use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_netconf_proto::yanglib::{SchemaLoadingError, YangLibrary};
-use netgauze_udp_notif_pkt::notification::{SubscriptionId, Target};
+use netgauze_udp_notif_pkt::notification::Target;
 use quick_xml::NsReader;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};

--- a/crates/yang-push/src/model/telemetry.rs
+++ b/crates/yang-push/src/model/telemetry.rs
@@ -41,13 +41,13 @@
 //!   key-value labels that can be used to enrich collected data with custom
 //!   information.
 use chrono::{DateTime, Utc};
+
+use netgauze_netconf_proto::yang_push::identities::{ChangeType, Encoding, Transport};
+use netgauze_netconf_proto::yang_push::types::{CentiSeconds, SubscriptionId};
+use netgauze_udp_notif_pkt::notification::YangPushModuleVersion;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::net::IpAddr;
-
-use netgauze_udp_notif_pkt::notification::{
-    CentiSeconds, ChangeType, Encoding, SubscriptionId, Transport, YangPushModuleVersion,
-};
 
 /// Telemetry Message Wrapper
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -443,17 +443,17 @@ pub enum UpdateTrigger {
     },
 }
 
-impl From<netgauze_udp_notif_pkt::notification::UpdateTrigger> for UpdateTrigger {
-    fn from(trigger: netgauze_udp_notif_pkt::notification::UpdateTrigger) -> Self {
+impl From<netgauze_netconf_proto::yang_push::subscription::UpdateTrigger> for UpdateTrigger {
+    fn from(trigger: netgauze_netconf_proto::yang_push::subscription::UpdateTrigger) -> Self {
         match trigger {
-            netgauze_udp_notif_pkt::notification::UpdateTrigger::Periodic {
+            netgauze_netconf_proto::yang_push::subscription::UpdateTrigger::Periodic {
                 period,
                 anchor_time,
             } => UpdateTrigger::Periodic {
                 period,
                 anchor_time,
             },
-            netgauze_udp_notif_pkt::notification::UpdateTrigger::OnChange {
+            netgauze_netconf_proto::yang_push::subscription::UpdateTrigger::OnChange {
                 dampening_period,
                 sync_on_start,
                 excluded_change,
@@ -565,7 +565,6 @@ where
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
-    use netgauze_udp_notif_pkt::notification::CentiSeconds;
     use serde_json;
     use std::str::FromStr;
     use std::vec;

--- a/crates/yang-push/src/validation/mod.rs
+++ b/crates/yang-push/src/validation/mod.rs
@@ -120,10 +120,9 @@ use crate::{
     OTL_YANG_PUSH_SUBSCRIPTION_ID_KEY, OTL_YANG_PUSH_SUBSCRIPTION_ROUTER_CONTENT_ID_KEY,
     OTL_YANG_PUSH_SUBSCRIPTION_TARGET_KEY,
 };
+use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_udp_notif_pkt::decoded::UdpNotifPacketDecoded;
-use netgauze_udp_notif_pkt::notification::{
-    NotificationVariant, SubscriptionId, SubscriptionStartedModified,
-};
+use netgauze_udp_notif_pkt::notification::{NotificationVariant, SubscriptionStartedModified};
 use netgauze_udp_notif_pkt::raw::UdpNotifPacket;
 use netgauze_udp_notif_service::OTL_UDP_NOTIF_PUBLISHER_ID_KEY;
 use rustc_hash::FxHashMap;


### PR DESCRIPTION
Add a new yang_push module to netconf-proto with XML serialization support, consolidating YANG-Push subscription types that were previously defined in udp-notif-pkt::notification.

New modules in netconf-proto::yang_push:
  - types: SubscriptionId, CentiSeconds
  - identities: Transport, Encoding, ConfiguredSubscriptionState, ChangeType
  - subscription: UpdateTrigger and subscription XML (de)serialization
  - filters: Filters, SelectionFilter, StreamFilter with XML round-tripping
  - tests: comprehensive XML serialization/deserialization tests

Removed duplicate type definitions from udp-notif-pkt and re-exported them from netconf-proto. Updated downstream consumers accordingly.