### PR TITLE
JSON schema support for BMP and BGP packet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,7 +2222,7 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
 ]
 
@@ -2737,7 +2737,7 @@ dependencies = [
  "nom 7.1.3",
  "pcap-parser",
  "rstest",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "strum_macros",
@@ -2969,7 +2969,7 @@ name = "netgauze-iana"
 version = "0.11.0"
 dependencies = [
  "arbitrary",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "strum_macros",
@@ -4825,18 +4825,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -4855,15 +4843,16 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,7 @@ dependencies = [
  "nom 7.1.3",
  "pcap-parser",
  "rstest",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "strum_macros",
@@ -4841,6 +4842,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,7 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
+ "schemars 0.8.22",
  "serde",
 ]
 
@@ -2736,6 +2737,7 @@ dependencies = [
  "nom 7.1.3",
  "pcap-parser",
  "rstest",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "strum_macros",
@@ -2967,6 +2969,7 @@ name = "netgauze-iana"
 version = "0.11.0"
 dependencies = [
  "arbitrary",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "strum_macros",
@@ -4822,6 +4825,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -4842,6 +4857,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -4961,6 +4988,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ sha2 = { version = "0.10" }
 schema-registry-client = { version = "0.4" }
 bitflags = { version = "2.10" }
 axum = { version = "0.8"}
+schemars = { version = "0.8.17", features = ["derive"] }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ sha2 = { version = "0.10" }
 schema-registry-client = { version = "0.4" }
 bitflags = { version = "2.10" }
 axum = { version = "0.8"}
-schemars = { version = "0.8.17", features = ["derive"] }
+schemars = { version = "1.2", features = ["derive"] }
 
 [profile.release]
 codegen-units = 1

--- a/crates/bgp-pkt/Cargo.toml
+++ b/crates/bgp-pkt/Cargo.toml
@@ -45,7 +45,7 @@ serde = [
 codec = ["tracing", "tokio-util", "bytes"]
 bench = ["criterion"]
 fuzz = ["arbitrary", "arbitrary_ext"]
-json-schema = ["schemars", "netgauze-iana/json-schema", "ipnet/schemars"]
+json-schema = ["schemars", "netgauze-iana/json-schema", "ipnet/schemars1"]
 
 [dev-dependencies]
 netgauze-pcap-reader = { workspace = true }

--- a/crates/bgp-pkt/Cargo.toml
+++ b/crates/bgp-pkt/Cargo.toml
@@ -31,6 +31,7 @@ arbitrary_ext = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 tokio-util = { workspace = true, default-features = false, features = ["codec"], optional = true }
 bytes = { workspace = true, optional = true }
+schemars = { workspace = true, features = ["derive"], optional = true }
 
 [features]
 default = ["serde"]
@@ -44,6 +45,7 @@ serde = [
 codec = ["tracing", "tokio-util", "bytes"]
 bench = ["criterion"]
 fuzz = ["arbitrary", "arbitrary_ext"]
+json-schema = ["schemars", "netgauze-iana/json-schema", "ipnet/schemars"]
 
 [dev-dependencies]
 netgauze-pcap-reader = { workspace = true }

--- a/crates/bgp-pkt/src/capabilities.rs
+++ b/crates/bgp-pkt/src/capabilities.rs
@@ -39,6 +39,7 @@ use strum_macros::{Display, FromRepr};
 /// ```
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpCapability {
     /// Defined in [RFC4760](https://datatracker.ietf.org/doc/html/rfc4760)
     MultiProtocolExtensions(MultiProtocolExtensionsCapability),
@@ -155,6 +156,7 @@ impl BgpCapability {
 #[repr(C)]
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UnrecognizedCapability {
     code: u8,
     value: Vec<u8>,
@@ -178,6 +180,7 @@ impl UnrecognizedCapability {
 #[repr(u8)]
 #[derive(Display, FromRepr, Hash, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum ExperimentalCapabilityCode {
     Experimental239 = 239,
     Experimental240 = 240,
@@ -201,6 +204,7 @@ pub enum ExperimentalCapabilityCode {
 /// by IANA See [RFC8810](https://datatracker.ietf.org/doc/html/RFC8810)
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct ExperimentalCapability {
     code: ExperimentalCapabilityCode,
     value: Vec<u8>,
@@ -231,6 +235,7 @@ impl ExperimentalCapability {
 /// ```
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct MultiProtocolExtensionsCapability {
     address_type: AddressType,
 }
@@ -248,6 +253,7 @@ impl MultiProtocolExtensionsCapability {
 /// Defined in [RFC6793](https://datatracker.ietf.org/doc/html/rfc6793)
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct FourOctetAsCapability {
     asn4: u32,
 }
@@ -266,6 +272,7 @@ impl FourOctetAsCapability {
 /// and [RFC8538](https://datatracker.ietf.org/doc/html/rfc8538)
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct GracefulRestartCapability {
     restart: bool,
     graceful_notification: bool,
@@ -307,6 +314,7 @@ impl GracefulRestartCapability {
 
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct GracefulRestartAddressFamily {
     forwarding_state: bool,
     address_type: AddressType,
@@ -335,6 +343,7 @@ impl GracefulRestartAddressFamily {
 /// See [RFC7911](https://datatracker.ietf.org/doc/html/RFC7911)
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct AddPathCapability {
     address_families: Vec<AddPathAddressFamily>,
 }
@@ -361,6 +370,7 @@ impl AddPathCapability {
 /// ```
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct AddPathAddressFamily {
     address_type: AddressType,
     send: bool,
@@ -417,6 +427,7 @@ impl AddPathAddressFamily {
 /// ```
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct ExtendedNextHopEncodingCapability {
     encodings: Vec<ExtendedNextHopEncoding>,
 }
@@ -444,6 +455,7 @@ impl ExtendedNextHopEncodingCapability {
 /// ```
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct ExtendedNextHopEncoding {
     address_type: AddressType,
     next_hop_afi: AddressFamily,
@@ -477,6 +489,7 @@ impl ExtendedNextHopEncoding {
 /// ```
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct MultipleLabel {
     address_type: AddressType,
     count: u8,
@@ -503,6 +516,7 @@ impl MultipleLabel {
 /// defined by: [RFC9234](https://datatracker.ietf.org/doc/html/rfc9234)
 #[derive(Debug, Hash, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpRoleCapability {
     role: BgpRoleValue,
 }

--- a/crates/bgp-pkt/src/community.rs
+++ b/crates/bgp-pkt/src/community.rs
@@ -27,6 +27,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 /// See [RFC1997](https://datatracker.ietf.org/doc/html/rfc1997)
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Community(u32);
 
 impl Community {
@@ -88,6 +89,7 @@ impl std::fmt::Display for Community {
 /// Local Data Part 2:  A four-octet operator-defined value.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct LargeCommunity {
     global_admin: u32,
     local_data1: u32,
@@ -163,6 +165,7 @@ pub trait ExtendedCommunityProperties {
 /// See [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum ExtendedCommunity {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     TransitiveTwoOctet(TransitiveTwoOctetExtendedCommunity),
@@ -551,6 +554,7 @@ impl std::fmt::Display for ExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveTwoOctetExtendedCommunity {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteTarget {
@@ -629,6 +633,7 @@ impl ExtendedCommunityProperties for TransitiveTwoOctetExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum NonTransitiveTwoOctetExtendedCommunity {
     LinkBandwidth {
         global_admin: u16,
@@ -657,6 +662,7 @@ impl ExtendedCommunityProperties for NonTransitiveTwoOctetExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveFourOctetExtendedCommunity {
     /// [RFC5668](https://datatracker.ietf.org/doc/html/rfc5668)
     RouteTarget {
@@ -724,6 +730,7 @@ impl ExtendedCommunityProperties for TransitiveFourOctetExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum NonTransitiveFourOctetExtendedCommunity {
     Unassigned {
         sub_type: u8,
@@ -744,6 +751,7 @@ impl ExtendedCommunityProperties for NonTransitiveFourOctetExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveIpv4ExtendedCommunity {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteTarget {
@@ -868,6 +876,7 @@ impl ExtendedCommunityProperties for TransitiveIpv4ExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum NonTransitiveIpv4ExtendedCommunity {
     Unassigned {
         sub_type: u8,
@@ -889,6 +898,7 @@ impl ExtendedCommunityProperties for NonTransitiveIpv4ExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveOpaqueExtendedCommunity {
     /// The Default Gateway community  It is a transitive community,
     /// which means that the first octet is 0x03.  The value of the second
@@ -915,6 +925,7 @@ impl ExtendedCommunityProperties for TransitiveOpaqueExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum NonTransitiveOpaqueExtendedCommunity {
     Unassigned { sub_type: u8, value: [u8; 6] },
 }
@@ -931,6 +942,7 @@ impl ExtendedCommunityProperties for NonTransitiveOpaqueExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct ExperimentalExtendedCommunity {
     code: u8,
     sub_type: u8,
@@ -971,6 +983,7 @@ impl ExtendedCommunityProperties for ExperimentalExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UnknownExtendedCommunity {
     code: u8,
     sub_type: u8,
@@ -1029,6 +1042,7 @@ impl ExtendedCommunityProperties for UnknownExtendedCommunity {
 /// See [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum ExtendedCommunityIpv6 {
     /// [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
     TransitiveIpv6(TransitiveIpv6ExtendedCommunity),
@@ -1059,6 +1073,7 @@ impl ExtendedCommunityProperties for ExtendedCommunityIpv6 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveIpv6ExtendedCommunity {
     /// [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
     RouteTarget {
@@ -1143,6 +1158,7 @@ impl ExtendedCommunityProperties for TransitiveIpv6ExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum NonTransitiveIpv6ExtendedCommunity {
     Unassigned {
         sub_type: u8,
@@ -1164,6 +1180,7 @@ impl ExtendedCommunityProperties for NonTransitiveIpv6ExtendedCommunity {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UnknownExtendedCommunityIpv6 {
     code: u8,
     sub_type: u8,
@@ -1204,6 +1221,7 @@ impl ExtendedCommunityProperties for UnknownExtendedCommunityIpv6 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum EvpnExtendedCommunity {
     /// MAC Mobility extended community
     /// ```text

--- a/crates/bgp-pkt/src/iana.rs
+++ b/crates/bgp-pkt/src/iana.rs
@@ -22,6 +22,7 @@ use strum_macros::{Display, FromRepr};
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpMessageType {
     Open = 1,
     Update = 2,
@@ -35,6 +36,7 @@ pub enum BgpMessageType {
 /// undefined code.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedBgpMessageType(pub u8);
 
 impl From<BgpMessageType> for u8 {
@@ -58,6 +60,7 @@ impl TryFrom<u8> for BgpMessageType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PathAttributeType {
     /// [RFC4271](https://datatracker.ietf.org/doc/html/rfc4271)
     Origin = 1,
@@ -161,6 +164,7 @@ impl From<PathAttributeType> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedPathAttributeType(pub u8);
 
 impl TryFrom<u8> for PathAttributeType {
@@ -178,6 +182,7 @@ impl TryFrom<u8> for PathAttributeType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpErrorNotificationCode {
     /// [RFC4271](https://datatracker.ietf.org/doc/html/rfc4271)
     MessageHeaderError = 1,
@@ -209,6 +214,7 @@ impl From<BgpErrorNotificationCode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedBgpErrorNotificationCode(pub u8);
 
 impl TryFrom<u8> for BgpErrorNotificationCode {
@@ -226,6 +232,7 @@ impl TryFrom<u8> for BgpErrorNotificationCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum MessageHeaderErrorSubCode {
     /// [RFC Errata 4493](https://www.rfc-editor.org/errata_search.php?eid=4493)
     Unspecific = 0,
@@ -242,6 +249,7 @@ impl From<MessageHeaderErrorSubCode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedMessageHeaderErrorSubCode(pub u8);
 
 impl TryFrom<u8> for MessageHeaderErrorSubCode {
@@ -259,6 +267,7 @@ impl TryFrom<u8> for MessageHeaderErrorSubCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum OpenMessageErrorSubCode {
     /// [RFC Errata 4493](https://www.rfc-editor.org/errata_search.php?eid=4493)
     Unspecific = 0,
@@ -283,6 +292,7 @@ impl From<OpenMessageErrorSubCode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedOpenMessageErrorSubCode(pub u8);
 
 impl TryFrom<u8> for OpenMessageErrorSubCode {
@@ -300,6 +310,7 @@ impl TryFrom<u8> for OpenMessageErrorSubCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum UpdateMessageErrorSubCode {
     /// [RFC Errata 4493](https://www.rfc-editor.org/errata_search.php?eid=4493)
     Unspecific = 0,
@@ -323,6 +334,7 @@ impl From<UpdateMessageErrorSubCode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedUpdateMessageErrorSubCode(pub u8);
 
 impl TryFrom<u8> for UpdateMessageErrorSubCode {
@@ -340,6 +352,7 @@ impl TryFrom<u8> for UpdateMessageErrorSubCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum FiniteStateMachineErrorSubCode {
     /// [RFC6608](https://datatracker.ietf.org/doc/html/rfc6608)
     UnspecifiedError = 0,
@@ -362,6 +375,7 @@ impl From<FiniteStateMachineErrorSubCode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedFiniteStateMachineErrorSubCode(pub u8);
 
 impl TryFrom<u8> for FiniteStateMachineErrorSubCode {
@@ -379,6 +393,7 @@ impl TryFrom<u8> for FiniteStateMachineErrorSubCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum CeaseErrorSubCode {
     /// [RFC4486](https://datatracker.ietf.org/doc/html/rfc4486)
     MaximumNumberOfPrefixesReached = 1,
@@ -419,6 +434,7 @@ impl From<CeaseErrorSubCode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedCeaseErrorSubCode(pub u8);
 
 impl TryFrom<u8> for CeaseErrorSubCode {
@@ -436,6 +452,7 @@ impl TryFrom<u8> for CeaseErrorSubCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteRefreshMessageErrorSubCode {
     /// [RFC7313](https://datatracker.ietf.org/doc/html/rfc7313)
     InvalidMessageLength = 1,
@@ -449,6 +466,7 @@ impl From<RouteRefreshMessageErrorSubCode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedRouteRefreshMessageError(pub u8);
 
 impl TryFrom<u8> for RouteRefreshMessageErrorSubCode {
@@ -466,6 +484,7 @@ impl TryFrom<u8> for RouteRefreshMessageErrorSubCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpOpenMessageParameterType {
     /// [RFC5492](https://datatracker.ietf.org/doc/html/rfc5492)
     Capability = 2,
@@ -482,6 +501,7 @@ impl From<BgpOpenMessageParameterType> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedBgpOpenMessageParameterType(pub u8);
 
 impl TryFrom<u8> for BgpOpenMessageParameterType {
@@ -609,6 +629,7 @@ impl From<BgpCapabilityCode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedBgpCapabilityCode(pub u8);
 
 impl TryFrom<u8> for BgpCapabilityCode {
@@ -626,6 +647,7 @@ impl TryFrom<u8> for BgpCapabilityCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteRefreshSubcode {
     NormalRequest = 0,
     BeginningOfRouteRefresh = 1,
@@ -640,6 +662,7 @@ impl From<RouteRefreshSubcode> for u8 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedRouteRefreshSubcode(pub u8);
 
 impl TryFrom<u8> for RouteRefreshSubcode {
@@ -657,6 +680,7 @@ impl TryFrom<u8> for RouteRefreshSubcode {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteDistinguisherTypeCode {
     As2Administrator = 0,
     Ipv4Administrator = 1,
@@ -673,6 +697,7 @@ impl From<RouteDistinguisherTypeCode> for u16 {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedRouteDistinguisherTypeCode(pub u16);
 
 impl TryFrom<u16> for RouteDistinguisherTypeCode {
@@ -698,6 +723,7 @@ impl TryFrom<u16> for RouteDistinguisherTypeCode {
 #[repr(u32)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum WellKnownCommunity {
     /// [RFC8326](https://datatracker.ietf.org/doc/html/rfc8326)
     GracefulShutdown = 0xFFFF0000,
@@ -728,6 +754,7 @@ pub enum WellKnownCommunity {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpDataCollectionCommunityValueCode {
     CustomerRoutes = 0b0000000000000001,
     PeerRoutes = 0b0000000000000010,
@@ -743,6 +770,7 @@ pub enum BgpDataCollectionCommunityValueCode {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpDataCollectionCommunityRegionIdentifierCode {
     Africa = 0b00001,
     Oceania = 0b00010,
@@ -756,6 +784,7 @@ pub enum BgpDataCollectionCommunityRegionIdentifierCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpExtendedCommunityType {
     /// [RFC7153](https://datatracker.ietf.org/doc/html/rfc7153)
     TransitiveTwoOctet = 0x00,
@@ -884,6 +913,7 @@ pub enum BgpExtendedCommunityType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedBgpExtendedCommunityType(pub u8);
 
 impl TryFrom<u8> for BgpExtendedCommunityType {
@@ -900,6 +930,7 @@ impl TryFrom<u8> for BgpExtendedCommunityType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpExtendedCommunityIpv6Type {
     /// [RFC7153](https://datatracker.ietf.org/doc/html/rfc7153)
     TransitiveIpv6 = 0x00,
@@ -910,6 +941,7 @@ pub enum BgpExtendedCommunityIpv6Type {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedBgpExtendedCommunityIpv6Type(pub u8);
 
 impl TryFrom<u8> for BgpExtendedCommunityIpv6Type {
@@ -926,6 +958,7 @@ impl TryFrom<u8> for BgpExtendedCommunityIpv6Type {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveTwoOctetExtendedCommunitySubType {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteTarget = 0x02,
@@ -957,6 +990,7 @@ pub enum TransitiveTwoOctetExtendedCommunitySubType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedTransitiveTwoOctetExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveTwoOctetExtendedCommunitySubType {
@@ -973,6 +1007,7 @@ impl TryFrom<u8> for TransitiveTwoOctetExtendedCommunitySubType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum NonTransitiveTwoOctetExtendedCommunitySubType {
     /// [draft-ietf-idr-link-bandwidth](https://datatracker.ietf.org/doc/draft-ietf-idr-link-bandwidth/)
     LinkBandwidth = 0x04,
@@ -983,6 +1018,7 @@ pub enum NonTransitiveTwoOctetExtendedCommunitySubType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedNonTransitiveTwoOctetExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for NonTransitiveTwoOctetExtendedCommunitySubType {
@@ -1001,6 +1037,7 @@ impl TryFrom<u8> for NonTransitiveTwoOctetExtendedCommunitySubType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveFourOctetExtendedCommunitySubType {
     /// [RFC5668](https://datatracker.ietf.org/doc/html/rfc5668)
     RouteTarget = 0x02,
@@ -1028,6 +1065,7 @@ pub enum TransitiveFourOctetExtendedCommunitySubType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedTransitiveFourOctetExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveFourOctetExtendedCommunitySubType {
@@ -1044,6 +1082,7 @@ impl TryFrom<u8> for TransitiveFourOctetExtendedCommunitySubType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveIpv4ExtendedCommunitySubType {
     /// [RFC4360](https://datatracker.ietf.org/doc/html/rfc4360)
     RouteTarget = 0x02,
@@ -1090,6 +1129,7 @@ pub enum TransitiveIpv4ExtendedCommunitySubType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedTransitiveIpv4ExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveIpv4ExtendedCommunitySubType {
@@ -1106,6 +1146,7 @@ impl TryFrom<u8> for TransitiveIpv4ExtendedCommunitySubType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveIpv6ExtendedCommunitySubType {
     /// [RFC5701](https://datatracker.ietf.org/doc/html/rfc5701)
     RouteTarget = 0x02,
@@ -1137,6 +1178,7 @@ pub enum TransitiveIpv6ExtendedCommunitySubType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedTransitiveIpv6ExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveIpv6ExtendedCommunitySubType {
@@ -1154,6 +1196,7 @@ impl TryFrom<u8> for TransitiveIpv6ExtendedCommunitySubType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum L2EvpnRouteTypeCode {
     /// [RFC7432](https://datatracker.ietf.org/doc/html/rfc7432)
     EthernetAutoDiscovery = 0x01,
@@ -1182,6 +1225,7 @@ pub enum L2EvpnRouteTypeCode {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedL2EvpnRouteTypeCode(pub u8);
 
 impl TryFrom<u8> for L2EvpnRouteTypeCode {
@@ -1199,6 +1243,7 @@ impl TryFrom<u8> for L2EvpnRouteTypeCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum EvpnExtendedCommunitySubType {
     /// [RFC7432](https://datatracker.ietf.org/doc/html/rfc7432)
     MacMobility = 0x00,
@@ -1242,6 +1287,7 @@ pub enum EvpnExtendedCommunitySubType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedEvpnExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for EvpnExtendedCommunitySubType {
@@ -1259,6 +1305,7 @@ impl TryFrom<u8> for EvpnExtendedCommunitySubType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TransitiveOpaqueExtendedCommunitySubType {
     /// [RFC7432](https://datatracker.ietf.org/doc/html/rfc7432)
     DefaultGateway = 0x0d,
@@ -1266,6 +1313,7 @@ pub enum TransitiveOpaqueExtendedCommunitySubType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedTransitiveOpaqueExtendedCommunitySubType(pub u8);
 
 impl TryFrom<u8> for TransitiveOpaqueExtendedCommunitySubType {
@@ -1284,6 +1332,7 @@ impl TryFrom<u8> for TransitiveOpaqueExtendedCommunitySubType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Hash, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpRoleValue {
     /// The local AS is a transit provider of the remote AS
     Provider = 0x00,
@@ -1396,6 +1445,7 @@ impl TryFrom<u16> for BgpLsNlriType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpLsProtocolId {
     IsIsLevel1 = 1,
     IsIsLevel2 = 2,

--- a/crates/bgp-pkt/src/lib.rs
+++ b/crates/bgp-pkt/src/lib.rs
@@ -58,6 +58,7 @@ pub mod codec;
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpMessage {
     Open(BgpOpenMessage),
     Update(BgpUpdateMessage),

--- a/crates/bgp-pkt/src/nlri/bgp_ls.rs
+++ b/crates/bgp-pkt/src/nlri/bgp_ls.rs
@@ -39,6 +39,7 @@ use strum_macros::{Display, FromRepr};
 /// see [RFC7752 Section 3.2](https://www.rfc-editor.org/rfc/rfc7752#section-3.2)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsNlri {
     pub path_id: Option<u32>,
     pub value: BgpLsNlriValue,
@@ -71,6 +72,7 @@ impl BgpLsNlri {
 /// see [RFC7752 Section 3.2](https://www.rfc-editor.org/rfc/rfc7752#section-3.2)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsVpnNlri {
     pub path_id: Option<u32>,
     pub rd: RouteDistinguisher,
@@ -102,6 +104,7 @@ impl BgpLsVpnNlri {
 /// see [RFC7752 Section 3.2](https://www.rfc-editor.org/rfc/rfc7752#section-3.2)
 #[derive(Display, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpLsNlriValue {
     /// ```text
     ///  0                   1                   2                   3
@@ -213,6 +216,7 @@ impl BgpLsNlriValue {
 /// see [RFC7752 Section 3.2](https://www.rfc-editor.org/rfc/rfc7752#section-3.2)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsNlriIpPrefix {
     pub protocol_id: BgpLsProtocolId,
     pub identifier: u64,
@@ -223,6 +227,7 @@ pub struct BgpLsNlriIpPrefix {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum OspfRouteType {
     IntraArea = 1,
     InterArea = 2,
@@ -304,6 +309,7 @@ pub enum IgpFlags {
 /// see [RFC7752 Section 3.3.2.3](https://www.rfc-editor.org/rfc/rfc7752#section-3.2.3.2)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct IpReachabilityInformationData(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipnet))] pub IpNet,
 );
@@ -334,6 +340,7 @@ impl IpReachabilityInformationData {
 
 #[derive(Display, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpLsPrefixDescriptor {
     /// The format of the MT-ID TLV is shown in the following figure.
     ///
@@ -424,6 +431,7 @@ impl BgpLsPrefixDescriptor {
 /// see [RFC7752 Section 3.2](https://www.rfc-editor.org/rfc/rfc7752#section-3.2)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsNlriNode {
     pub protocol_id: BgpLsProtocolId,
     pub identifier: u64,
@@ -443,6 +451,7 @@ pub struct BgpLsNlriNode {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsNodeDescriptors(pub Vec<BgpLsNodeDescriptorSubTlv>);
 
 /// ```text
@@ -458,6 +467,7 @@ pub struct BgpLsNodeDescriptors(pub Vec<BgpLsNodeDescriptorSubTlv>);
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsLocalNodeDescriptors(pub BgpLsNodeDescriptors);
 /// ```text
 ///  0                   1                   2                   3
@@ -472,6 +482,7 @@ pub struct BgpLsLocalNodeDescriptors(pub BgpLsNodeDescriptors);
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsRemoteNodeDescriptors(pub BgpLsNodeDescriptors);
 
 impl BgpLsNodeDescriptors {
@@ -487,6 +498,7 @@ impl BgpLsNodeDescriptors {
 /// see [RFC7752 Section 3.2.2](https://www.rfc-editor.org/rfc/rfc7752#section-3.2.2)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpLsLinkDescriptor {
     /// ```text
     ///  0                   1                   2                   3
@@ -566,6 +578,7 @@ impl BgpLsLinkDescriptor {
 /// see [RFC7752 Section 3.2.1](https://www.rfc-editor.org/rfc/rfc7752#section-3.2.1)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpLsNodeDescriptorSubTlv {
     AutonomousSystem(u32),
     BgpLsIdentifier(u32),
@@ -626,6 +639,7 @@ impl BgpLsNodeDescriptorSubTlv {
 /// see [RFC7752 Section 3.2](https://www.rfc-editor.org/rfc/rfc7752#section-3.2)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsNlriLink {
     pub protocol_id: BgpLsProtocolId,
     pub identifier: u64,
@@ -653,6 +667,7 @@ pub struct BgpLsNlriLink {
 /// see [RFC7752 Section 3.2.1.5](https://www.rfc-editor.org/rfc/rfc7752#section-3.2.1.5)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct MultiTopologyIdData(pub Vec<MultiTopologyId>);
 
 impl From<Vec<MultiTopologyId>> for MultiTopologyIdData {
@@ -691,6 +706,7 @@ impl MultiTopologyIdData {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct MultiTopologyId(pub u16);
 
 impl MultiTopologyId {
@@ -736,6 +752,7 @@ impl From<u16> for MultiTopologyId {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct SharedRiskLinkGroupValue(pub u32);
 
 impl SharedRiskLinkGroupValue {

--- a/crates/bgp-pkt/src/nlri/nlri.rs
+++ b/crates/bgp-pkt/src/nlri/nlri.rs
@@ -30,6 +30,7 @@ pub trait NlriAddressType {
 /// Temporary representation of MPLS Labels
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct MplsLabel([u8; 3]);
 
 impl MplsLabel {
@@ -54,6 +55,7 @@ impl MplsLabel {
 ///     - Value Field: 6 bytes
 #[derive(Hash, Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteDistinguisher {
     /// The Value field consists of two subfields:
     ///     - Administrator subfield: ASN2
@@ -130,6 +132,7 @@ impl From<RouteDistinguisher> for u64 {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct LabeledIpv4NextHop {
     rd: RouteDistinguisher,
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv4))]
@@ -152,6 +155,7 @@ impl LabeledIpv4NextHop {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct LabeledIpv6NextHop {
     rd: RouteDistinguisher,
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv6))]
@@ -188,6 +192,7 @@ impl LabeledIpv6NextHop {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum LabeledNextHop {
     Ipv4(LabeledIpv4NextHop),
     Ipv6(LabeledIpv6NextHop),
@@ -213,6 +218,7 @@ impl LabeledNextHop {
 /// networks
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv4Unicast(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv4net))] Ipv4Net,
 );
@@ -226,6 +232,7 @@ impl std::fmt::Display for Ipv4Unicast {
 /// Raised when the network is not a unicast range
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct InvalidIpv4UnicastNetwork(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv4net))] pub Ipv4Net,
 );
@@ -259,6 +266,7 @@ impl TryFrom<Ipv4Net> for Ipv4Unicast {
 /// Ipv4 Network address in NLRI
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv4UnicastAddress {
     path_id: Option<u32>,
     network: Ipv4Unicast,
@@ -293,6 +301,7 @@ impl NlriAddressType for Ipv4UnicastAddress {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv4MplsVpnUnicastAddress {
     path_id: Option<u32>,
     rd: RouteDistinguisher,
@@ -355,6 +364,7 @@ impl NlriAddressType for Ipv4MplsVpnUnicastAddress {
 /// networks
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv4Multicast(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv4net))] Ipv4Net,
 );
@@ -367,6 +377,7 @@ impl std::fmt::Display for Ipv4Multicast {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct InvalidIpv4MulticastNetwork(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv4net))] pub Ipv4Net,
 );
@@ -395,6 +406,7 @@ impl TryFrom<Ipv4Net> for Ipv4Multicast {
 /// Ipv4 Multicast Network address in NLRI
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv4MulticastAddress {
     path_id: Option<u32>,
     network: Ipv4Multicast,
@@ -431,6 +443,7 @@ impl NlriAddressType for Ipv4MulticastAddress {
 /// networks
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv6Unicast(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv6net))] Ipv6Net,
 );
@@ -443,6 +456,7 @@ impl std::fmt::Display for Ipv6Unicast {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct InvalidIpv6UnicastNetwork(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv6net))] pub Ipv6Net,
 );
@@ -471,6 +485,7 @@ impl TryFrom<Ipv6Net> for Ipv6Unicast {
 /// Ipv6 Network address in NLRI
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv6UnicastAddress {
     path_id: Option<u32>,
     network: Ipv6Unicast,
@@ -498,6 +513,7 @@ impl NlriAddressType for Ipv6UnicastAddress {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv6MplsVpnUnicastAddress {
     path_id: Option<u32>,
     rd: RouteDistinguisher,
@@ -560,6 +576,7 @@ impl NlriAddressType for Ipv6MplsVpnUnicastAddress {
 /// networks
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv6Multicast(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv6net))] Ipv6Net,
 );
@@ -572,6 +589,7 @@ impl std::fmt::Display for Ipv6Multicast {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct InvalidIpv6MulticastNetwork(
     #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ipv6net))] pub Ipv6Net,
 );
@@ -605,6 +623,7 @@ impl TryFrom<Ipv6Net> for Ipv6Multicast {
 /// Ipv4 Multicast Network address in NLRI
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv6MulticastAddress {
     path_id: Option<u32>,
     network: Ipv6Multicast,
@@ -639,14 +658,17 @@ impl NlriAddressType for Ipv6MulticastAddress {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct EthernetSegmentIdentifier(pub [u8; 10]);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct EthernetTag(pub u32);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct MacAddress(pub [u8; 6]);
 
 impl std::fmt::Display for MacAddress {
@@ -661,6 +683,7 @@ impl std::fmt::Display for MacAddress {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct L2EvpnAddress {
     path_id: Option<u32>,
     route: L2EvpnRoute,
@@ -682,6 +705,7 @@ impl L2EvpnAddress {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum L2EvpnRoute {
     EthernetAutoDiscovery(EthernetAutoDiscovery),
     MacIpAdvertisement(MacIpAdvertisement),
@@ -726,6 +750,7 @@ impl NlriAddressType for L2EvpnAddress {
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct EthernetAutoDiscovery {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
@@ -790,6 +815,7 @@ impl EthernetAutoDiscovery {
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct MacIpAdvertisement {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
@@ -868,6 +894,7 @@ impl MacIpAdvertisement {
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct InclusiveMulticastEthernetTagRoute {
     rd: RouteDistinguisher,
     tag: EthernetTag,
@@ -910,6 +937,7 @@ impl InclusiveMulticastEthernetTagRoute {
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct EthernetSegmentRoute {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
@@ -942,6 +970,7 @@ impl EthernetSegmentRoute {
 /// The BGP EVPN IPv4 or IPv6 Prefix Route
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum L2EvpnIpPrefixRoute {
     V4(L2EvpnIpv4PrefixRoute),
     V6(L2EvpnIpv6PrefixRoute),
@@ -968,6 +997,7 @@ pub enum L2EvpnIpPrefixRoute {
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct L2EvpnIpv4PrefixRoute {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
@@ -1042,6 +1072,7 @@ impl L2EvpnIpv4PrefixRoute {
 /// ```
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct L2EvpnIpv6PrefixRoute {
     rd: RouteDistinguisher,
     segment_id: EthernetSegmentIdentifier,
@@ -1097,6 +1128,7 @@ impl L2EvpnIpv6PrefixRoute {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct RouteTargetMembershipAddress {
     path_id: Option<u32>,
     membership: Option<RouteTargetMembership>,
@@ -1132,6 +1164,7 @@ impl RouteTargetMembershipAddress {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct RouteTargetMembership {
     origin_as: u32,
     /// Route targets can then be expressed as prefixes, where, for instance,
@@ -1165,6 +1198,7 @@ impl NlriAddressType for RouteTargetMembershipAddress {
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum InvalidIpv4NlriMplsLabelsAddress {
     /// Total length should not exceed 255, each MPLS Label is 24 bit and
     /// account for up to 32 bit IPv4 prefix length
@@ -1204,6 +1238,7 @@ pub enum InvalidIpv4NlriMplsLabelsAddress {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv4NlriMplsLabelsAddress {
     path_id: Option<u32>,
     labels: Vec<MplsLabel>,
@@ -1260,6 +1295,7 @@ impl NlriAddressType for Ipv4NlriMplsLabelsAddress {
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum InvalidIpv6NlriMplsLabelsAddress {
     /// Total length should not exceed 255, each MPLS Label is 24 bit and
     /// account for up to 128 bit IPv6 prefix length
@@ -1299,6 +1335,7 @@ pub enum InvalidIpv6NlriMplsLabelsAddress {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Ipv6NlriMplsLabelsAddress {
     path_id: Option<u32>,
     labels: Vec<MplsLabel>,

--- a/crates/bgp-pkt/src/notification.rs
+++ b/crates/bgp-pkt/src/notification.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpNotificationMessage {
     MessageHeaderError(MessageHeaderError),
     OpenMessageError(OpenMessageError),
@@ -40,6 +41,7 @@ pub enum BgpNotificationMessage {
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum MessageHeaderError {
     Unspecific { value: Vec<u8> },
     ConnectionNotSynchronized { value: Vec<u8> },
@@ -50,6 +52,7 @@ pub enum MessageHeaderError {
 /// See [`crate::iana::OpenMessageErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum OpenMessageError {
     Unspecific { value: Vec<u8> },
     UnsupportedVersionNumber { value: Vec<u8> },
@@ -64,6 +67,7 @@ pub enum OpenMessageError {
 /// See [`crate::iana::UpdateMessageErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum UpdateMessageError {
     Unspecific { value: Vec<u8> },
     MalformedAttributeList { value: Vec<u8> },
@@ -80,6 +84,7 @@ pub enum UpdateMessageError {
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum HoldTimerExpiredError {
     Unspecific { sub_code: u8, value: Vec<u8> },
 }
@@ -87,6 +92,7 @@ pub enum HoldTimerExpiredError {
 /// See [`crate::iana::FiniteStateMachineErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum FiniteStateMachineError {
     Unspecific { value: Vec<u8> },
     ReceiveUnexpectedMessageInOpenSentState { value: Vec<u8> },
@@ -97,6 +103,7 @@ pub enum FiniteStateMachineError {
 /// See [`crate::iana::CeaseErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum CeaseError {
     MaximumNumberOfPrefixesReached { value: Vec<u8> },
     AdministrativeShutdown { value: Vec<u8> },
@@ -113,6 +120,7 @@ pub enum CeaseError {
 /// See [`crate::iana::RouteRefreshMessageErrorSubCode`] for full documentation
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteRefreshError {
     InvalidMessageLength { value: Vec<u8> },
 }

--- a/crates/bgp-pkt/src/open.rs
+++ b/crates/bgp-pkt/src/open.rs
@@ -42,6 +42,7 @@ pub const BGP_VERSION: u8 = 4;
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpOpenMessage {
     version: u8,
     my_as: u16,
@@ -124,6 +125,7 @@ impl BgpOpenMessage {
 /// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-...
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpOpenMessageParameter {
     /// Capabilities Advertisement
     Capabilities(Vec<BgpCapability>),

--- a/crates/bgp-pkt/src/path_attribute/bgp_ls.rs
+++ b/crates/bgp-pkt/src/path_attribute/bgp_ls.rs
@@ -24,6 +24,7 @@ use strum_macros::{Display, FromRepr};
 /// The BGP Link-State Attribute. see [RFC7752 Section 3.3](https://www.rfc-editor.org/rfc/rfc7752#section-3.3)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpLsAttribute {
     pub attributes: Vec<BgpLsAttributeValue>,
 }
@@ -47,6 +48,7 @@ impl PathAttributeValueProperties for BgpLsAttribute {
 
 #[derive(Display, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpLsAttributeValue {
     /// see [RFC7752 Section 3.3.1.4](https://www.rfc-editor.org/rfc/rfc7752#section-3.3.1.4)
     LocalNodeIpv4RouterId(
@@ -462,6 +464,7 @@ pub enum LinkProtectionType {
 
 #[derive(Display, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpLsPeerSid {
     LabelValue {
         flags: u8,

--- a/crates/bgp-pkt/src/path_attribute/bgp_sid.rs
+++ b/crates/bgp-pkt/src/path_attribute/bgp_sid.rs
@@ -19,6 +19,7 @@ use strum_macros::Display;
 /// 3 bytes for range size
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct SegmentRoutingGlobalBlock {
     pub first_label: MplsLabel,
     pub range_size: [u8; 3],
@@ -26,6 +27,7 @@ pub struct SegmentRoutingGlobalBlock {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BgpSidAttribute {
     /// ```text
     ///  0                   1                   2                   3
@@ -188,6 +190,7 @@ pub enum BgpSidAttribute {
 ///       whose format is described in Section 3.2 below.
 #[derive(Display, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum SRv6ServiceSubTlv {
     /// ```text
     ///     0                   1                   2                   3
@@ -300,6 +303,7 @@ impl SRv6ServiceSubTlv {
 
 #[derive(Display, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum SRv6ServiceSubSubTlv {
     /// ```text
     ///     0                   1                   2                   3
@@ -380,6 +384,7 @@ impl SRv6ServiceSubSubTlv {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct PrefixSegmentIdentifier {
     tlvs: Vec<BgpSidAttribute>,
 }

--- a/crates/bgp-pkt/src/path_attribute/path_attribute.rs
+++ b/crates/bgp-pkt/src/path_attribute/path_attribute.rs
@@ -50,6 +50,7 @@ pub trait PathAttributeValueProperties {
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum InvalidPathAttribute {
     InvalidOptionalFlagValue(bool),
     InvalidTransitiveFlagValue(bool),
@@ -67,6 +68,7 @@ pub enum InvalidPathAttribute {
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct PathAttribute {
     /// Optional bit defines whether the attribute is optional (if set to
     /// `true`) or well-known (if set to `false`).
@@ -164,6 +166,7 @@ impl PathAttribute {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PathAttributeValue {
     Origin(Origin),
     AsPath(AsPath),
@@ -314,6 +317,7 @@ impl PathAttributeValue {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum Origin {
     IGP = 0,
     EGP = 1,
@@ -344,6 +348,7 @@ impl From<Origin> for u8 {
 /// The value carried is the undefined value being parsed
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedOrigin(pub u8);
 
 impl TryFrom<u8> for Origin {
@@ -363,6 +368,7 @@ impl TryFrom<u8> for Origin {
 /// length, path segment value>.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum AsPath {
     As2PathSegments(Vec<As2PathSegment>),
     As4PathSegments(Vec<As4PathSegment>),
@@ -415,6 +421,7 @@ impl From<AsPath> for Vec<u32> {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum AsPathSegmentType {
     AsSet = 1,
     AsSequence = 2,
@@ -430,6 +437,7 @@ impl From<AsPathSegmentType> for u8 {
 /// The value carried is the undefined value being parsed
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UndefinedAsPathSegmentType(pub u8);
 
 impl TryFrom<u8> for AsPathSegmentType {
@@ -461,6 +469,7 @@ impl TryFrom<u8> for AsPathSegmentType {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct As2PathSegment {
     segment_type: AsPathSegmentType,
     as_numbers: Vec<u16>,
@@ -487,6 +496,7 @@ impl As2PathSegment {
 /// <path segment type, path segment length, path segment value>.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct As4PathSegment {
     segment_type: AsPathSegmentType,
     as_numbers: Vec<u32>,
@@ -511,6 +521,7 @@ impl As4PathSegment {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct As4Path {
     segments: Vec<As4PathSegment>,
 }
@@ -551,6 +562,7 @@ impl PathAttributeValueProperties for As4Path {
 /// Reachability Information field of the UPDATE message.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct NextHop {
     next_hop: Ipv4Addr,
 }
@@ -585,6 +597,7 @@ impl PathAttributeValueProperties for NextHop {
 /// autonomous system.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct MultiExitDiscriminator {
     metric: u32,
 }
@@ -619,6 +632,7 @@ impl PathAttributeValueProperties for MultiExitDiscriminator {
 /// preference for an advertised route.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct LocalPreference {
     metric: u32,
 }
@@ -650,6 +664,7 @@ impl PathAttributeValueProperties for LocalPreference {
 /// `ATOMIC_AGGREGATE` is a well-known discretionary attribute of length 0.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct AtomicAggregate;
 
 impl PathAttributeValueProperties for AtomicAggregate {
@@ -673,6 +688,7 @@ impl PathAttributeValueProperties for AtomicAggregate {
 /// the one used for the BGP Identifier of the speaker.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct As2Aggregator {
     asn: u16,
     origin: Ipv4Addr,
@@ -693,6 +709,7 @@ impl As2Aggregator {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct As4Aggregator {
     asn: u32,
     origin: Ipv4Addr,
@@ -718,6 +735,7 @@ impl As4Aggregator {
 /// the speaker.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum Aggregator {
     As2Aggregator(As2Aggregator),
     As4Aggregator(As4Aggregator),
@@ -740,6 +758,7 @@ impl PathAttributeValueProperties for Aggregator {
 /// Path attribute can be of size `u8` or `u16` based on `extended_length` bit.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PathAttributeLength {
     U8(u8),
     U16(u16),
@@ -762,6 +781,7 @@ impl From<PathAttributeLength> for u16 {
 /// See [RFC1997](https://datatracker.ietf.org/doc/html/rfc1997)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Communities {
     communities: Vec<Community>,
 }
@@ -792,6 +812,7 @@ impl PathAttributeValueProperties for Communities {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct ExtendedCommunities {
     communities: Vec<ExtendedCommunity>,
 }
@@ -822,6 +843,7 @@ impl PathAttributeValueProperties for ExtendedCommunities {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct ExtendedCommunitiesIpv6 {
     communities: Vec<ExtendedCommunityIpv6>,
 }
@@ -852,6 +874,7 @@ impl PathAttributeValueProperties for ExtendedCommunitiesIpv6 {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct LargeCommunities {
     communities: Vec<LargeCommunity>,
 }
@@ -891,6 +914,7 @@ impl PathAttributeValueProperties for LargeCommunities {
 /// [RFC4456](https://datatracker.ietf.org/doc/html/rfc4456) defines this value
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct Originator(Ipv4Addr);
 
 impl Originator {
@@ -924,6 +948,7 @@ impl PathAttributeValueProperties for Originator {
 /// [RFC4456](https://datatracker.ietf.org/doc/html/rfc4456) defines this value
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct ClusterList(Vec<ClusterId>);
 
 impl ClusterList {
@@ -952,6 +977,7 @@ impl PathAttributeValueProperties for ClusterList {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct ClusterId(Ipv4Addr);
 
 impl ClusterId {
@@ -991,6 +1017,7 @@ impl ClusterId {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum MpReach {
     Ipv4Unicast {
         #[cfg_attr(feature = "fuzz", arbitrary(with = crate::arbitrary_ip))]
@@ -1174,6 +1201,7 @@ impl PathAttributeValueProperties for MpReach {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum MpUnreach {
     Ipv4Unicast {
         nlri: Vec<Ipv4UnicastAddress>,
@@ -1326,6 +1354,7 @@ impl PathAttributeValueProperties for MpUnreach {
 /// the transitive and partial bits of the attribute.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct UnknownAttribute {
     code: u8,
     value: Vec<u8>,
@@ -1363,6 +1392,7 @@ impl PathAttributeValueProperties for UnknownAttribute {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct OnlyToCustomer(u32);
 
 impl OnlyToCustomer {
@@ -1392,6 +1422,7 @@ impl PathAttributeValueProperties for OnlyToCustomer {
 /// Accumulated IGP Metric Attribute [RFC7311](https://datatracker.ietf.org/doc/html/rfc7311)
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum Aigp {
     AccumulatedIgpMetric(u64),
 }

--- a/crates/bgp-pkt/src/route_refresh.rs
+++ b/crates/bgp-pkt/src/route_refresh.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpRouteRefreshMessage {
     address_type: AddressType,
     operation_type: RouteRefreshSubcode,

--- a/crates/bgp-pkt/src/update.rs
+++ b/crates/bgp-pkt/src/update.rs
@@ -39,6 +39,7 @@ use crate::path_attribute::{MpUnreach, PathAttribute, PathAttributeValue};
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct BgpUpdateMessage {
     withdrawn_routes: Vec<Ipv4UnicastAddress>,
     path_attributes: Vec<PathAttribute>,

--- a/crates/bmp-pkt/Cargo.toml
+++ b/crates/bmp-pkt/Cargo.toml
@@ -34,6 +34,7 @@ tokio-util = { workspace = true, default-features = false, features = ["codec"],
 bytes = { workspace = true, optional = true }
 either = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
+schemars = { workspace = true, features = ["derive", "chrono04"], optional = true }
 
 [features]
 default = ["serde"]
@@ -47,6 +48,7 @@ serde = [
 codec = ["tokio-util", "bytes"]
 bench = ["criterion"]
 fuzz = ["arbitrary", "arbitrary_ext", "bitflags/arbitrary"]
+json-schema = ["schemars", "netgauze-bgp-pkt/json-schema", "netgauze-iana/json-schema", "ipnet/schemars1"]
 
 [dev-dependencies]
 netgauze-pcap-reader = { workspace = true }

--- a/crates/bmp-pkt/src/iana.rs
+++ b/crates/bmp-pkt/src/iana.rs
@@ -42,6 +42,7 @@ pub const PEER_FLAGS_IS_FILTERED: u8 = 0b10000000;
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BmpVersion {
     Version3 = 3,
     Version4 = 4,
@@ -73,6 +74,7 @@ impl TryFrom<u8> for BmpVersion {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BmpMessageType {
     #[strum(to_string = "Route Monitoring")]
     RouteMonitoring = 0,
@@ -124,6 +126,7 @@ impl TryFrom<u8> for BmpMessageType {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BmpPeerTypeCode {
     #[strum(to_string = "Global Instance Peer")]
     GlobalInstancePeer = 0,
@@ -169,6 +172,7 @@ impl TryFrom<u8> for BmpPeerTypeCode {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum InitiationInformationTlvType {
     #[strum(to_string = "String")]
     String = 0,
@@ -216,6 +220,7 @@ impl TryFrom<u16> for InitiationInformationTlvType {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TerminationInformationTlvType {
     #[strum(to_string = "String")]
     String = 0,
@@ -257,6 +262,7 @@ impl TryFrom<u16> for TerminationInformationTlvType {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PeerTerminationCode {
     #[strum(to_string = "Administratively closed")]
     AdministrativelyClosed = 0,
@@ -304,6 +310,7 @@ impl TryFrom<u16> for PeerTerminationCode {
 #[repr(u8)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PeerDownReasonCode {
     #[strum(to_string = "Local system closed, NOTIFICATION PDU follows")]
     LocalSystemClosedNotificationPduFollows = 1,
@@ -353,6 +360,7 @@ impl TryFrom<u8> for PeerDownReasonCode {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMirroringTlvType {
     #[strum(to_string = "BGP Message")]
     BgpMessage = 0,
@@ -394,6 +402,7 @@ impl TryFrom<u16> for RouteMirroringTlvType {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMirroringInformation {
     #[strum(to_string = "Errored PDU")]
     ErroredPdu = 0,
@@ -435,6 +444,7 @@ impl TryFrom<u16> for RouteMirroringInformation {
 #[repr(u16)]
 #[derive(Display, FromRepr, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BmpStatisticsType {
     // [RFC8671](https://datatracker.ietf.org/doc/html/rfc8671)
     #[strum(to_string = "Number of prefixes rejected by inbound policy")]

--- a/crates/bmp-pkt/src/lib.rs
+++ b/crates/bmp-pkt/src/lib.rs
@@ -47,6 +47,7 @@ pub mod wire;
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BmpMessage {
     V3(v3::BmpMessageValue),
     V4(v4::BmpMessageValue),
@@ -99,6 +100,7 @@ impl BmpMessage {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct PeerHeader {
     peer_type: BmpPeerType,
     rd: Option<RouteDistinguisher>,
@@ -192,6 +194,7 @@ impl PeerHeader {
 ///    set when a filter is applied to Loc-RIB routes sent to the BMP collector.
 #[derive(Debug, Hash, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BmpPeerType {
     GlobalInstancePeer {
         ipv6: bool,
@@ -249,6 +252,7 @@ impl BmpPeerType {
 /// increasing again from 0.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct CounterU32(u32);
 
 impl CounterU32 {
@@ -281,6 +285,7 @@ impl Deref for CounterU32 {
 /// value), the 64-bit Gauge also decreases (or increases).
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct GaugeU64(u64);
 
 impl GaugeU64 {
@@ -312,6 +317,7 @@ fn arbitrary_ipv4(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Ipv4
 /// to the BMP session.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct PeerKey {
     #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ext::arbitrary_option(crate::arbitrary_ip)))]
     peer_address: Option<IpAddr>,

--- a/crates/bmp-pkt/src/v3.rs
+++ b/crates/bmp-pkt/src/v3.rs
@@ -27,6 +27,7 @@ use std::net::IpAddr;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BmpMessageValue {
     RouteMonitoring(RouteMonitoringMessage),
     StatisticsReport(StatisticsReportMessage),
@@ -71,6 +72,7 @@ impl BmpMessageValue {
 /// others are optional. The string TLV MAY be included multiple times.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct InitiationMessage {
     information: Vec<InitiationInformation>,
 }
@@ -100,6 +102,7 @@ impl InitiationMessage {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum InitiationInformation {
     /// The Information field contains a free-form UTF-8 string whose length is
     /// given by the Information Length field.
@@ -169,6 +172,7 @@ impl InitiationInformation {
 /// why it is terminating a session.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct TerminationMessage {
     information: Vec<TerminationInformation>,
 }
@@ -197,6 +201,7 @@ impl TerminationMessage {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TerminationInformation {
     String(String),
     Reason(PeerTerminationCode),
@@ -225,6 +230,7 @@ impl TerminationInformation {
 /// [`BgpMessage::Update`], anything else is an error
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMonitoringMessageError {
     UnexpectedMessageType(BgpMessageType),
 }
@@ -238,6 +244,7 @@ pub enum RouteMonitoringMessageError {
 /// PDU.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct RouteMonitoringMessage {
     peer_header: PeerHeader,
     update_message: BgpMessage,
@@ -272,6 +279,7 @@ impl RouteMonitoringMessage {
 /// received.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct RouteMirroringMessage {
     peer_header: PeerHeader,
     mirrored: Vec<RouteMirroringValue>,
@@ -296,6 +304,7 @@ impl RouteMirroringMessage {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum MirroredBgpMessage {
     Parsed(BgpMessage),
     Raw(Vec<u8>),
@@ -303,6 +312,7 @@ pub enum MirroredBgpMessage {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMirroringValue {
     /// A BGP PDU.  This PDU may or may not be an Update message.
     /// If the BGP Message TLV occurs in the Route Mirroring message,
@@ -356,6 +366,7 @@ impl RouteMirroringValue {
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct PeerUpNotificationMessage {
     peer_header: PeerHeader,
     #[cfg_attr(feature = "fuzz", arbitrary(with = arbitrary_ext::arbitrary_option(crate::arbitrary_ip)))]
@@ -372,6 +383,7 @@ pub struct PeerUpNotificationMessage {
 /// [`BgpMessage::Open`], anything else is an error
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PeerUpNotificationMessageError {
     UnexpectedSentMessageType(BgpMessageType),
     UnexpectedReceivedMessageType(BgpMessageType),
@@ -444,6 +456,7 @@ impl PeerUpNotificationMessage {
 /// [`BgpMessage::Notification`], anything else is an error
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PeerDownNotificationMessageError {
     UnexpectedBgpMessageType(BgpMessageType),
     UnexpectedInitiationInformationTlvType(InitiationInformationTlvType),
@@ -463,6 +476,7 @@ pub enum PeerDownNotificationMessageError {
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct PeerDownNotificationMessage {
     peer_header: PeerHeader,
     reason: PeerDownNotificationReason,
@@ -519,6 +533,7 @@ impl PeerDownNotificationMessage {
 /// [`PeerDownNotificationMessage`] is sent.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PeerDownNotificationReason {
     /// The local system closed the session.  Following the
     /// Reason is a BGP PDU containing a BGP NOTIFICATION message that
@@ -605,6 +620,7 @@ impl PeerDownNotificationReason {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct StatisticsReportMessage {
     peer_header: PeerHeader,
     counters: Vec<StatisticsCounter>,
@@ -641,6 +657,7 @@ impl StatisticsReportMessage {
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum StatisticsCounter {
     NumberOfPrefixesRejectedByInboundPolicy(CounterU32),
     NumberOfDuplicatePrefixAdvertisements(CounterU32),

--- a/crates/bmp-pkt/src/v4.rs
+++ b/crates/bmp-pkt/src/v4.rs
@@ -27,6 +27,7 @@ pub const BMPV4_TLV_GROUP_GBIT: u16 = 0x8000;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum BmpMessageValue {
     RouteMonitoring(RouteMonitoringMessage),
     StatisticsReport(v3::StatisticsReportMessage),
@@ -43,6 +44,7 @@ pub enum BmpMessageValue {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PeerDownTlv {
     Unknown { code: u16, value: Vec<u8> },
 }
@@ -75,6 +77,7 @@ impl BmpMessageValue {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct RouteMonitoringTlv {
     index: u16,
     value: RouteMonitoringTlvValue,
@@ -82,6 +85,7 @@ pub struct RouteMonitoringTlv {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMonitoringTlvError {
     BadGroupTlvIndex(u16),
     BadBgpMessageType(BgpMessageType),
@@ -150,6 +154,7 @@ impl RouteMonitoringTlv {
 #[repr(u16)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FromRepr, Display)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMonitoringTlvType {
     StatelessParsing = 1,
     GroupTlv = 2,
@@ -160,6 +165,7 @@ pub enum RouteMonitoringTlvType {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMonitoringTlvValue {
     StatelessParsing(BgpCapability),
     GroupTlv(Vec<u16>),
@@ -184,6 +190,7 @@ pub enum RouteMonitoringTlvValue {
 /// ```
 #[derive(Debug, Hash, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct PathMarking {
     /// [PathStatus] is just a collection of all possible flags in this bitflag
     path_status: PathStatus,
@@ -281,8 +288,29 @@ impl PathStatus {
     }
 }
 
+#[cfg(feature = "json-schema")]
+mod json_schema_impl {
+    use schemars::{JsonSchema, Schema, SchemaGenerator};
+    use std::borrow::Cow;
+
+    impl JsonSchema for super::PathStatus {
+        fn schema_name() -> Cow<'static, str> {
+            "PathStatus".into()
+        }
+
+        fn json_schema(_: &mut SchemaGenerator) -> Schema {
+            schemars::json_schema!({
+                "type": "string",
+                "description": "Bitflags serialized as a `|`-separated string, e.g. \"BEST | PRIMARY\".",
+                "examples": ["BEST | PRIMARY", "STALE"]
+            })
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PathMarkingReason {
     WellKnown(WellKnownPathMarkingReasonCode),
     Unknown(u16),
@@ -318,6 +346,7 @@ impl From<WellKnownPathMarkingReasonCode> for PathMarkingReason {
     Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, FromRepr, strum_macros::Display,
 )]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[repr(u16)]
 pub enum WellKnownPathMarkingReasonCode {
     #[strum(to_string = "Invalid due to AS loop")]
@@ -346,6 +375,7 @@ pub enum WellKnownPathMarkingReasonCode {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMonitoringError {
     TlvError(RouteMonitoringTlvError),
 }
@@ -365,6 +395,7 @@ impl From<RouteMonitoringTlvError> for RouteMonitoringError {
 /// PDU.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct RouteMonitoringMessage {
     peer_header: PeerHeader,
     update_pdu: RouteMonitoringTlv,
@@ -411,6 +442,7 @@ impl RouteMonitoringMessage {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct PeerDownNotificationMessage {
     peer_header: PeerHeader,
     reason: v3::PeerDownNotificationReason,

--- a/crates/iana/Cargo.toml
+++ b/crates/iana/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["network-programming"]
 strum_macros = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 arbitrary = { workspace = true, optional = true }
+schemars = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -26,3 +27,4 @@ serde_json = { workspace = true }
 [features]
 default = []
 fuzz = ["arbitrary"]
+json-schema = ["schemars"]

--- a/crates/iana/src/address_family.rs
+++ b/crates/iana/src/address_family.rs
@@ -58,6 +58,7 @@ use strum_macros::{Display, FromRepr};
 #[repr(u16)]
 #[derive(FromRepr, Display, Hash, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum AddressFamily {
     IPv4 = 1,
     IPv6 = 2,
@@ -218,6 +219,7 @@ impl TryFrom<u16> for AddressFamily {
 #[repr(u8)]
 #[derive(FromRepr, Display, Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum SubsequentAddressFamily {
     /// Network Layer Reachability Information used for unicast forwarding
     /// [RFC4760](https://datatracker.ietf.org/doc/html/RFC4760)
@@ -399,6 +401,7 @@ impl TryFrom<u8> for SubsequentAddressFamily {
 /// valid AFI/SAFI are used at compile time.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum AddressType {
     Ipv4Unicast,
     Ipv4Multicast,


### PR DESCRIPTION
Support automatic generation of JSON schema for BMP and BGP packets using the https://json-schema.org/draft/2020-12 version. Note this feature is an optional feature and enabled by "json-schema". 


For example:

```rust
use netgauze_bmp_pkt::{BmpMessage};

fn main() {
    let schema = schema_for!(BmpMessage);
    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
}
```
