### PR TITLE
Prepare Subscription struct of netconf-proto to be the source struct for subscription started/modified. 

### DIFF
--- a/crates/netconf-proto/src/yang_push/mod.rs
+++ b/crates/netconf-proto/src/yang_push/mod.rs
@@ -47,3 +47,6 @@ pub const SUBSCRIBED_NOTIFICATIONS_NS: Namespace<'static> =
     Namespace(b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications");
 pub const DISTRIBUTED_NOTIF_NS: Namespace<'static> =
     Namespace(b"urn:ietf:params:xml:ns:yang:ietf-distributed-notif");
+
+pub const YANG_PUSH_REVISION: Namespace<'static> =
+    Namespace(b"urn:ietf:params:xml:ns:yang:ietf-yang-push-revision");

--- a/crates/netconf-proto/src/yang_push/subscription.rs
+++ b/crates/netconf-proto/src/yang_push/subscription.rs
@@ -36,7 +36,9 @@ use crate::yang_push::filters::{
 };
 use crate::yang_push::identities::{ChangeType, ConfiguredSubscriptionState, Encoding, Transport};
 use crate::yang_push::types::{CentiSeconds, SubscriptionId};
-use crate::yang_push::{DISTRIBUTED_NOTIF_NS, SUBSCRIBED_NOTIFICATIONS_NS, YANG_PUSH_NS};
+use crate::yang_push::{
+    DISTRIBUTED_NOTIF_NS, SUBSCRIBED_NOTIFICATIONS_NS, YANG_PUSH_NS, YANG_PUSH_REVISION,
+};
 use crate::yanglib::DatastoreName;
 use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
@@ -86,6 +88,10 @@ pub struct Subscription {
 
     #[serde(flatten)]
     pub update_trigger: Option<UpdateTrigger>,
+
+    #[serde(rename = "ietf-yang-push-revision:module-version")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module_version: Option<Box<[YangPushModuleVersion]>>,
 }
 
 impl Subscription {
@@ -104,6 +110,7 @@ impl Subscription {
             configured_subscription_state: None,
             message_publisher_id: None,
             update_trigger: None,
+            module_version: None,
         }
     }
 }
@@ -620,6 +627,13 @@ impl XmlSerialize for Subscription {
             trigger.xml_serialize(writer)?;
         }
 
+        // ypr:module-version
+        if let Some(module_version) = self.module_version.as_deref() {
+            for module_version in module_version {
+                module_version.xml_serialize(writer)?;
+            }
+        }
+
         writer.write_event(Event::End(elem.to_end()))?;
         if ns_added {
             writer.pop_namespace_binding();
@@ -644,6 +658,7 @@ impl<'a> XmlDeserialize<'a, Subscription> for Subscription {
         let mut configured_subscription_state = None;
         let mut message_publisher_ids: Option<Vec<u32>> = None;
         let mut update_trigger = None;
+        let mut module_versions: Option<Vec<YangPushModuleVersion>> = None;
 
         // Target pieces — collected separately because XML elements can
         // appear in any order and the target choice children are interleaved
@@ -783,12 +798,20 @@ impl<'a> XmlDeserialize<'a, Subscription> for Subscription {
                 }
                 parser.close()?;
             }
+            // ietf-yang-push-revision:module-version
+            else if parser.is_tag(Some(YANG_PUSH_REVISION), "module-version") {
+                let module_version = YangPushModuleVersion::xml_deserialize(parser)?;
+                if let Some(ref mut versions) = module_versions {
+                    versions.push(module_version);
+                } else {
+                    module_versions = Some(vec![module_version]);
+                }
+            }
             // ── Unknown / augmented element — skip gracefully ───────────
             else {
                 parser.skip()?;
             }
         }
-
         parser.close()?; // </subscription>
 
         let id = id.ok_or_else(|| ParsingError::WrongToken {
@@ -840,6 +863,7 @@ impl<'a> XmlDeserialize<'a, Subscription> for Subscription {
             configured_subscription_state,
             message_publisher_id: message_publisher_ids.map(|x| x.into_boxed_slice()),
             update_trigger,
+            module_version: module_versions.map(|x| x.into_boxed_slice()),
         })
     }
 }
@@ -918,33 +942,117 @@ pub struct YangPushModuleVersion {
     /// Alias 'module-name' still supported
     /// (draft-ietf-netconf-yang-notifications-versioning < 9)
     #[serde(alias = "module-name")]
-    pub name: String,
+    pub name: Box<str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revision: Option<String>,
+    pub revision: Option<Box<str>>,
 
     /// Alias 'revision-label' still supported
     /// (draft-ietf-netconf-yang-notifications-versioning < 9)
     #[serde(alias = "revision-label")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
+    pub version: Option<Box<str>>,
 }
 
 impl YangPushModuleVersion {
-    pub const fn new(name: String, revision: Option<String>, version: Option<String>) -> Self {
+    pub const fn new(
+        name: Box<str>,
+        revision: Option<Box<str>>,
+        version: Option<Box<str>>,
+    ) -> Self {
         Self {
             name,
             revision,
             version,
         }
     }
-    pub const fn name(&self) -> &str {
-        self.name.as_str()
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
     }
+
     pub fn revision(&self) -> Option<&str> {
         self.revision.as_deref()
     }
     pub fn version(&self) -> Option<&str> {
         self.version.as_deref()
+    }
+}
+
+impl XmlSerialize for YangPushModuleVersion {
+    fn xml_serialize<T: io::Write>(
+        &self,
+        writer: &mut XmlWriter<T>,
+    ) -> Result<(), quick_xml::Error> {
+        let mut ns_added = false;
+        if writer.get_namespace_prefix(YANG_PUSH_REVISION).is_none() {
+            ns_added = true;
+            writer
+                .push_namespace_binding(IndexMap::from([(YANG_PUSH_REVISION, "".to_string())]))?;
+        }
+        let module_version_start =
+            writer.create_ns_element(YANG_PUSH_REVISION, "module-version")?;
+        writer.write_event(Event::Start(module_version_start.clone()))?;
+        let name_start = writer.create_ns_element(YANG_PUSH_REVISION, "name")?;
+
+        writer.write_event(Event::Start(name_start.clone()))?;
+        writer.write_event(Event::Text(BytesText::new(self.name.as_ref())))?;
+        writer.write_event(Event::End(name_start.to_end()))?;
+
+        if let Some(revision) = &self.revision {
+            let revision_start = writer.create_ns_element(YANG_PUSH_REVISION, "revision")?;
+            writer.write_event(Event::Start(revision_start.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(revision.as_ref())))?;
+            writer.write_event(Event::End(revision_start.to_end()))?;
+        }
+        if let Some(version) = &self.version {
+            let version_start = writer.create_ns_element(YANG_PUSH_REVISION, "version")?;
+            writer.write_event(Event::Start(version_start.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(version.as_ref())))?;
+            writer.write_event(Event::End(version_start.to_end()))?;
+        }
+        writer.write_event(Event::End(module_version_start.to_end()))?;
+        if ns_added {
+            writer.pop_namespace_binding();
+        }
+        Ok(())
+    }
+}
+
+impl XmlDeserialize<'_, YangPushModuleVersion> for YangPushModuleVersion {
+    fn xml_deserialize(parser: &mut XmlParser<'_, impl io::BufRead>) -> Result<Self, ParsingError> {
+        parser.skip_text()?;
+        let module_version_start = parser.open(Some(YANG_PUSH_REVISION), "module-version")?;
+
+        let mut revision: Option<Box<str>> = None;
+        let mut version: Option<Box<str>> = None;
+
+        parser.skip_text()?;
+        parser.open(Some(YANG_PUSH_REVISION), "name")?;
+        let name = parser.tag_string()?.trim().into();
+        parser.close()?;
+
+        parser.skip_text()?;
+        if parser.is_tag(Some(YANG_PUSH_REVISION), "revision") {
+            parser.open(Some(YANG_PUSH_REVISION), "revision")?;
+            revision = Some(parser.tag_string()?.trim().into());
+            parser.close()?;
+        }
+        parser.skip_text()?;
+        if parser.is_tag(Some(YANG_PUSH_REVISION), "version") {
+            parser.open(Some(YANG_PUSH_REVISION), "version")?;
+            version = Some(parser.tag_string()?.trim().into());
+            parser.close()?;
+        }
+        while parser.peek() != &Event::End(module_version_start.to_end()) {
+            // skip any augmentation
+            parser.skip()?;
+        }
+        parser.close()?; // </module-version>
+
+        Ok(Self {
+            name,
+            revision,
+            version,
+        })
     }
 }

--- a/crates/netconf-proto/src/yang_push/subscription.rs
+++ b/crates/netconf-proto/src/yang_push/subscription.rs
@@ -92,6 +92,10 @@ pub struct Subscription {
     #[serde(rename = "ietf-yang-push-revision:module-version")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub module_version: Option<Box<[YangPushModuleVersion]>>,
+
+    #[serde(rename = "ietf-yang-push-revision:yang-library-content-id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub yang_library_content_id: Option<String>,
 }
 
 impl Subscription {
@@ -111,6 +115,7 @@ impl Subscription {
             message_publisher_id: None,
             update_trigger: None,
             module_version: None,
+            yang_library_content_id: None,
         }
     }
 }
@@ -634,6 +639,26 @@ impl XmlSerialize for Subscription {
             }
         }
 
+        // ypr:yang-library-content-id
+        if let Some(yang_library_content_id) = self.yang_library_content_id.as_deref() {
+            let mut ns_added = false;
+            if writer.get_namespace_prefix(YANG_PUSH_REVISION).is_none() {
+                ns_added = true;
+                writer.push_namespace_binding(IndexMap::from([(
+                    YANG_PUSH_REVISION,
+                    "ypr".to_string(),
+                )]))?;
+            }
+            let child = writer.create_ns_element(YANG_PUSH_REVISION, "yang-library-content-id")?;
+            writer.write_event(Event::Start(child.clone()))?;
+            writer.write_event(Event::Text(BytesText::new(yang_library_content_id)))?;
+            writer.write_event(Event::End(child.to_end()))?;
+
+            if ns_added {
+                writer.pop_namespace_binding();
+            }
+        }
+
         writer.write_event(Event::End(elem.to_end()))?;
         if ns_added {
             writer.pop_namespace_binding();
@@ -659,6 +684,7 @@ impl<'a> XmlDeserialize<'a, Subscription> for Subscription {
         let mut message_publisher_ids: Option<Vec<u32>> = None;
         let mut update_trigger = None;
         let mut module_versions: Option<Vec<YangPushModuleVersion>> = None;
+        let mut yang_library_content_id = None;
 
         // Target pieces — collected separately because XML elements can
         // appear in any order and the target choice children are interleaved
@@ -807,6 +833,12 @@ impl<'a> XmlDeserialize<'a, Subscription> for Subscription {
                     module_versions = Some(vec![module_version]);
                 }
             }
+            // ietf-yang-push-revision:yang-library-content-id
+            else if parser.is_tag(Some(YANG_PUSH_REVISION), "yang-library-content-id") {
+                parser.open(Some(YANG_PUSH_REVISION), "yang-library-content-id")?;
+                yang_library_content_id = Some(parser.tag_string()?.trim().into());
+                parser.close()?;
+            }
             // ── Unknown / augmented element — skip gracefully ───────────
             else {
                 parser.skip()?;
@@ -864,6 +896,7 @@ impl<'a> XmlDeserialize<'a, Subscription> for Subscription {
             message_publisher_id: message_publisher_ids.map(|x| x.into_boxed_slice()),
             update_trigger,
             module_version: module_versions.map(|x| x.into_boxed_slice()),
+            yang_library_content_id,
         })
     }
 }

--- a/crates/netconf-proto/src/yang_push/subscription.rs
+++ b/crates/netconf-proto/src/yang_push/subscription.rs
@@ -904,3 +904,47 @@ impl<'a> XmlDeserialize<'a, DatastoreSelectionFilterObjects> for DatastoreSelect
         }
     }
 }
+
+/// Module Versioning (draft-ietf-netconf-yang-notifications-versioning)
+///
+/// The `YangPushModuleVersion` structure provides information about YANG
+/// modules:
+/// - `name`: Module name
+/// - `revision`: Module revision date (e.g., "2025-04-25")
+/// - `version`: Semantic version label
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct YangPushModuleVersion {
+    /// Alias 'module-name' still supported
+    /// (draft-ietf-netconf-yang-notifications-versioning < 9)
+    #[serde(alias = "module-name")]
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+
+    /// Alias 'revision-label' still supported
+    /// (draft-ietf-netconf-yang-notifications-versioning < 9)
+    #[serde(alias = "revision-label")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+impl YangPushModuleVersion {
+    pub const fn new(name: String, revision: Option<String>, version: Option<String>) -> Self {
+        Self {
+            name,
+            revision,
+            version,
+        }
+    }
+    pub const fn name(&self) -> &str {
+        self.name.as_str()
+    }
+    pub fn revision(&self) -> Option<&str> {
+        self.revision.as_deref()
+    }
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
+    }
+}

--- a/crates/netconf-proto/src/yang_push/tests.rs
+++ b/crates/netconf-proto/src/yang_push/tests.rs
@@ -593,6 +593,7 @@ fn test_subscription() {
             ),
         }),
         module_version: None,
+        yang_library_content_id: None,
     };
 
     // Subscription with filter-by-reference, transport, encoding,
@@ -647,6 +648,7 @@ fn test_subscription() {
             ),
         }),
         module_version: None,
+        yang_library_content_id: None,
     };
 
     // Parse-only test for input_by_value (contains unknown elements that
@@ -714,6 +716,9 @@ fn test_subscription_yang_push_augments() {
           <revision>2024-02-02</revision>
           <version>3.0.0</version>
         </module-version>
+        <yang-library-content-id xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push-revision">
+          123
+        </yang-library-content-id>
     </subscription>"#;
 
     let expected_by_value = Subscription {
@@ -762,6 +767,7 @@ fn test_subscription_yang_push_augments() {
             ]
             .into_boxed_slice(),
         ),
+        yang_library_content_id: Some("123".into()),
     };
 
     test_xml_value(input_by_value, expected_by_value)

--- a/crates/netconf-proto/src/yang_push/tests.rs
+++ b/crates/netconf-proto/src/yang_push/tests.rs
@@ -592,6 +592,7 @@ fn test_subscription() {
                     .with_timezone(&Utc),
             ),
         }),
+        module_version: None,
     };
 
     // Subscription with filter-by-reference, transport, encoding,
@@ -645,6 +646,7 @@ fn test_subscription() {
                     .with_timezone(&Utc),
             ),
         }),
+        module_version: None,
     };
 
     // Parse-only test for input_by_value (contains unknown elements that
@@ -670,4 +672,128 @@ fn test_subscription() {
     // lose, so full serialize → deserialize → compare works).
     test_xml_value(input_by_reference, expected_by_reference)
         .expect("subscription by-reference round-trip failed");
+}
+
+#[test]
+fn test_subscription_yang_push_augments() {
+    let input_by_value = r#"<subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">
+        <id>3</id>
+        <datastore-xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+            openconfig-platform:components/component/state
+        </datastore-xpath-filter>
+        <datastore xmlns:idx="urn:ietf:params:xml:ns:yang:ietf-datastores"
+                   xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">idx:operational
+        </datastore>
+        <periodic xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">
+            <anchor-time>2025-01-01T00:00:30+00:00</anchor-time>
+            <period>360000</period>
+        </periodic>
+        <receivers>
+            <receiver>
+                <name>DAISY</name>
+                <receiver-instance-ref xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notif-receivers">DAISY
+                </receiver-instance-ref>
+            </receiver>
+        </receivers>
+        <source-interface>MgmtEth0/RP0/CPU0/0</source-interface>
+        <encoding xmlns:sn="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications">sn:encode-json</encoding>
+        <dscp>0</dscp>
+        <module-version xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push-revision">
+          <name>ietf-interfaces</name>
+        </module-version>
+        <module-version xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push-revision">
+          <name>example-module1</name>
+          <revision>2024-01-01</revision>
+        </module-version>
+        <module-version xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push-revision">
+          <name>example-module2</name>
+          <version>2.0.0</version>
+        </module-version>
+        <module-version xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push-revision">
+          <name>example-module3</name>
+          <revision>2024-02-02</revision>
+          <version>3.0.0</version>
+        </module-version>
+    </subscription>"#;
+
+    let expected_by_value = Subscription {
+        id: 3,
+        target: Target::Datastore(DatastoreTarget {
+            datastore: DatastoreName::Operational,
+            selection: DatastoreSelectionFilterObjects::WithInSubscription(
+                DatastoreFilterSpec::Xpath(DatastoreXPathFilter {
+                    namespaces: IndexMap::new(), /* no namespace prefixes declared for
+                                                  * "openconfig-platform" */
+                    path: "openconfig-platform:components/component/state".into(),
+                }),
+            ),
+        }),
+        stop_time: None,
+        dscp: Some(0),
+        weighting: None,
+        dependency: None,
+        transport: None,
+        encoding: Some(Encoding::Json),
+        purpose: None,
+        configured_subscription_state: None,
+        message_publisher_id: None,
+        update_trigger: Some(UpdateTrigger::Periodic {
+            period: Some(CentiSeconds::new(360000)),
+            anchor_time: Some(
+                DateTime::parse_from_rfc3339("2025-01-01T00:00:30+00:00")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+        }),
+        module_version: Some(
+            vec![
+                YangPushModuleVersion::new("ietf-interfaces".into(), None, None),
+                YangPushModuleVersion::new(
+                    "example-module1".into(),
+                    Some("2024-01-01".into()),
+                    None,
+                ),
+                YangPushModuleVersion::new("example-module2".into(), None, Some("2.0.0".into())),
+                YangPushModuleVersion::new(
+                    "example-module3".into(),
+                    Some("2024-02-02".into()),
+                    Some("3.0.0".into()),
+                ),
+            ]
+            .into_boxed_slice(),
+        ),
+    };
+
+    test_xml_value(input_by_value, expected_by_value)
+        .expect("subscription by-reference round-trip failed");
+}
+
+#[test]
+fn test_yang_push_module_version_json_serde() {
+    let json_legacy = serde_json::json!({
+        "module-name": "ietf-interfaces",
+        "revision": "2014-05-08",
+        "revision-label": "2.0.0",
+    });
+
+    let json_value = serde_json::json!({
+        "name": "ietf-interfaces",
+        "revision": "2014-05-08",
+        "version": "2.0.0",
+    });
+
+    let modeled = YangPushModuleVersion {
+        name: "ietf-interfaces".into(),
+        revision: Some("2014-05-08".into()),
+        version: Some("2.0.0".into()),
+    };
+
+    let serialized = serde_json::to_value(&modeled).unwrap();
+    assert_eq!(serialized, json_value);
+
+    let deserialized: YangPushModuleVersion = serde_json::from_value(json_legacy).unwrap();
+    assert_eq!(deserialized, modeled);
+
+    let deserialized: YangPushModuleVersion = serde_json::from_value(json_value).unwrap();
+    assert_eq!(deserialized, modeled);
 }

--- a/crates/udp-notif-pkt/src/decoded.rs
+++ b/crates/udp-notif-pkt/src/decoded.rs
@@ -211,12 +211,12 @@ mod tests {
     use super::*;
     use crate::notification::{
         NotificationEnvelope, NotificationLegacy, NotificationVariant, SubscriptionStartedModified,
-        Target, YangPushModuleVersion,
+        Target,
     };
     use bytes::Bytes;
     use chrono::{DateTime, Utc};
     use netgauze_netconf_proto::yang_push::identities::Encoding;
-    use netgauze_netconf_proto::yang_push::subscription::UpdateTrigger;
+    use netgauze_netconf_proto::yang_push::subscription::{UpdateTrigger, YangPushModuleVersion};
     use serde_json::json;
     use std::collections::HashMap;
 

--- a/crates/udp-notif-pkt/src/decoded.rs
+++ b/crates/udp-notif-pkt/src/decoded.rs
@@ -282,8 +282,8 @@ mod tests {
                 excluded_change: None,
             }),
             Some(vec![YangPushModuleVersion::new(
-                "openconfig-interfaces".to_string(),
-                Some("2025-06-10".to_string()),
+                "openconfig-interfaces".into(),
+                Some("2025-06-10".into()),
                 None,
             )]),
             None,

--- a/crates/udp-notif-pkt/src/notification.rs
+++ b/crates/udp-notif-pkt/src/notification.rs
@@ -208,7 +208,7 @@
 
 use chrono::{DateTime, Utc};
 use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
-use netgauze_netconf_proto::yang_push::subscription::UpdateTrigger;
+use netgauze_netconf_proto::yang_push::subscription::{UpdateTrigger, YangPushModuleVersion};
 use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -739,50 +739,6 @@ impl std::fmt::Display for Target {
             result.push(format!("datastore-xpath-filter: {datastore_xpath_filter}"));
         }
         write!(f, "{{ {} }}", result.join(", "))
-    }
-}
-
-/// Module Versioning (draft-ietf-netconf-yang-notifications-versioning)
-///
-/// The `YangPushModuleVersion` structure provides information about YANG
-/// modules:
-/// - `name`: Module name
-/// - `revision`: Module revision date (e.g., "2025-04-25")
-/// - `version`: Semantic version label
-#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub struct YangPushModuleVersion {
-    /// Alias 'module-name' still supported
-    /// (draft-ietf-netconf-yang-notifications-versioning < 9)
-    #[serde(alias = "module-name")]
-    name: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    revision: Option<String>,
-
-    /// Alias 'revision-label' still supported
-    /// (draft-ietf-netconf-yang-notifications-versioning < 9)
-    #[serde(alias = "revision-label")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    version: Option<String>,
-}
-
-impl YangPushModuleVersion {
-    pub const fn new(name: String, revision: Option<String>, version: Option<String>) -> Self {
-        Self {
-            name,
-            revision,
-            version,
-        }
-    }
-    pub const fn name(&self) -> &str {
-        self.name.as_str()
-    }
-    pub fn revision(&self) -> Option<&str> {
-        self.revision.as_deref()
-    }
-    pub fn version(&self) -> Option<&str> {
-        self.version.as_deref()
     }
 }
 

--- a/crates/udp-notif-pkt/src/notification.rs
+++ b/crates/udp-notif-pkt/src/notification.rs
@@ -839,8 +839,8 @@ mod tests {
                 excluded_change: Some(vec![ChangeType::Create, ChangeType::Replace]),
             }),
             module_version: Some(vec![YangPushModuleVersion {
-                name: "example-module".to_string(),
-                revision: Some("2025-04-25".to_string()),
+                name: "example-module".into(),
+                revision: Some("2025-04-25".into()),
                 version: None,
             }]),
             yang_library_content_id: Some("content-id".to_string()),
@@ -935,8 +935,8 @@ mod tests {
                 excluded_change: Some(vec![ChangeType::Create, ChangeType::Replace]),
             }),
             module_version: Some(vec![YangPushModuleVersion {
-                name: "example-module".to_string(),
-                revision: Some("2025-04-25".to_string()),
+                name: "example-module".into(),
+                revision: Some("2025-04-25".into()),
                 version: None,
             }]),
             yang_library_content_id: Some("content-id".to_string()),

--- a/crates/yang-push/src/model/telemetry.rs
+++ b/crates/yang-push/src/model/telemetry.rs
@@ -44,7 +44,7 @@ use chrono::{DateTime, Utc};
 
 use netgauze_netconf_proto::yang_push::identities::{ChangeType, Encoding, Transport};
 use netgauze_netconf_proto::yang_push::types::{CentiSeconds, SubscriptionId};
-use netgauze_udp_notif_pkt::notification::YangPushModuleVersion;
+use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::net::IpAddr;

--- a/crates/yang-push/src/model/telemetry.rs
+++ b/crates/yang-push/src/model/telemetry.rs
@@ -43,8 +43,8 @@
 use chrono::{DateTime, Utc};
 
 use netgauze_netconf_proto::yang_push::identities::{ChangeType, Encoding, Transport};
-use netgauze_netconf_proto::yang_push::types::{CentiSeconds, SubscriptionId};
 use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
+use netgauze_netconf_proto::yang_push::types::{CentiSeconds, SubscriptionId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::net::IpAddr;
@@ -614,11 +614,11 @@ mod tests {
                             anchor_time: Some(Utc.timestamp_millis_opt(0).unwrap()),
                         }),
                         module: vec![YangPushModuleVersion::new(
-                            "example-module".to_string(),
-                            Some("2025-01-01".to_string()),
-                            Some("1.0.0".to_string()),
+                            "example-module".into(),
+                            Some("2025-01-01".into()),
+                            Some("1.0.0".into()),
                         )],
-                        yang_library_content_id: Some("random-content-id".to_string()),
+                        yang_library_content_id: Some("random-content-id".into()),
                     }),
                 },
                 data_collection_manifest: Some(Manifest {
@@ -769,9 +769,9 @@ mod tests {
             excluded_change: Some(vec![ChangeType::Delete]),
         };
         let module = vec![YangPushModuleVersion::new(
-            "mod".to_string(),
-            Some("rev".to_string()),
-            Some("ver".to_string()),
+            "mod".into(),
+            Some("rev".into()),
+            Some("ver".into()),
         )];
         let metadata = YangPushSubscriptionMetadata::new(
             Some(1),


### PR DESCRIPTION
Currently there are two Subscriptions one in udp-notif-pkt and another in netconf-proto, this PR brings the one in netconf-proto closer to the one in udp-notif-pkt.