### PR TITLE
Fix typo in BmpMessageType::Experimental251 deserialization

### DIFF
--- a/crates/bmp-pkt/src/wire/deserializer/v3.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/v3.rs
@@ -100,16 +100,20 @@ impl<'a> ReadablePduWithOneInput<'a, &mut BmpParsingContext, LocatedBmpMessageVa
                 (buf, v3::BmpMessageValue::RouteMirroring(init))
             }
             BmpMessageType::Experimental251 => {
-                (buf, v3::BmpMessageValue::Experimental252(buf.to_vec()))
+                let (span, buf) = nom::bytes::complete::take(buf.len())(buf)?;
+                (span, v3::BmpMessageValue::Experimental251(buf.to_vec()))
             }
             BmpMessageType::Experimental252 => {
-                (buf, v3::BmpMessageValue::Experimental252(buf.to_vec()))
+                let (span, buf) = nom::bytes::complete::take(buf.len())(buf)?;
+                (span, v3::BmpMessageValue::Experimental252(buf.to_vec()))
             }
             BmpMessageType::Experimental253 => {
-                (buf, v3::BmpMessageValue::Experimental253(buf.to_vec()))
+                let (span, buf) = nom::bytes::complete::take(buf.len())(buf)?;
+                (span, v3::BmpMessageValue::Experimental253(buf.to_vec()))
             }
             BmpMessageType::Experimental254 => {
-                (buf, v3::BmpMessageValue::Experimental254(buf.to_vec()))
+                let (span, buf) = nom::bytes::complete::take(buf.len())(buf)?;
+                (span, v3::BmpMessageValue::Experimental254(buf.to_vec()))
             }
         };
         Ok((buf, msg))

--- a/crates/bmp-pkt/src/wire/deserializer/v4.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/v4.rs
@@ -108,16 +108,20 @@ impl<'a> ReadablePduWithOneInput<'a, &mut BmpParsingContext, LocatedBmpMessageVa
                 (buf, v4::BmpMessageValue::RouteMirroring(init))
             }
             BmpMessageType::Experimental251 => {
-                (buf, v4::BmpMessageValue::Experimental252(buf.to_vec()))
+                let (span, buf) = nom::bytes::complete::take(buf.len())(buf)?;
+                (span, v4::BmpMessageValue::Experimental251(buf.to_vec()))
             }
             BmpMessageType::Experimental252 => {
-                (buf, v4::BmpMessageValue::Experimental252(buf.to_vec()))
+                let (span, buf) = nom::bytes::complete::take(buf.len())(buf)?;
+                (span, v4::BmpMessageValue::Experimental252(buf.to_vec()))
             }
             BmpMessageType::Experimental253 => {
-                (buf, v4::BmpMessageValue::Experimental253(buf.to_vec()))
+                let (span, buf) = nom::bytes::complete::take(buf.len())(buf)?;
+                (span, v4::BmpMessageValue::Experimental253(buf.to_vec()))
             }
             BmpMessageType::Experimental254 => {
-                (buf, v4::BmpMessageValue::Experimental254(buf.to_vec()))
+                let (span, buf) = nom::bytes::complete::take(buf.len())(buf)?;
+                (span, v4::BmpMessageValue::Experimental254(buf.to_vec()))
             }
         };
         Ok((buf, msg))

--- a/crates/bmp-pkt/src/wire/tests/v3.rs
+++ b/crates/bmp-pkt/src/wire/tests/v3.rs
@@ -1665,3 +1665,78 @@ fn test_bmp_route_monitoring_unaligned_prefix() -> Result<(), BmpMessageWritingE
     test_write(&good, &good_wire)?;
     Ok(())
 }
+
+#[test]
+fn test_bmp_value_experimental_messages() -> Result<(), BmpMessageValueWritingError> {
+    let good_251_wire = [
+        0xfb, 0x00, 0x01, 0x00, 0x06, 0x74, 0x65, 0x73, 0x74, 0x31, 0x31, 0x00, 0x02, 0x00, 0x03,
+        0x50, 0x45, 0x32,
+    ];
+    let good_252_wire = [
+        0xfc, 0x00, 0x01, 0x00, 0x06, 0x74, 0x65, 0x73, 0x74, 0x31, 0x31, 0x00, 0x02, 0x00, 0x03,
+        0x50, 0x45, 0x32,
+    ];
+    let good_253_wire = [
+        0xfd, 0x00, 0x01, 0x00, 0x06, 0x74, 0x65, 0x73, 0x74, 0x31, 0x31, 0x00, 0x02, 0x00, 0x03,
+        0x50, 0x45, 0x32,
+    ];
+    let good_254_wire = [
+        0xfe, 0x00, 0x01, 0x00, 0x06, 0x74, 0x65, 0x73, 0x74, 0x31, 0x31, 0x00, 0x02, 0x00, 0x03,
+        0x50, 0x45, 0x32,
+    ];
+
+    let good_251 = BmpMessageValue::Experimental251(good_251_wire[1..].to_vec());
+    let good_252 = BmpMessageValue::Experimental252(good_252_wire[1..].to_vec());
+    let good_253 = BmpMessageValue::Experimental253(good_253_wire[1..].to_vec());
+    let good_254 = BmpMessageValue::Experimental254(good_254_wire[1..].to_vec());
+
+    test_parsed_completely_with_one_input(&good_251_wire, &mut Default::default(), &good_251);
+    test_parsed_completely_with_one_input(&good_252_wire, &mut Default::default(), &good_252);
+    test_parsed_completely_with_one_input(&good_253_wire, &mut Default::default(), &good_253);
+    test_parsed_completely_with_one_input(&good_254_wire, &mut Default::default(), &good_254);
+
+    test_write(&good_251, &good_251_wire)?;
+    test_write(&good_252, &good_252_wire)?;
+    test_write(&good_253, &good_253_wire)?;
+    test_write(&good_254, &good_254_wire)?;
+    Ok(())
+}
+
+#[test]
+fn test_bmp_experimental() -> Result<(), BmpMessageWritingError> {
+    let good_251_wire = [
+        0x03, 0x00, 0x00, 0x00, 0x0c, 0xfb, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+    ];
+    let good_252_wire = [
+        0x03, 0x00, 0x00, 0x00, 0x0b, 0xfc, 0x06, 0x07, 0x08, 0x09, 0x0a,
+    ];
+    let good_253_wire = [
+        0x03, 0x00, 0x00, 0x00, 0x0d, 0xfd, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+    ];
+    let good_254_wire = [0x03, 0x00, 0x00, 0x00, 0x06, 0xfe];
+
+    let good_251 = BmpMessage::V3(BmpMessageValue::Experimental251(
+        good_251_wire[6..].to_vec(),
+    ));
+    let good_252 = BmpMessage::V3(BmpMessageValue::Experimental252(
+        good_252_wire[6..].to_vec(),
+    ));
+    let good_253 = BmpMessage::V3(BmpMessageValue::Experimental253(
+        good_253_wire[6..].to_vec(),
+    ));
+    let good_254 = BmpMessage::V3(BmpMessageValue::Experimental254(
+        good_254_wire[6..].to_vec(),
+    ));
+
+    test_parsed_completely_with_one_input(&good_251_wire, &mut Default::default(), &good_251);
+    test_parsed_completely_with_one_input(&good_252_wire, &mut Default::default(), &good_252);
+    test_parsed_completely_with_one_input(&good_253_wire, &mut Default::default(), &good_253);
+    test_parsed_completely_with_one_input(&good_254_wire, &mut Default::default(), &good_254);
+
+    test_write(&good_251, &good_251_wire)?;
+    test_write(&good_252, &good_252_wire)?;
+    test_write(&good_253, &good_253_wire)?;
+    test_write(&good_254, &good_254_wire)?;
+
+    Ok(())
+}

--- a/crates/bmp-pkt/src/wire/tests/v4.rs
+++ b/crates/bmp-pkt/src/wire/tests/v4.rs
@@ -19,6 +19,7 @@ use crate::wire::deserializer::{
     BmpMessageParsingError, BmpParsingContext, LocatedBmpMessageParsingError,
 };
 use crate::wire::serializer::BmpMessageWritingError;
+use crate::wire::serializer::v4::BmpMessageValueWritingError;
 use crate::*;
 #[cfg(not(feature = "fuzz"))]
 use chrono::TimeZone;
@@ -806,4 +807,79 @@ fn test_path_status_with_unknown_bits() {
     // Deserialize back - unknown bits should be preserved
     let deserialized: PathStatus = serde_json::from_str(&json).unwrap();
     assert_eq!(status, deserialized);
+}
+
+#[test]
+fn test_bmp_value_experimental_messages() -> Result<(), BmpMessageValueWritingError> {
+    let good_251_wire = [
+        0xfb, 0x00, 0x01, 0x00, 0x06, 0x74, 0x65, 0x73, 0x74, 0x31, 0x31, 0x00, 0x02, 0x00, 0x03,
+        0x50, 0x45, 0x32,
+    ];
+    let good_252_wire = [
+        0xfc, 0x00, 0x01, 0x00, 0x06, 0x74, 0x65, 0x73, 0x74, 0x31, 0x31, 0x00, 0x02, 0x00, 0x03,
+        0x50, 0x45, 0x32,
+    ];
+    let good_253_wire = [
+        0xfd, 0x00, 0x01, 0x00, 0x06, 0x74, 0x65, 0x73, 0x74, 0x31, 0x31, 0x00, 0x02, 0x00, 0x03,
+        0x50, 0x45, 0x32,
+    ];
+    let good_254_wire = [
+        0xfe, 0x00, 0x01, 0x00, 0x06, 0x74, 0x65, 0x73, 0x74, 0x31, 0x31, 0x00, 0x02, 0x00, 0x03,
+        0x50, 0x45, 0x32,
+    ];
+
+    let good_251 = BmpMessageValue::Experimental251(good_251_wire[1..].to_vec());
+    let good_252 = BmpMessageValue::Experimental252(good_252_wire[1..].to_vec());
+    let good_253 = BmpMessageValue::Experimental253(good_253_wire[1..].to_vec());
+    let good_254 = BmpMessageValue::Experimental254(good_254_wire[1..].to_vec());
+
+    test_parsed_completely_with_one_input(&good_251_wire, &mut Default::default(), &good_251);
+    test_parsed_completely_with_one_input(&good_252_wire, &mut Default::default(), &good_252);
+    test_parsed_completely_with_one_input(&good_253_wire, &mut Default::default(), &good_253);
+    test_parsed_completely_with_one_input(&good_254_wire, &mut Default::default(), &good_254);
+
+    test_write(&good_251, &good_251_wire)?;
+    test_write(&good_252, &good_252_wire)?;
+    test_write(&good_253, &good_253_wire)?;
+    test_write(&good_254, &good_254_wire)?;
+    Ok(())
+}
+
+#[test]
+fn test_bmp_experimental() -> Result<(), BmpMessageWritingError> {
+    let good_251_wire = [
+        0x04, 0x00, 0x00, 0x00, 0x0c, 0xfb, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+    ];
+    let good_252_wire = [
+        0x04, 0x00, 0x00, 0x00, 0x0b, 0xfc, 0x06, 0x07, 0x08, 0x09, 0x0a,
+    ];
+    let good_253_wire = [
+        0x04, 0x00, 0x00, 0x00, 0x0d, 0xfd, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+    ];
+    let good_254_wire = [0x04, 0x00, 0x00, 0x00, 0x06, 0xfe];
+
+    let good_251 = BmpMessage::V4(BmpMessageValue::Experimental251(
+        good_251_wire[6..].to_vec(),
+    ));
+    let good_252 = BmpMessage::V4(BmpMessageValue::Experimental252(
+        good_252_wire[6..].to_vec(),
+    ));
+    let good_253 = BmpMessage::V4(BmpMessageValue::Experimental253(
+        good_253_wire[6..].to_vec(),
+    ));
+    let good_254 = BmpMessage::V4(BmpMessageValue::Experimental254(
+        good_254_wire[6..].to_vec(),
+    ));
+
+    test_parsed_completely_with_one_input(&good_251_wire, &mut Default::default(), &good_251);
+    test_parsed_completely_with_one_input(&good_252_wire, &mut Default::default(), &good_252);
+    test_parsed_completely_with_one_input(&good_253_wire, &mut Default::default(), &good_253);
+    test_parsed_completely_with_one_input(&good_254_wire, &mut Default::default(), &good_254);
+
+    test_write(&good_251, &good_251_wire)?;
+    test_write(&good_252, &good_252_wire)?;
+    test_write(&good_253, &good_253_wire)?;
+    test_write(&good_254, &good_254_wire)?;
+
+    Ok(())
 }


### PR DESCRIPTION
- Fix typo in deserializing BmpMessageType::Experimental251 as 252.
- Improve buffer handling for Experimental BMP message types
- Add more tests for experimental BMP message types