### PR TITLE
Replace YANG enrichment with direct conversion from subscription info

### DIFF
--- a/assets/yang/ietf-interfaces/subscriptions-info.json
+++ b/assets/yang/ietf-interfaces/subscriptions-info.json
@@ -9,6 +9,11 @@
     "transport": "ietf-udp-notif-transport:udp-notif",
     "encoding": "ietf-subscribed-notifications:encode-json",
     "purpose": "test subscription",
+    "update_trigger": {
+      "ietf-yang-push:periodic": {
+        "period": 6000
+      }
+    },
     "models": [
       {
         "name": "ietf-interfaces",

--- a/assets/yang/ietf-interfaces/subscriptions-info.json
+++ b/assets/yang/ietf-interfaces/subscriptions-info.json
@@ -8,8 +8,13 @@
       "ietf-yang-push:datastore-xpath-filter": "/ietf-interfaces:interfaces"
     },
     "models": [
-      "ietf-interfaces",
-      "ietf-subscribed-notifications"
+      {
+        "name": "ietf-interfaces",
+        "revision": "2018-02-20"
+      },
+      {
+        "name": "ietf-subscribed-notifications"
+      }
     ]
   }
 ]

--- a/assets/yang/ietf-interfaces/subscriptions-info.json
+++ b/assets/yang/ietf-interfaces/subscriptions-info.json
@@ -2,11 +2,13 @@
   {
     "peer": "0.0.0.0:830",
     "id": 1,
-    "content_id": "test-content-id-1",
     "target": {
       "ietf-yang-push:datastore": "ietf-datastores:operational",
       "ietf-yang-push:datastore-xpath-filter": "/ietf-interfaces:interfaces"
     },
+    "transport": "ietf-udp-notif-transport:udp-notif",
+    "encoding": "ietf-subscribed-notifications:encode-json",
+    "purpose": "test subscription",
     "models": [
       {
         "name": "ietf-interfaces",
@@ -15,6 +17,7 @@
       {
         "name": "ietf-subscribed-notifications"
       }
-    ]
+    ],
+    "content_id": "test-content-id-1"
   }
 ]

--- a/crates/collector/src/lib.rs
+++ b/crates/collector/src/lib.rs
@@ -40,13 +40,15 @@ use netgauze_yang_push::ContentId;
 use netgauze_yang_push::cache::actor::CacheActorHandle;
 use netgauze_yang_push::cache::fetcher::NetconfYangLibraryFetcher;
 use netgauze_yang_push::cache::storage::SubscriptionInfo;
-use netgauze_yang_push::model::telemetry::TelemetryMessageWrapper;
+use netgauze_yang_push::model::telemetry::{Manifest, TelemetryMessageWrapper};
 use netgauze_yang_push::validation::ValidationActorHandle;
+use shadow_rs::shadow;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::str::Utf8Error;
 use std::sync::Arc;
 use std::time::Duration;
+use sysinfo::System;
 use tracing::{debug, info, warn};
 
 pub mod bmp;
@@ -55,6 +57,8 @@ pub mod flow;
 pub mod inputs;
 pub mod publishers;
 pub mod yang_push;
+
+shadow!(build);
 
 pub async fn init_flow_collection(
     flow_config: FlowConfig,
@@ -627,8 +631,8 @@ pub async fn init_udp_notif_collection(
                     let (enrichment_join, enrichment_handle) = YangPushEnrichmentActorHandle::new(
                         publisher_config.buffer_size,
                         validated_rx,
+                        fetch_sysinfo_manifest(Some(config.writer_id.clone())),
                         either::Left(meter.clone()),
-                        config.writer_id.clone(),
                     );
                     join_set.push(enrichment_join);
                     publisher_enrichment_handles.push(enrichment_handle.clone());
@@ -702,8 +706,8 @@ pub async fn init_udp_notif_collection(
                     let (enrichment_join, enrichment_handle) = YangPushEnrichmentActorHandle::new(
                         publisher_config.buffer_size,
                         validated_rx,
+                        fetch_sysinfo_manifest(Some(config.writer_id.clone())),
                         either::Left(meter.clone()),
-                        config.writer_id.clone(),
                     );
                     join_set.push(enrichment_join);
                     publisher_enrichment_handles.push(enrichment_handle.clone());
@@ -1015,6 +1019,29 @@ fn netconf_fetcher(config: &NetconfConfig) -> Result<NetconfYangLibraryFetcher, 
         Duration::from_secs(100),
     );
     Ok(fetcher)
+}
+
+/// Fetches local system information into a Manifest object.
+/// (host name, OS version, software version, build info, etc.)
+pub(crate) fn fetch_sysinfo_manifest(name: Option<String>) -> Manifest {
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    Manifest::new(
+        name.filter(|n| !n.is_empty()).or_else(|| {
+            Some(format!(
+                "{}@{}",
+                build::PROJECT_NAME,
+                System::host_name().unwrap_or_else(|| "unknown".to_string())
+            ))
+        }),
+        Some("NetGauze".to_string()),
+        Some(3746), // Swisscom AG (temp until NetGauze has its own PEN number)
+        Some(format!("{} ({})", build::PKG_VERSION, build::SHORT_COMMIT)),
+        Some(build::BUILD_RUST_CHANNEL.to_string()),
+        System::os_version(),
+        System::name(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/collector/src/yang_push/config.rs
+++ b/crates/collector/src/yang_push/config.rs
@@ -143,6 +143,7 @@ impl
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
     use netgauze_yang_push::model::telemetry::*;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
@@ -155,7 +156,7 @@ mod tests {
                 "ietf-datastores:operational".to_string(),
                 either::Right("/test-path".to_string()),
             ),
-            vec!["test-module".to_string()],
+            Box::new([YangPushModuleVersion::new("test-module".into(), None, None)]),
         )
     }
 

--- a/crates/collector/src/yang_push/config.rs
+++ b/crates/collector/src/yang_push/config.rs
@@ -143,6 +143,7 @@ impl
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
     use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
     use netgauze_yang_push::model::telemetry::*;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -151,12 +152,16 @@ mod tests {
         SubscriptionInfo::new(
             SocketAddr::new(ip, 8080),
             1,
-            "test-content-id".to_string(),
             netgauze_udp_notif_pkt::notification::Target::new_datastore(
                 "ietf-datastores:operational".to_string(),
                 either::Right("/test-path".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            None,
             Box::new([YangPushModuleVersion::new("test-module".into(), None, None)]),
+            "test-content-id".to_string(),
         )
     }
 

--- a/crates/collector/src/yang_push/config.rs
+++ b/crates/collector/src/yang_push/config.rs
@@ -160,6 +160,13 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             None,
+            Some(
+                netgauze_netconf_proto::yang_push::subscription::UpdateTrigger::OnChange {
+                    dampening_period: None,
+                    sync_on_start: Some(true),
+                    excluded_change: None,
+                },
+            ),
             Box::new([YangPushModuleVersion::new("test-module".into(), None, None)]),
             "test-content-id".to_string(),
         )

--- a/crates/collector/src/yang_push/enrichment.rs
+++ b/crates/collector/src/yang_push/enrichment.rs
@@ -1064,16 +1064,20 @@ mod tests {
         let subscription_info = SubscriptionInfo::new(
             peer,
             1,
-            "test-content-id".to_string(),
             Target::new_datastore(
                 "ds:operational".to_string(),
                 either::Right("/ietf-interfaces".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            None,
             Box::new([YangPushModuleVersion::new(
                 "ietf-interfaces".into(),
                 Some("2018-02-20".into()),
                 None,
             )]),
+            "test-content-id".to_string(),
         );
         // Attempt to decode the packet (should succeed)
         let decoded: UdpNotifPacketDecoded = (&packet).try_into().unwrap();

--- a/crates/collector/src/yang_push/enrichment.rs
+++ b/crates/collector/src/yang_push/enrichment.rs
@@ -597,7 +597,7 @@ mod tests {
     use bytes::Bytes;
     use chrono::TimeZone;
     use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
-    use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
+    use netgauze_netconf_proto::yang_push::subscription::{UpdateTrigger, YangPushModuleVersion};
     use netgauze_netconf_proto::yang_push::types::SubscriptionId;
     use netgauze_netconf_proto::yanglib::DatastoreName;
     use netgauze_udp_notif_pkt::decoded::UdpNotifPacketDecoded;
@@ -698,6 +698,11 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             None,
+            Some(UpdateTrigger::OnChange {
+                dampening_period: None,
+                sync_on_start: Some(true),
+                excluded_change: None,
+            }),
             Box::new([YangPushModuleVersion::new(
                 "openconfig-interface".into(),
                 Some("2025-06-10".into()),

--- a/crates/collector/src/yang_push/enrichment.rs
+++ b/crates/collector/src/yang_push/enrichment.rs
@@ -34,35 +34,22 @@ use crate::yang_push::{
     DeleteAllPayload, DeletePayload, EnrichmentOperation, UpsertPayload, Weight,
 };
 use chrono::Utc;
-use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_udp_notif_pkt::decoded::{UdpNotifPacketDecoded, UdpNotifPayload};
-use netgauze_udp_notif_pkt::notification::{
-    NotificationVariant, SubscriptionStartedModified, SubscriptionTerminated,
-};
 use netgauze_udp_notif_service::OTL_UDP_NOTIF_PUBLISHER_ID_KEY;
 use netgauze_yang_push::cache::storage::SubscriptionInfo;
 use netgauze_yang_push::model::telemetry::{
-    EventType, FilterSpec, Label, Manifest, NetworkOperatorMetadata, SessionProtocol,
-    TelemetryMessage, TelemetryMessageMetadata, TelemetryMessageWrapper,
-    YangPushSubscriptionMetadata,
+    EventType, Label, Manifest, NetworkOperatorMetadata, SessionProtocol, TelemetryMessage,
+    TelemetryMessageMetadata, TelemetryMessageWrapper, YangPushSubscriptionMetadata,
 };
 use netgauze_yang_push::{
     ContentId, OTL_YANG_PUSH_CACHED_CONTENT_ID_KEY, OTL_YANG_PUSH_SUBSCRIPTION_ID_KEY,
     OTL_YANG_PUSH_SUBSCRIPTION_ROUTER_CONTENT_ID_KEY, OTL_YANG_PUSH_SUBSCRIPTION_TARGET_KEY,
 };
-use serde_json::Value;
-use shadow_rs::shadow;
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
-use sysinfo::System;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, trace, warn};
-
-shadow!(build);
-
-/// Cache for YangPush subscriptions metadata
-pub type SubscriptionsCache = HashMap<SubscriptionId, YangPushSubscriptionMetadata>;
+use tracing::{debug, error, info, warn};
 
 /// Weighted Label for Enrichment Cache
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -162,29 +149,6 @@ impl YangPushEnrichmentStats {
     }
 }
 
-/// Fetches local system information into a Manifest object.
-/// (host name, OS version, software version, build info, etc.)
-fn fetch_sysinfo_manifest(name: Option<String>) -> Manifest {
-    let mut sys = System::new_all();
-    sys.refresh_all();
-
-    Manifest::new(
-        name.filter(|n| !n.is_empty()).or_else(|| {
-            Some(format!(
-                "{}@{}",
-                build::PROJECT_NAME,
-                System::host_name().unwrap_or_else(|| "unknown".to_string())
-            ))
-        }),
-        Some("NetGauze".to_string()),
-        Some(3746), // Swisscom AG (temp until NetGauze has its own PEN number)
-        Some(format!("{} ({})", build::PKG_VERSION, build::SHORT_COMMIT)),
-        Some(build::BUILD_RUST_CHANNEL.to_string()),
-        System::os_version(),
-        System::name(),
-    )
-}
-
 /// Actor responsible for enriching Yang Push notifications.
 /// Sends enriched TelemetryMessage objects.
 struct YangPushEnrichmentActor {
@@ -195,7 +159,6 @@ struct YangPushEnrichmentActor {
     enriched_tx:
         async_channel::Sender<(Option<ContentId>, SubscriptionInfo, TelemetryMessageWrapper)>,
     labels: HashMap<IpAddr, HashMap<String, WeightedLabel>>,
-    subscriptions: HashMap<SocketAddr, SubscriptionsCache>,
     manifest: Manifest,
     stats: YangPushEnrichmentStats,
 }
@@ -214,8 +177,8 @@ impl YangPushEnrichmentActor {
             SubscriptionInfo,
             TelemetryMessageWrapper,
         )>,
+        manifest: Manifest,
         stats: YangPushEnrichmentStats,
-        writer_id: String,
     ) -> Self {
         Self {
             cmd_rx,
@@ -223,8 +186,7 @@ impl YangPushEnrichmentActor {
             enrichment_rx,
             enriched_tx,
             labels: HashMap::new(),
-            subscriptions: HashMap::new(),
-            manifest: fetch_sysinfo_manifest(Some(writer_id)),
+            manifest,
             stats,
         }
     }
@@ -371,247 +333,6 @@ impl YangPushEnrichmentActor {
         }
     }
 
-    /// Caches metadata from SubscriptionStarted and SubscriptionModified
-    /// messages.
-    fn cache_subscription(
-        &mut self,
-        peer: SocketAddr,
-        sub: &SubscriptionStartedModified,
-    ) -> Result<Option<YangPushSubscriptionMetadata>, YangPushEnrichmentActorError> {
-        let stream = sub.target().stream().map(|f| f.to_string());
-
-        let datastore = sub.target().datastore().map(|f| f.to_string());
-
-        let xpath_filter: Option<String> = sub
-            .target()
-            .datastore_xpath_filter()
-            .map(|f| f.to_string())
-            .or_else(|| sub.target().stream_xpath_filter().map(|f| f.to_string()));
-
-        let subtree_filter: Option<Value> = sub
-            .target()
-            .datastore_subtree_filter()
-            .cloned()
-            .or_else(|| sub.target().stream_subtree_filter().cloned());
-
-        let filter_spec = FilterSpec::new(stream, datastore, xpath_filter, subtree_filter);
-
-        let subscription_metadata = YangPushSubscriptionMetadata::new(
-            Some(sub.id()),
-            filter_spec,
-            sub.stop_time().cloned(),
-            sub.transport().cloned(),
-            sub.encoding().cloned(),
-            sub.purpose().map(|id| id.to_string()),
-            sub.update_trigger().cloned().map(Into::into),
-            sub.module_version().cloned().unwrap_or_default(),
-            sub.yang_library_content_id().map(|id| id.to_string()),
-        );
-
-        // Insert the subscription metadata into the cache
-        let peer_subscriptions = self.subscriptions.entry(peer).or_default();
-        peer_subscriptions.insert(sub.id(), subscription_metadata.clone());
-
-        // Update the gauge tracking per-peer subscriptions
-        self.stats
-            .update_peer_subscriptions_gauge(&peer, peer_subscriptions.len());
-
-        trace!(
-            "Yang Push Subscription Cache: {}",
-            serde_json::to_string(&self.subscriptions).unwrap()
-        );
-
-        Ok(Some(subscription_metadata))
-    }
-
-    /// Handles SubscriptionTerminated messages by removing subscription
-    /// metadata from the cache.
-    fn delete_subscription(
-        &mut self,
-        peer: SocketAddr,
-        sub: &SubscriptionTerminated,
-    ) -> Result<Option<YangPushSubscriptionMetadata>, YangPushEnrichmentActorError> {
-        // Get and delete subscription information from the cache
-        let subscription_metadata = self
-            .subscriptions
-            .get_mut(&peer)
-            .and_then(|subscriptions| subscriptions.remove(&sub.id()));
-
-        // Increment counter if there was a cache miss
-        if subscription_metadata.is_none() {
-            let peer_tags = [
-                opentelemetry::KeyValue::new("network.peer.address", format!("{}", peer.ip())),
-                opentelemetry::KeyValue::new(
-                    "network.peer.port",
-                    opentelemetry::Value::I64(peer.port().into()),
-                ),
-                opentelemetry::KeyValue::new(
-                    OTL_YANG_PUSH_SUBSCRIPTION_ID_KEY,
-                    opentelemetry::Value::I64(sub.id().into()),
-                ),
-            ];
-            self.stats.subscription_cache_miss.add(1, &peer_tags);
-        }
-
-        // Update the gauge tracking per-peer subscriptions
-        if let Some(subscriptions) = self.subscriptions.get(&peer) {
-            self.stats
-                .update_peer_subscriptions_gauge(&peer, subscriptions.len());
-        } else {
-            self.stats.update_peer_subscriptions_gauge(&peer, 0);
-        }
-
-        debug!(
-            "Yang Push Subscription Cache: {}",
-            serde_json::to_string(&self.subscriptions).unwrap()
-        );
-
-        Ok(subscription_metadata)
-    }
-
-    /// Retrieves subscription metadata from the cache based on the peer address
-    /// and subscription ID.
-    fn get_subscription(
-        &self,
-        peer: SocketAddr,
-        subscription_id: SubscriptionId,
-    ) -> Result<Option<YangPushSubscriptionMetadata>, YangPushEnrichmentActorError> {
-        // Get subscription information from the cache
-        let subscription_metadata = self
-            .subscriptions
-            .get(&peer)
-            .and_then(|subscriptions| subscriptions.get(&subscription_id))
-            .cloned();
-
-        // Increment counter if there was a cache miss
-        if subscription_metadata.is_none() {
-            let peer_tags = [
-                opentelemetry::KeyValue::new("network.peer.address", format!("{}", peer.ip())),
-                opentelemetry::KeyValue::new(
-                    "network.peer.port",
-                    opentelemetry::Value::I64(peer.port().into()),
-                ),
-                opentelemetry::KeyValue::new(
-                    OTL_YANG_PUSH_SUBSCRIPTION_ID_KEY,
-                    opentelemetry::Value::I64(subscription_id.into()),
-                ),
-            ];
-            self.stats.subscription_cache_miss.add(1, &peer_tags);
-        }
-
-        Ok(subscription_metadata)
-    }
-
-    /// Processes Notification and returns the relevant TelemetryMessageMetadata
-    fn process_notification(
-        &mut self,
-        content_id: Option<&ContentId>,
-        subscription_info: &SubscriptionInfo,
-        decoded_packet: &UdpNotifPacketDecoded,
-    ) -> Result<Option<YangPushSubscriptionMetadata>, YangPushEnrichmentActorError> {
-        let peer = subscription_info.peer();
-        let message_id = decoded_packet.message_id();
-        let publisher_id = decoded_packet.publisher_id();
-        let cached_content_id = content_id.map_or("", |v| v);
-        let notification_type = decoded_packet
-            .notification_type()
-            .map(|nt| nt.to_string())
-            .unwrap_or("UNKNOWN".to_string());
-
-        let notification = match decoded_packet.payload() {
-            UdpNotifPayload::NotificationEnvelope(envelope) => envelope.contents(),
-            UdpNotifPayload::NotificationLegacy(notif) => notif.notification(),
-        };
-        match notification {
-            Some(NotificationVariant::SubscriptionStarted(sub_started)) => {
-                debug!(
-                    peer=%peer,
-                    message_id,
-                    publisher_id,
-                    subscription_id=sub_started.id(),
-                    router_content_id=sub_started.yang_library_content_id(),
-                    target=%sub_started.target(),
-                    notification_type,
-                    cached_content_id,
-                    "Received Subscription Started Message",
-
-                );
-                self.cache_subscription(peer, sub_started)
-            }
-            Some(NotificationVariant::SubscriptionModified(sub_modified)) => {
-                debug!(
-                    peer=%peer,
-                    message_id,
-                    publisher_id,
-                    subscription_id=sub_modified.id(),
-                    router_content_id=sub_modified.yang_library_content_id(),
-                    target=%sub_modified.target(),
-                    notification_type,
-                    cached_content_id,
-                    "Received Subscription Modified Message",
-                );
-                self.cache_subscription(peer, sub_modified)
-            }
-            Some(NotificationVariant::SubscriptionTerminated(sub_terminated)) => {
-                debug!(
-                    peer=%peer,
-                    message_id,
-                    publisher_id,
-                    subscription_id=sub_terminated.id(),
-                    router_content_id=subscription_info.content_id(),
-                    target=%subscription_info.target(),
-                    termination_reason=sub_terminated.reason(),
-                    notification_type,
-                    cached_content_id,
-                    "Received Subscription Terminated Message",
-                );
-                self.delete_subscription(peer, sub_terminated)
-            }
-            Some(NotificationVariant::YangPushUpdate(push_update)) => {
-                trace!(
-                    peer=%peer,
-                    message_id,
-                    publisher_id,
-                    subscription_id=push_update.id(),
-                    router_content_id=subscription_info.content_id(),
-                    target=%subscription_info.target(),
-                    notification_type,
-                    cached_content_id,
-                    "Received Yang Push Update Message",
-                );
-                self.get_subscription(peer, push_update.id())
-            }
-            Some(NotificationVariant::YangPushChangeUpdate(push_change_update)) => {
-                trace!(
-                    peer=%peer,
-                    message_id,
-                    publisher_id,
-                    subscription_id=push_change_update.id(),
-                    router_content_id=subscription_info.content_id(),
-                    target=%subscription_info.target(),
-                    notification_type,
-                    cached_content_id,
-                    "Received Yang Push Change Update Message",
-                );
-                self.get_subscription(peer, push_change_update.id())
-            }
-            None => {
-                warn!(
-                 peer=%peer,
-                    message_id,
-                    publisher_id,
-                    subscription_id=subscription_info.id(),
-                    router_content_id=subscription_info.content_id(),
-                    target=%subscription_info.target(),
-                    notification_type,
-                    cached_content_id,
-                    "Received Notification Message without content",
-                );
-                Err(YangPushEnrichmentActorError::NotificationWithoutContent)
-            }
-        }
-    }
-
     /// Processes UDP-Notif a decoded packet and produce a TelemetryMessage
     /// object.
     fn process_decoded_udp_notif_packet(
@@ -620,6 +341,9 @@ impl YangPushEnrichmentActor {
         subscription_info: &SubscriptionInfo,
         decoded_packet: &UdpNotifPacketDecoded,
     ) -> Result<TelemetryMessageWrapper, YangPushEnrichmentActorError> {
+        if decoded_packet.notification_type().is_none() {
+            return Err(YangPushEnrichmentActorError::NotificationWithoutContent);
+        }
         let peer = subscription_info.peer();
         let message_id = decoded_packet.message_id();
         let publisher_id = decoded_packet.publisher_id();
@@ -639,8 +363,13 @@ impl YangPushEnrichmentActor {
             UdpNotifPayload::NotificationEnvelope(envelope) => envelope.event_time(),
         };
 
-        let subscription_metadata =
-            self.process_notification(content_id, subscription_info, decoded_packet)?;
+        let subscription_metadata = if !subscription_info.is_empty() {
+            Some(YangPushSubscriptionMetadata::from(
+                subscription_info.clone(),
+            ))
+        } else {
+            None
+        };
 
         let telemetry_message_metadata = TelemetryMessageMetadata::new(
             Some(node_export_timestamp),
@@ -801,8 +530,8 @@ impl YangPushEnrichmentActorHandle {
             SubscriptionInfo,
             UdpNotifPacketDecoded,
         )>,
+        manifest: Manifest,
         stats: either::Either<opentelemetry::metrics::Meter, YangPushEnrichmentStats>,
-        writer_id: String,
     ) -> (JoinHandle<anyhow::Result<String>>, Self) {
         let (cmd_send, cmd_recv) = mpsc::channel(10);
         let (enrichment_tx, enrichment_rx) = async_channel::bounded(buffer_size);
@@ -816,8 +545,8 @@ impl YangPushEnrichmentActorHandle {
             enrichment_rx,
             validated_rx,
             enriched_tx,
+            manifest,
             stats,
-            writer_id,
         );
         let join_handle = tokio::spawn(actor.run());
         let handle = Self {
@@ -866,175 +595,241 @@ impl EnrichmentHandle<EnrichmentOperation> for YangPushEnrichmentActorHandle {
 mod tests {
     use super::*;
     use bytes::Bytes;
+    use chrono::TimeZone;
     use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
-    use netgauze_netconf_proto::yang_push::subscription::{UpdateTrigger, YangPushModuleVersion};
-    use netgauze_netconf_proto::yang_push::types::CentiSeconds;
+    use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
+    use netgauze_netconf_proto::yang_push::types::SubscriptionId;
+    use netgauze_netconf_proto::yanglib::DatastoreName;
     use netgauze_udp_notif_pkt::decoded::UdpNotifPacketDecoded;
     use netgauze_udp_notif_pkt::notification::Target;
     use netgauze_udp_notif_pkt::raw::{MediaType, UdpNotifPacket};
     use netgauze_yang_push::model::telemetry::{Label, LabelValue};
+    use opentelemetry::global;
     use serde_json::json;
     use std::collections::HashMap;
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, SocketAddr};
+    use std::time::Duration;
 
-    fn create_subscription_started_modified(
-        id: SubscriptionId,
-        purpose: String,
-    ) -> SubscriptionStartedModified {
-        SubscriptionStartedModified::new(
-            id,
-            Target::new(
-                None,
-                None,
-                None,
-                None,
-                Some("example-datastore-name".to_string()),
-                None,
-                Some("/example/datastore/xpath".to_string()),
-            ),
-            None,
-            None,
-            None,
-            None,
-            Some(Transport::UDPNotif),
-            Some(Encoding::Json),
-            Some(purpose),
-            None,
-            Some(UpdateTrigger::Periodic {
-                period: Some(CentiSeconds::new(100)),
-                anchor_time: None,
-            }),
-            None,
-            None,
-            json!({}),
+    fn test_manifest() -> Manifest {
+        Manifest::new(
+            Some("test-writer".into()),
+            Some("NetGauze".into()),
+            Some(3746),
+            Some("0.11.0 (f5b7083e)".into()),
+            Some("debug".into()),
+            Some("26.4.1".into()),
+            Some("Darwin".into()),
         )
     }
 
-    fn create_subscription_terminated(id: SubscriptionId) -> SubscriptionTerminated {
-        SubscriptionTerminated::new(id, "some-termination-reason".to_string(), json!({}))
+    #[allow(clippy::type_complexity)]
+    fn create_actor_handle() -> (
+        async_channel::Sender<(Option<ContentId>, SubscriptionInfo, UdpNotifPacketDecoded)>,
+        Manifest,
+        JoinHandle<anyhow::Result<String>>,
+        YangPushEnrichmentActorHandle,
+    ) {
+        let test_manifest = test_manifest();
+        let (receiver_tx, receiver_rx) = async_channel::bounded(10);
+        let (join_handle, actor_handle) = YangPushEnrichmentActorHandle::new(
+            100,
+            receiver_rx,
+            test_manifest.clone(),
+            either::Left(global::meter_provider().meter("test")),
+        );
+        (receiver_tx, test_manifest, join_handle, actor_handle)
     }
 
     fn create_actor() -> YangPushEnrichmentActor {
+        let manifest = test_manifest();
         YangPushEnrichmentActor {
             cmd_rx: mpsc::channel(10).1,
             enrichment_rx: async_channel::bounded(10).1,
             validated_rx: async_channel::bounded(10).1,
             enriched_tx: async_channel::bounded(10).0,
             labels: HashMap::new(),
-            subscriptions: HashMap::new(),
-            manifest: fetch_sysinfo_manifest(None),
+            manifest,
             stats: YangPushEnrichmentStats::new(opentelemetry::global::meter("my-meter")),
         }
     }
 
-    #[test]
-    fn test_cache_and_get_subscription() {
-        let mut actor = create_actor();
-        let peer: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+    fn create_subscription_started(
+        peer: SocketAddr,
+        id: SubscriptionId,
+    ) -> (SubscriptionInfo, serde_json::Value, UdpNotifPacketDecoded) {
+        let payload = json!({
+            "ietf-yp-notification:envelope": {
+                "contents": {
+                    "ietf-subscribed-notifications:subscription-started": {
+                        "encoding": "ietf-subscribed-notifications:encode-json",
+                        "id": id,
+                        "ietf-yang-push-revision:module-version": [
+                            { "name": "openconfig-interfaces", "revision": "2025-06-10" }
+                        ],
+                        "ietf-yang-push:datastore": "ietf-datastores:operational",
+                        "ietf-yang-push:datastore-xpath-filter": "openconfig-interfaces:interfaces",
+                        "ietf-yang-push:on-change": { "sync-on-start": true },
+                    }
+                },
+                "event-time": "2025-04-17T15:20:14Z",
+                "another-time": "2025-01-01T15:20:14Z",
+                "hostname": "ipf-zbl1327-r-daisy-91",
+                "sequence-number": 0
+            }
+        });
 
-        // Create a SubscriptionStartedModified message and cache it
-        let subscription_started =
-            create_subscription_started_modified(1, "example-purpose".to_string());
-        let result = actor.cache_subscription(peer, &subscription_started);
-        assert!(result.is_ok());
+        let packet = UdpNotifPacket::new(
+            MediaType::YangDataJson,
+            1234,
+            5678,
+            HashMap::new(),
+            Bytes::from(serde_json::to_vec(&payload).unwrap()),
+        );
 
-        // Check get_subscription method
-        let get_result = actor.get_subscription(peer, 1);
-        assert!(get_result.is_ok());
-        assert_eq!(result.clone().unwrap(), get_result.unwrap());
-
-        // Check if the subscription is cached correctly
-        let peer_subscription = match result {
-            Ok(Some(metadata)) => metadata,
-            _ => panic!("Expected Some(YangPushSubscriptionMetadata), got: {result:?}"),
-        };
-
-        assert_eq!(peer_subscription.id(), Some(1));
-        assert_eq!(
-            peer_subscription.filter_spec().datastore(),
-            Some("example-datastore-name")
+        let decoded: UdpNotifPacketDecoded = (&packet).try_into().unwrap();
+        let subscription_info = SubscriptionInfo::new(
+            peer,
+            id,
+            Target::new_datastore(
+                DatastoreName::Operational.to_string(),
+                either::Right("openconfig-interfaces:interfaces".to_string()),
+            ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            None,
+            Box::new([YangPushModuleVersion::new(
+                "openconfig-interface".into(),
+                Some("2025-06-10".into()),
+                None,
+            )]),
+            "some-content-id".into(),
         );
-        assert_eq!(
-            peer_subscription.filter_spec().xpath_filter(),
-            Some("/example/datastore/xpath")
-        );
-        assert_eq!(
-            peer_subscription.transport().cloned(),
-            Some(Transport::UDPNotif)
-        );
-        assert_eq!(peer_subscription.encoding().cloned(), Some(Encoding::Json));
-        assert_eq!(peer_subscription.purpose(), Some("example-purpose"));
-        assert_eq!(
-            peer_subscription.update_trigger().cloned(),
-            Some(
-                UpdateTrigger::Periodic {
-                    period: Some(CentiSeconds::new(100)),
-                    anchor_time: None
-                }
-                .into()
-            )
-        );
-        assert_eq!(
-            peer_subscription.module(),
-            Vec::new() // default
-        );
-        assert_eq!(peer_subscription.yang_library_content_id(), None);
-
-        // Modify the subscription and check if it updates the cache
-        let subscription_modified =
-            create_subscription_started_modified(1, "updated-purpose".to_string());
-        let peer_subscription = actor
-            .cache_subscription(peer, &subscription_modified)
-            .unwrap();
-        assert_eq!(
-            peer_subscription.unwrap().purpose(),
-            Some("updated-purpose")
-        );
+        (subscription_info, payload, decoded)
     }
 
-    #[test]
-    fn test_delete_subscription() {
-        let mut actor = create_actor();
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_process_payload_empty_subscription() {
+        // Set up the enrichment actor and input test data
+        let (msgs_tx, test_manifest, join_handle, actor_handle) = create_actor_handle();
         let peer: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+        let (_subscription_info, json_payload, decoded) = create_subscription_started(peer, 1);
+        let empty_subscription_info = SubscriptionInfo::new_empty(peer, 1);
 
-        // Create a SubscriptionStartedModified message and cache it
-        let subscription_started = create_subscription_started_modified(1, "".to_string());
-        actor
-            .cache_subscription(peer, &subscription_started)
-            .unwrap();
+        msgs_tx
+            .send((
+                Some(empty_subscription_info.content_id().clone()),
+                empty_subscription_info.clone(),
+                decoded.clone(),
+            ))
+            .await
+            .expect("Failed to send message to the actor");
+        tokio::task::yield_now().await;
+        let (received_content_id, received_subscription_info, received_enriched) = actor_handle
+            .enriched_rx
+            .recv()
+            .await
+            .expect("Failed to receive message");
 
-        // Ensure the subscription is cached before deletion
-        let peer_subscriptions = actor.subscriptions.get(&peer);
-        assert!(peer_subscriptions.is_some() && peer_subscriptions.unwrap().contains_key(&1));
+        let expected_enriched = TelemetryMessageWrapper::new(TelemetryMessage::new(
+            None,
+            TelemetryMessageMetadata::new(
+                Some(Utc.with_ymd_and_hms(2025, 4, 17, 15, 20, 14).unwrap()),
+                // copy the collection timestamp from the received message since it's the current
+                // system time
+                received_enriched
+                    .message()
+                    .telemetry_message_metadata()
+                    .collection_timestamp(),
+                EventType::Log,
+                None,
+                SessionProtocol::YangPush,
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                Some(12345),
+                None,
+                None,
+                None,
+            ),
+            Some(test_manifest.clone()),
+            None,
+            Some(json_payload),
+        ));
+        assert_eq!(
+            received_content_id.as_ref(),
+            Some(empty_subscription_info.content_id())
+        );
+        assert_eq!(received_subscription_info, empty_subscription_info);
+        assert_eq!(received_enriched, expected_enriched);
 
-        let terminated = create_subscription_terminated(1);
-        let result = actor.delete_subscription(peer, &terminated);
-        assert!(result.is_ok());
-
-        let peer_subscriptions = actor.subscriptions.get(&peer);
-        assert!(peer_subscriptions.is_none() || !peer_subscriptions.unwrap().contains_key(&1));
+        // shutdown the actor
+        tokio::time::timeout(Duration::from_millis(100), actor_handle.shutdown())
+            .await
+            .expect("Failed to shutdown the actor")
+            .expect("Actor was not shutdown cleanly");
+        join_handle.abort();
     }
 
-    #[test]
-    fn test_get_subscription_cache_miss() {
-        let mut actor = create_actor();
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_process_payload_envelope() {
+        // Set up the enrichment actor and input test data
+        let (msgs_tx, test_manifest, join_handle, actor_handle) = create_actor_handle();
         let peer: SocketAddr = "127.0.0.1:12345".parse().unwrap();
-        let subscription_id_1 = create_subscription_started_modified(1, "".to_string());
-        let subscription_id_23 = create_subscription_started_modified(23, "".to_string());
-        actor.cache_subscription(peer, &subscription_id_1).unwrap();
-        actor.cache_subscription(peer, &subscription_id_23).unwrap();
+        let (subscription_info, json_payload, decoded) = create_subscription_started(peer, 1);
 
-        assert_eq!(actor.subscriptions.len(), 1);
-        assert!(actor.subscriptions.contains_key(&peer));
-        assert!(actor.subscriptions[&peer].contains_key(&1));
-        assert!(actor.subscriptions[&peer].contains_key(&23));
-        assert_eq!(actor.subscriptions[&peer].len(), 2);
+        msgs_tx
+            .send((
+                Some(subscription_info.content_id().clone()),
+                subscription_info.clone(),
+                decoded.clone(),
+            ))
+            .await
+            .expect("Failed to send message to the actor");
+        tokio::task::yield_now().await;
+        let (received_content_id, received_subscription_info, received_enriched) = actor_handle
+            .enriched_rx
+            .recv()
+            .await
+            .expect("Failed to receive message");
 
-        let get_result = actor.get_subscription(peer, 12);
-        assert!(get_result.is_ok());
+        let expected_metadata = YangPushSubscriptionMetadata::from(subscription_info.clone());
+        let expected_enriched = TelemetryMessageWrapper::new(TelemetryMessage::new(
+            None,
+            TelemetryMessageMetadata::new(
+                Some(Utc.with_ymd_and_hms(2025, 4, 17, 15, 20, 14).unwrap()),
+                // copy the collection timestamp from the received message since it's the current
+                // system time
+                received_enriched
+                    .message()
+                    .telemetry_message_metadata()
+                    .collection_timestamp(),
+                EventType::Log,
+                None,
+                SessionProtocol::YangPush,
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                Some(12345),
+                None,
+                None,
+                Some(expected_metadata),
+            ),
+            Some(test_manifest.clone()),
+            None,
+            Some(json_payload),
+        ));
+        assert_eq!(
+            received_content_id.as_ref(),
+            Some(subscription_info.content_id())
+        );
+        assert_eq!(received_subscription_info, subscription_info);
+        assert_eq!(received_enriched, expected_enriched);
 
-        let peer_subscription = get_result.unwrap();
-        assert_eq!(peer_subscription, None);
+        // shutdown the actor
+        tokio::time::timeout(Duration::from_millis(100), actor_handle.shutdown())
+            .await
+            .expect("Failed to shutdown the actor")
+            .expect("Actor was not shutdown cleanly");
+        join_handle.abort();
     }
 
     #[test]
@@ -1061,32 +856,15 @@ mod tests {
             Bytes::from(payload),
         );
 
-        let subscription_info = SubscriptionInfo::new(
-            peer,
-            1,
-            Target::new_datastore(
-                "ds:operational".to_string(),
-                either::Right("/ietf-interfaces".to_string()),
-            ),
-            None,
-            Some(Transport::UDPNotif),
-            Some(Encoding::Json),
-            None,
-            Box::new([YangPushModuleVersion::new(
-                "ietf-interfaces".into(),
-                Some("2018-02-20".into()),
-                None,
-            )]),
-            "test-content-id".to_string(),
-        );
+        let subscription_info = SubscriptionInfo::new_empty(peer, 1);
         // Attempt to decode the packet (should succeed)
         let decoded: UdpNotifPacketDecoded = (&packet).try_into().unwrap();
 
         let result = actor.process_decoded_udp_notif_packet(None, &subscription_info, &decoded);
-        assert!(result.is_err());
+
         assert_eq!(
-            result.unwrap_err(),
-            YangPushEnrichmentActorError::NotificationWithoutContent
+            result,
+            Err(YangPushEnrichmentActorError::NotificationWithoutContent)
         );
     }
 

--- a/crates/collector/src/yang_push/enrichment.rs
+++ b/crates/collector/src/yang_push/enrichment.rs
@@ -867,7 +867,7 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
-    use netgauze_netconf_proto::yang_push::subscription::UpdateTrigger;
+    use netgauze_netconf_proto::yang_push::subscription::{UpdateTrigger, YangPushModuleVersion};
     use netgauze_netconf_proto::yang_push::types::CentiSeconds;
     use netgauze_udp_notif_pkt::decoded::UdpNotifPacketDecoded;
     use netgauze_udp_notif_pkt::notification::Target;
@@ -1069,7 +1069,11 @@ mod tests {
                 "ds:operational".to_string(),
                 either::Right("/ietf-interfaces".to_string()),
             ),
-            vec!["ietf-interfaces".to_string()],
+            Box::new([YangPushModuleVersion::new(
+                "ietf-interfaces".into(),
+                Some("2018-02-20".into()),
+                None,
+            )]),
         );
         // Attempt to decode the packet (should succeed)
         let decoded: UdpNotifPacketDecoded = (&packet).try_into().unwrap();

--- a/crates/netconf-proto/src/yang_push/identities.rs
+++ b/crates/netconf-proto/src/yang_push/identities.rs
@@ -76,7 +76,7 @@ impl<'a> XmlDeserialize<'a, ConfiguredSubscriptionState> for ConfiguredSubscript
 
 /// Transport protocol used to deliver the notification message to the data
 /// collection.
-#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Transport {
     /// UDP-based notification transport
     /// [ietf-udp-notif-transport](https://datatracker.ietf.org/doc/html/draft-ietf-netconf-udp-notif)
@@ -134,7 +134,7 @@ impl<'a> XmlDeserialize<'a, Transport> for Transport {
 }
 
 /// Encoding used for the notification payload
-#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Encoding {
     #[serde(rename = "ietf-subscribed-notifications:encode-xml")]
     #[serde(alias = "encode-xml")]
@@ -199,7 +199,7 @@ impl<'a> XmlDeserialize<'a, Encoding> for Encoding {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum ChangeType {
     Create,

--- a/crates/netconf-proto/src/yang_push/subscription.rs
+++ b/crates/netconf-proto/src/yang_push/subscription.rs
@@ -969,7 +969,7 @@ impl<'a> XmlDeserialize<'a, DatastoreSelectionFilterObjects> for DatastoreSelect
 /// - `name`: Module name
 /// - `revision`: Module revision date (e.g., "2025-04-25")
 /// - `version`: Semantic version label
-#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub struct YangPushModuleVersion {
     /// Alias 'module-name' still supported

--- a/crates/netconf-proto/src/yang_push/subscription.rs
+++ b/crates/netconf-proto/src/yang_push/subscription.rs
@@ -183,7 +183,7 @@ pub struct DatastoreTarget {
 ///         ├── Move
 ///         └── Replace
 /// ```
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum UpdateTrigger {
     #[serde(rename = "ietf-yang-push:periodic")]
     #[serde(rename_all = "kebab-case")]

--- a/crates/netconf-proto/src/yang_push/types.rs
+++ b/crates/netconf-proto/src/yang_push/types.rs
@@ -22,7 +22,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct CentiSeconds(u32);
 
 impl CentiSeconds {

--- a/crates/udp-notif-pkt/src/notification.rs
+++ b/crates/udp-notif-pkt/src/notification.rs
@@ -762,31 +762,31 @@ impl YangPushChangeUpdate {
 pub struct Target {
     #[serde(rename = "stream")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    stream: Option<String>,
+    pub stream: Option<String>,
 
     #[serde(rename = "stream-subtree-filter")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    stream_subtree_filter: Option<Value>,
+    pub stream_subtree_filter: Option<Value>,
 
     #[serde(rename = "stream-xpath-filter")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    stream_xpath_filter: Option<String>,
+    pub stream_xpath_filter: Option<String>,
 
     #[serde(rename = "replay-start-time")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    replay_start_time: Option<DateTime<Utc>>,
+    pub replay_start_time: Option<DateTime<Utc>>,
 
     #[serde(rename = "ietf-yang-push:datastore")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    datastore: Option<String>,
+    pub datastore: Option<String>,
 
     #[serde(rename = "datastore-subtree-filter")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    datastore_subtree_filter: Option<Value>,
+    pub datastore_subtree_filter: Option<Value>,
 
     #[serde(rename = "ietf-yang-push:datastore-xpath-filter")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    datastore_xpath_filter: Option<String>,
+    pub datastore_xpath_filter: Option<String>,
 }
 
 impl Target {

--- a/crates/yang-push/src/cache/actor.rs
+++ b/crates/yang-push/src/cache/actor.rs
@@ -1250,6 +1250,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::cache::fetcher::tests::TestYangLibFetcher;
     use futures_util::stream::FuturesOrdered;
+    use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
     use netgauze_udp_notif_pkt::notification::Target;
     use std::collections::HashMap;
     use std::net::{IpAddr, Ipv4Addr};
@@ -1265,7 +1266,10 @@ pub(crate) mod tests {
                 "ds:operational".to_string(),
                 either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
             ),
-            vec!["ietf-interfaces".to_string(), "ietf-ip".to_string()],
+            Box::new([
+                YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
+                YangPushModuleVersion::new("ietf-ip".into(), None, None),
+            ]),
         )
     }
 

--- a/crates/yang-push/src/cache/actor.rs
+++ b/crates/yang-push/src/cache/actor.rs
@@ -1251,7 +1251,7 @@ pub(crate) mod tests {
     use crate::cache::fetcher::tests::TestYangLibFetcher;
     use futures_util::stream::FuturesOrdered;
     use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
-    use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
+    use netgauze_netconf_proto::yang_push::subscription::{UpdateTrigger, YangPushModuleVersion};
     use netgauze_udp_notif_pkt::notification::Target;
     use std::collections::HashMap;
     use std::net::{IpAddr, Ipv4Addr};
@@ -1270,6 +1270,11 @@ pub(crate) mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             Some("test subscription".into()),
+            Some(UpdateTrigger::OnChange {
+                dampening_period: None,
+                sync_on_start: Some(true),
+                excluded_change: None,
+            }),
             Box::new([
                 YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
                 YangPushModuleVersion::new("ietf-ip".into(), None, None),

--- a/crates/yang-push/src/cache/actor.rs
+++ b/crates/yang-push/src/cache/actor.rs
@@ -1250,6 +1250,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::cache::fetcher::tests::TestYangLibFetcher;
     use futures_util::stream::FuturesOrdered;
+    use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
     use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
     use netgauze_udp_notif_pkt::notification::Target;
     use std::collections::HashMap;
@@ -1261,15 +1262,19 @@ pub(crate) mod tests {
         SubscriptionInfo::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 830),
             1,
-            ContentId::from("ietf-interfaces-lib".to_string()),
             Target::new_datastore(
                 "ds:operational".to_string(),
                 either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some("test subscription".into()),
             Box::new([
                 YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
                 YangPushModuleVersion::new("ietf-ip".into(), None, None),
             ]),
+            ContentId::from("ietf-interfaces-lib".to_string()),
         )
     }
 

--- a/crates/yang-push/src/cache/fetcher.rs
+++ b/crates/yang-push/src/cache/fetcher.rs
@@ -295,6 +295,7 @@ impl NetconfYangLibraryFetcher {
             subscription.transport,
             subscription.encoding,
             subscription.purpose,
+            subscription.update_trigger,
             modules.into_boxed_slice(),
             router_yang_library.content_id().to_string(),
         );

--- a/crates/yang-push/src/cache/fetcher.rs
+++ b/crates/yang-push/src/cache/fetcher.rs
@@ -264,7 +264,10 @@ impl NetconfYangLibraryFetcher {
             ret
         };
 
-        let module_names = modules.iter().map(|x| x.name()).collect::<Vec<_>>();
+        let mut module_names = modules.iter().map(|x| x.name()).collect::<Vec<_>>();
+        if !module_names.contains(&"ietf-subscribed-notifications") {
+            module_names.push("ietf-subscribed-notifications");
+        }
         // TODO: add timeout to loading YANG Library from the device
         let (yang_lib, schemas) = client
             .load_from_modules(&module_names, &PermissiveVersionChecker)

--- a/crates/yang-push/src/cache/fetcher.rs
+++ b/crates/yang-push/src/cache/fetcher.rs
@@ -290,9 +290,13 @@ impl NetconfYangLibraryFetcher {
         let subscription_info = SubscriptionInfo::new(
             peer,
             subscription_id,
-            router_yang_library.content_id().to_string(),
             subscription_target,
+            subscription.stop_time,
+            subscription.transport,
+            subscription.encoding,
+            subscription.purpose,
             modules.into_boxed_slice(),
+            router_yang_library.content_id().to_string(),
         );
         info!( host = %host,
             peer=%peer,

--- a/crates/yang-push/src/cache/fetcher.rs
+++ b/crates/yang-push/src/cache/fetcher.rs
@@ -29,7 +29,9 @@ use crate::cache::storage::{SubscriptionInfo, YangLibraryCacheError};
 use netgauze_netconf_proto::capabilities::{Capability, NetconfVersion};
 use netgauze_netconf_proto::client::{NetconfSshConnectConfig, SshAuth, SshHandler, connect};
 use netgauze_netconf_proto::yang_push::filters::StreamSelectionFilterObjects;
-use netgauze_netconf_proto::yang_push::subscription::{DatastoreSelectionFilterObjects, Target};
+use netgauze_netconf_proto::yang_push::subscription::{
+    DatastoreSelectionFilterObjects, Target, YangPushModuleVersion,
+};
 use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_netconf_proto::yanglib::{DatastoreName, PermissiveVersionChecker, YangLibrary};
 use std::collections::{HashMap, HashSet};
@@ -143,7 +145,7 @@ impl NetconfYangLibraryFetcher {
         let modules = subscription_info
             .models()
             .iter()
-            .map(|x| x.as_str())
+            .map(|x| x.name())
             .collect::<Vec<_>>();
         // TODO: add timeout to loading YANG Library from the device
         let (yang_lib, schemas) = client
@@ -216,10 +218,7 @@ impl NetconfYangLibraryFetcher {
             .map_err(|err| (empty.clone(), err.into()))?;
 
         let modules = if let Some(modules) = &subscription.module_version {
-            modules
-                .iter()
-                .map(|x| x.name.to_string())
-                .collect::<Vec<_>>()
+            modules.clone().to_vec()
         } else {
             let (ds_name, namespaces) = match &subscription.target {
                 Target::Stream(stream_target) => {
@@ -256,15 +255,19 @@ impl NetconfYangLibraryFetcher {
             let mut ret = Vec::with_capacity(namespaces.len());
             for (_prefix, namespace) in namespaces {
                 let module = router_yang_library.find_module_by_datastore_and_ns(&ds_name, namespace).ok_or_else(|| (empty.clone(), YangLibraryCacheError::IoError(std::io::Error::other(format!("module with namespace {namespace} not found in YANG Library for datastore {ds_name}")))))?;
-                ret.push(module.name().to_string());
+                ret.push(YangPushModuleVersion::new(
+                    module.name().into(),
+                    module.revision().map(|x| x.into()),
+                    None,
+                ));
             }
             ret
         };
 
-        let modules_str = modules.iter().map(|x| x.as_str()).collect::<Vec<_>>();
+        let module_names = modules.iter().map(|x| x.name()).collect::<Vec<_>>();
         // TODO: add timeout to loading YANG Library from the device
         let (yang_lib, schemas) = client
-            .load_from_modules(&modules_str, &PermissiveVersionChecker)
+            .load_from_modules(&module_names, &PermissiveVersionChecker)
             .await
             .map_err(|err| (empty.clone(), err.into()))?;
         match tokio::time::timeout(timeout_duration, client.close()).await {
@@ -289,7 +292,7 @@ impl NetconfYangLibraryFetcher {
             subscription_id,
             router_yang_library.content_id().to_string(),
             subscription_target,
-            modules,
+            modules.into_boxed_slice(),
         );
         info!( host = %host,
             peer=%peer,

--- a/crates/yang-push/src/cache/storage.rs
+++ b/crates/yang-push/src/cache/storage.rs
@@ -94,6 +94,7 @@
 
 use crate::ContentId;
 use netgauze_netconf_proto::xml_utils::{XmlDeserialize, XmlSerialize, XmlWriter};
+use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
 use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_netconf_proto::yanglib::{SchemaLoadingError, YangLibrary};
 use netgauze_udp_notif_pkt::notification::Target;
@@ -778,7 +779,7 @@ pub struct SubscriptionInfo {
     content_id: ContentId,
     target: Target,
     // TODO: add Module revision
-    models: Vec<String>,
+    models: Box<[YangPushModuleVersion]>,
 }
 
 impl SubscriptionInfo {
@@ -787,7 +788,7 @@ impl SubscriptionInfo {
         id: SubscriptionId,
         content_id: ContentId,
         target: Target,
-        models: Vec<String>,
+        models: Box<[YangPushModuleVersion]>,
     ) -> Self {
         Self {
             peer,
@@ -807,7 +808,7 @@ impl SubscriptionInfo {
             id,
             content_id: "EMPTY".to_string(),
             target: Target::new_datastore("EMPTY".to_string(), either::Right("EMPTY".to_string())),
-            models: vec![],
+            models: Box::new([]),
         }
     }
 
@@ -839,7 +840,7 @@ impl SubscriptionInfo {
     }
 
     /// The list of YANG modules associated with the subscription.
-    pub fn models(&self) -> &[String] {
+    pub fn models(&self) -> &[YangPushModuleVersion] {
         &self.models
     }
 }
@@ -1165,7 +1166,10 @@ mod tests {
                 "ds:operational".to_string(),
                 either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
             ),
-            vec!["ietf-interfaces".to_string(), "ietf-ip".to_string()],
+            Box::new([
+                YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
+                YangPushModuleVersion::new("ietf-ip".into(), None, None),
+            ]),
         )
     }
 
@@ -1360,8 +1364,11 @@ mod tests {
             "ds:operational".to_string(),
             either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
         );
-        let models = vec!["model1".to_string(), "model2".to_string()];
 
+        let models = Box::new([
+            YangPushModuleVersion::new("model1".into(), None, None),
+            YangPushModuleVersion::new("model2".into(), None, None),
+        ]);
         let info = SubscriptionInfo::new(peer, 1, content_id.clone(), Target::new_datastore(
             "ds:operational".to_string(),
             either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
@@ -1612,7 +1619,11 @@ mod tests {
                 "ds:operational".to_string(),
                 either::Right("/ietf-routing:routing/routing-protocols".to_string()),
             ),
-            vec!["ietf-routing".to_string()],
+            Box::new([YangPushModuleVersion::new(
+                "ietf-routing".into(),
+                None,
+                None,
+            )]),
         );
         let subscription_info3 = SubscriptionInfo::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 102)), 830),
@@ -1622,7 +1633,11 @@ mod tests {
                 "ds:operational".to_string(),
                 either::Right("/ietf-routing:routing/routing-protocols".to_string()),
             ),
-            vec!["ietf-routing".to_string()],
+            Box::new([YangPushModuleVersion::new(
+                "ietf-routing".into(),
+                None,
+                None,
+            )]),
         );
         setup_yang_library_on_disk(
             &temp_dir,
@@ -1691,7 +1706,11 @@ mod tests {
                 "ds:operational".to_string(),
                 either::Right("/ietf-routing:routing/routing-protocols".to_string()),
             ),
-            vec!["ietf-routing".to_string()],
+            Box::new([YangPushModuleVersion::new(
+                "ietf-routing".into(),
+                None,
+                None,
+            )]),
         );
 
         // Test appending new subscription info
@@ -1733,7 +1752,10 @@ mod tests {
                 "ds:operational".to_string(),
                 either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
             ),
-            vec!["ietf-interfaces".to_string(), "ietf-ip".to_string()],
+            Box::new([
+                YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
+                YangPushModuleVersion::new("ietf-ip".into(), None, None),
+            ]),
         );
 
         // Create YANG library and schemas
@@ -1772,7 +1794,11 @@ mod tests {
                 "ds:operational".to_string(),
                 either::Right("/ietf-routing:routing/routing-protocols".to_string()),
             ),
-            vec!["ietf-routing".to_string()],
+            Box::new([YangPushModuleVersion::new(
+                "ietf-routing".into(),
+                None,
+                None,
+            )]),
         );
 
         // Put a second subscription with the same YANG library

--- a/crates/yang-push/src/cache/storage.rs
+++ b/crates/yang-push/src/cache/storage.rs
@@ -93,7 +93,9 @@
 //! ```
 
 use crate::ContentId;
+use chrono::{DateTime, Utc};
 use netgauze_netconf_proto::xml_utils::{XmlDeserialize, XmlSerialize, XmlWriter};
+use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
 use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
 use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_netconf_proto::yanglib::{SchemaLoadingError, YangLibrary};
@@ -776,26 +778,48 @@ impl YangLibraryReference {
 pub struct SubscriptionInfo {
     peer: SocketAddr,
     id: SubscriptionId,
-    content_id: ContentId,
     target: Target,
-    // TODO: add Module revision
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_time: Option<DateTime<Utc>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transport: Option<Transport>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encoding: Option<Encoding>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    purpose: Option<Box<str>>,
+
     models: Box<[YangPushModuleVersion]>,
+
+    content_id: ContentId,
 }
 
 impl SubscriptionInfo {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         peer: SocketAddr,
         id: SubscriptionId,
-        content_id: ContentId,
         target: Target,
+        stop_time: Option<DateTime<Utc>>,
+        transport: Option<Transport>,
+        encoding: Option<Encoding>,
+        purpose: Option<Box<str>>,
         models: Box<[YangPushModuleVersion]>,
+        content_id: ContentId,
     ) -> Self {
         Self {
             peer,
             id,
-            content_id,
             target,
+            stop_time,
+            transport,
+            encoding,
+            purpose,
             models,
+            content_id,
         }
     }
 
@@ -806,9 +830,13 @@ impl SubscriptionInfo {
         Self {
             peer,
             id,
-            content_id: "EMPTY".to_string(),
             target: Target::new_datastore("EMPTY".to_string(), either::Right("EMPTY".to_string())),
+            stop_time: None,
+            transport: None,
+            encoding: None,
+            purpose: None,
             models: Box::new([]),
+            content_id: "EMPTY".to_string(),
         }
     }
 
@@ -826,6 +854,22 @@ impl SubscriptionInfo {
     /// identifier for the subscription within each peer
     pub const fn id(&self) -> SubscriptionId {
         self.id
+    }
+
+    pub const fn stop_time(&self) -> Option<DateTime<Utc>> {
+        self.stop_time
+    }
+
+    pub const fn transport(&self) -> Option<Transport> {
+        self.transport
+    }
+
+    pub const fn encoding(&self) -> Option<Encoding> {
+        self.encoding
+    }
+
+    pub fn purpose(&self) -> Option<&str> {
+        self.purpose.as_deref()
     }
 
     /// The YANG Library content ID associated with the subscription by the
@@ -1161,15 +1205,19 @@ mod tests {
         SubscriptionInfo::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 830),
             1,
-            ContentId::from(content_id.to_string()),
             Target::new_datastore(
                 "ds:operational".to_string(),
                 either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some("test subscription".into()),
             Box::new([
                 YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
                 YangPushModuleVersion::new("ietf-ip".into(), None, None),
             ]),
+            ContentId::from(content_id.to_string()),
         )
     }
 
@@ -1369,10 +1417,20 @@ mod tests {
             YangPushModuleVersion::new("model1".into(), None, None),
             YangPushModuleVersion::new("model2".into(), None, None),
         ]);
-        let info = SubscriptionInfo::new(peer, 1, content_id.clone(), Target::new_datastore(
-            "ds:operational".to_string(),
-            either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
-        ), models.clone());
+        let info = SubscriptionInfo::new(
+            peer,
+            1,
+            Target::new_datastore(
+                "ds:operational".to_string(),
+                either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
+            ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some("test subscription".into()),
+            models.clone(),
+            content_id.clone(),
+        );
 
         assert_eq!(info.peer(), peer);
         assert_eq!(info.content_id(), &content_id);
@@ -1614,30 +1672,38 @@ mod tests {
         let subscription_info2 = SubscriptionInfo::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101)), 830),
             2,
-            ContentId::from("content_id2".to_string()),
             Target::new_datastore(
                 "ds:operational".to_string(),
                 either::Right("/ietf-routing:routing/routing-protocols".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some("test subscription".into()),
             Box::new([YangPushModuleVersion::new(
                 "ietf-routing".into(),
                 None,
                 None,
             )]),
+            ContentId::from("content_id2".to_string()),
         );
         let subscription_info3 = SubscriptionInfo::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 102)), 830),
             2,
-            ContentId::from("content_id3".to_string()),
             Target::new_datastore(
                 "ds:operational".to_string(),
                 either::Right("/ietf-routing:routing/routing-protocols".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some("test subscription".into()),
             Box::new([YangPushModuleVersion::new(
                 "ietf-routing".into(),
                 None,
                 None,
             )]),
+            ContentId::from("content_id3".to_string()),
         );
         setup_yang_library_on_disk(
             &temp_dir,
@@ -1701,16 +1767,20 @@ mod tests {
         let subscription_info2 = SubscriptionInfo::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101)), 830),
             2,
-            ContentId::from(content_id.to_string()),
             Target::new_datastore(
                 "ds:operational".to_string(),
                 either::Right("/ietf-routing:routing/routing-protocols".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some("test subscription".into()),
             Box::new([YangPushModuleVersion::new(
                 "ietf-routing".into(),
                 None,
                 None,
             )]),
+            ContentId::from(content_id.to_string()),
         );
 
         // Test appending new subscription info
@@ -1747,15 +1817,19 @@ mod tests {
         let subscription_info1 = SubscriptionInfo::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)), 830),
             1,
-            ContentId::from(content_id.to_string()),
             Target::new_datastore(
                 "ds:operational".to_string(),
                 either::Right("/ietf-interfaces:interfaces/ietf-interfaces:interface[ietf-interfaces:name='eth0']/statistics".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some("test subscription".into()),
             Box::new([
                 YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
                 YangPushModuleVersion::new("ietf-ip".into(), None, None),
             ]),
+            ContentId::from(content_id.to_string()),
         );
 
         // Create YANG library and schemas
@@ -1789,16 +1863,20 @@ mod tests {
         let subscription_info2 = SubscriptionInfo::new(
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101)), 830),
             2,
-            ContentId::from(content_id.to_string()),
             Target::new_datastore(
                 "ds:operational".to_string(),
                 either::Right("/ietf-routing:routing/routing-protocols".to_string()),
             ),
+            None,
+            Some(Transport::UDPNotif),
+            Some(Encoding::Json),
+            Some("test subscription".into()),
             Box::new([YangPushModuleVersion::new(
                 "ietf-routing".into(),
                 None,
                 None,
             )]),
+            ContentId::from(content_id.to_string()),
         );
 
         // Put a second subscription with the same YANG library

--- a/crates/yang-push/src/cache/storage.rs
+++ b/crates/yang-push/src/cache/storage.rs
@@ -776,28 +776,28 @@ impl YangLibraryReference {
 /// ```
 #[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SubscriptionInfo {
-    peer: SocketAddr,
-    id: SubscriptionId,
-    target: Target,
+    pub peer: SocketAddr,
+    pub id: SubscriptionId,
+    pub target: Target,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    stop_time: Option<DateTime<Utc>>,
+    pub stop_time: Option<DateTime<Utc>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    transport: Option<Transport>,
+    pub transport: Option<Transport>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    encoding: Option<Encoding>,
+    pub encoding: Option<Encoding>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    purpose: Option<Box<str>>,
+    pub purpose: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    update_trigger: Option<UpdateTrigger>,
+    pub update_trigger: Option<UpdateTrigger>,
 
-    models: Box<[YangPushModuleVersion]>,
+    pub models: Box<[YangPushModuleVersion]>,
 
-    content_id: ContentId,
+    pub content_id: ContentId,
 }
 
 impl SubscriptionInfo {

--- a/crates/yang-push/src/cache/storage.rs
+++ b/crates/yang-push/src/cache/storage.rs
@@ -96,7 +96,7 @@ use crate::ContentId;
 use chrono::{DateTime, Utc};
 use netgauze_netconf_proto::xml_utils::{XmlDeserialize, XmlSerialize, XmlWriter};
 use netgauze_netconf_proto::yang_push::identities::{Encoding, Transport};
-use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
+use netgauze_netconf_proto::yang_push::subscription::{UpdateTrigger, YangPushModuleVersion};
 use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_netconf_proto::yanglib::{SchemaLoadingError, YangLibrary};
 use netgauze_udp_notif_pkt::notification::Target;
@@ -792,6 +792,9 @@ pub struct SubscriptionInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     purpose: Option<Box<str>>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    update_trigger: Option<UpdateTrigger>,
+
     models: Box<[YangPushModuleVersion]>,
 
     content_id: ContentId,
@@ -807,6 +810,7 @@ impl SubscriptionInfo {
         transport: Option<Transport>,
         encoding: Option<Encoding>,
         purpose: Option<Box<str>>,
+        update_trigger: Option<UpdateTrigger>,
         models: Box<[YangPushModuleVersion]>,
         content_id: ContentId,
     ) -> Self {
@@ -818,6 +822,7 @@ impl SubscriptionInfo {
             transport,
             encoding,
             purpose,
+            update_trigger,
             models,
             content_id,
         }
@@ -836,6 +841,7 @@ impl SubscriptionInfo {
             encoding: None,
             purpose: None,
             models: Box::new([]),
+            update_trigger: None,
             content_id: "EMPTY".to_string(),
         }
     }
@@ -881,6 +887,10 @@ impl SubscriptionInfo {
     /// The [Target] associated with the subscription.
     pub const fn target(&self) -> &Target {
         &self.target
+    }
+
+    pub const fn update_trigger(&self) -> Option<&UpdateTrigger> {
+        self.update_trigger.as_ref()
     }
 
     /// The list of YANG modules associated with the subscription.
@@ -1198,6 +1208,7 @@ impl YangLibraryCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use netgauze_netconf_proto::yang_push::types::CentiSeconds;
     use std::net::{IpAddr, Ipv4Addr};
     use tempfile::TempDir;
 
@@ -1213,6 +1224,11 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             Some("test subscription".into()),
+            Some(UpdateTrigger::OnChange {
+                dampening_period: None,
+                sync_on_start: Some(true),
+                excluded_change: None,
+            }),
             Box::new([
                 YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
                 YangPushModuleVersion::new("ietf-ip".into(), None, None),
@@ -1428,6 +1444,11 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             Some("test subscription".into()),
+            Some(UpdateTrigger::OnChange {
+                dampening_period: None,
+                sync_on_start: Some(true),
+                excluded_change: None,
+            }),
             models.clone(),
             content_id.clone(),
         );
@@ -1680,6 +1701,11 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             Some("test subscription".into()),
+            Some(UpdateTrigger::OnChange {
+                dampening_period: None,
+                sync_on_start: Some(true),
+                excluded_change: None,
+            }),
             Box::new([YangPushModuleVersion::new(
                 "ietf-routing".into(),
                 None,
@@ -1698,6 +1724,10 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             Some("test subscription".into()),
+            Some(UpdateTrigger::Periodic {
+                period: Some(CentiSeconds::new(300)),
+                anchor_time: None,
+            }),
             Box::new([YangPushModuleVersion::new(
                 "ietf-routing".into(),
                 None,
@@ -1775,6 +1805,11 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             Some("test subscription".into()),
+            Some(UpdateTrigger::OnChange {
+                dampening_period: None,
+                sync_on_start: Some(true),
+                excluded_change: None,
+            }),
             Box::new([YangPushModuleVersion::new(
                 "ietf-routing".into(),
                 None,
@@ -1825,6 +1860,11 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             Some("test subscription".into()),
+            Some(UpdateTrigger::OnChange {
+                dampening_period: None,
+                sync_on_start: Some(true),
+                excluded_change: None,
+            }),
             Box::new([
                 YangPushModuleVersion::new("ietf-interfaces".into(), Some("2018-02-20".into()), None),
                 YangPushModuleVersion::new("ietf-ip".into(), None, None),
@@ -1871,6 +1911,11 @@ mod tests {
             Some(Transport::UDPNotif),
             Some(Encoding::Json),
             Some("test subscription".into()),
+            Some(UpdateTrigger::OnChange {
+                dampening_period: None,
+                sync_on_start: Some(true),
+                excluded_change: None,
+            }),
             Box::new([YangPushModuleVersion::new(
                 "ietf-routing".into(),
                 None,

--- a/crates/yang-push/src/model/telemetry.rs
+++ b/crates/yang-push/src/model/telemetry.rs
@@ -42,9 +42,11 @@
 //!   information.
 use chrono::{DateTime, Utc};
 
+use crate::cache::storage::SubscriptionInfo;
 use netgauze_netconf_proto::yang_push::identities::{ChangeType, Encoding, Transport};
 use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
 use netgauze_netconf_proto::yang_push::types::{CentiSeconds, SubscriptionId};
+use netgauze_udp_notif_pkt::notification::Target;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::net::IpAddr;
@@ -371,6 +373,22 @@ impl YangPushSubscriptionMetadata {
     }
 }
 
+impl From<SubscriptionInfo> for YangPushSubscriptionMetadata {
+    fn from(info: SubscriptionInfo) -> Self {
+        Self {
+            id: Some(info.id()),
+            filter_spec: info.target().clone().into(),
+            stop_time: None,
+            transport: Some(Transport::UDPNotif),
+            encoding: Some(Encoding::Json),
+            purpose: None,
+            update_trigger: None,
+            module: vec![],
+            yang_library_content_id: None,
+        }
+    }
+}
+
 #[derive(Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct FilterSpec {
@@ -412,6 +430,27 @@ impl FilterSpec {
     }
     pub const fn subtree_filter(&self) -> Option<&Value> {
         self.subtree_filter.as_ref()
+    }
+}
+
+impl From<Target> for FilterSpec {
+    fn from(target: Target) -> Self {
+        let xpath_filter = if let Some(xpath_filter) = target.stream_xpath_filter() {
+            Some(xpath_filter.to_string())
+        } else {
+            target.datastore_xpath_filter().map(String::from)
+        };
+        let subtree_filter = if let Some(subtree) = target.stream_subtree_filter() {
+            Some(subtree.clone())
+        } else {
+            target.datastore_subtree_filter().cloned()
+        };
+        Self {
+            stream: target.stream().map(String::from),
+            datastore: target.datastore().map(String::from),
+            xpath_filter,
+            subtree_filter,
+        }
     }
 }
 

--- a/crates/yang-push/src/model/telemetry.rs
+++ b/crates/yang-push/src/model/telemetry.rs
@@ -378,13 +378,13 @@ impl From<SubscriptionInfo> for YangPushSubscriptionMetadata {
         Self {
             id: Some(info.id()),
             filter_spec: info.target().clone().into(),
-            stop_time: None,
+            stop_time: info.stop_time(),
             transport: Some(Transport::UDPNotif),
             encoding: Some(Encoding::Json),
-            purpose: None,
-            update_trigger: None,
-            module: vec![],
-            yang_library_content_id: None,
+            purpose: info.purpose().map(String::from),
+            update_trigger: info.update_trigger().cloned().map(UpdateTrigger::from),
+            module: info.models().to_vec(),
+            yang_library_content_id: Some(info.content_id().clone()),
         }
     }
 }

--- a/crates/yang-push/src/model/telemetry.rs
+++ b/crates/yang-push/src/model/telemetry.rs
@@ -376,15 +376,15 @@ impl YangPushSubscriptionMetadata {
 impl From<SubscriptionInfo> for YangPushSubscriptionMetadata {
     fn from(info: SubscriptionInfo) -> Self {
         Self {
-            id: Some(info.id()),
-            filter_spec: info.target().clone().into(),
-            stop_time: info.stop_time(),
+            id: Some(info.id),
+            filter_spec: info.target.into(),
+            stop_time: info.stop_time,
             transport: Some(Transport::UDPNotif),
             encoding: Some(Encoding::Json),
-            purpose: info.purpose().map(String::from),
-            update_trigger: info.update_trigger().cloned().map(UpdateTrigger::from),
-            module: info.models().to_vec(),
-            yang_library_content_id: Some(info.content_id().clone()),
+            purpose: info.purpose.map(String::from),
+            update_trigger: info.update_trigger.map(UpdateTrigger::from),
+            module: info.models.to_vec(),
+            yang_library_content_id: Some(info.content_id),
         }
     }
 }
@@ -435,19 +435,19 @@ impl FilterSpec {
 
 impl From<Target> for FilterSpec {
     fn from(target: Target) -> Self {
-        let xpath_filter = if let Some(xpath_filter) = target.stream_xpath_filter() {
+        let xpath_filter = if let Some(xpath_filter) = target.stream_xpath_filter {
             Some(xpath_filter.to_string())
         } else {
-            target.datastore_xpath_filter().map(String::from)
+            target.datastore_xpath_filter
         };
-        let subtree_filter = if let Some(subtree) = target.stream_subtree_filter() {
-            Some(subtree.clone())
+        let subtree_filter = if let Some(subtree) = target.stream_subtree_filter {
+            Some(subtree)
         } else {
-            target.datastore_subtree_filter().cloned()
+            target.datastore_subtree_filter
         };
         Self {
-            stream: target.stream().map(String::from),
-            datastore: target.datastore().map(String::from),
+            stream: target.stream,
+            datastore: target.datastore,
             xpath_filter,
             subtree_filter,
         }

--- a/crates/yang-push/src/model/telemetry.rs
+++ b/crates/yang-push/src/model/telemetry.rs
@@ -417,7 +417,7 @@ impl FilterSpec {
 
 /// Update Trigger for Yang Push Subscription
 /// (redefined for Telemetry Message)
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum UpdateTrigger {
     #[serde(rename = "periodic")]
     #[serde(rename_all = "kebab-case")]

--- a/crates/yang-push/src/validation/mod.rs
+++ b/crates/yang-push/src/validation/mod.rs
@@ -122,7 +122,7 @@ use crate::{
 };
 use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
 use netgauze_netconf_proto::yang_push::types::SubscriptionId;
-use netgauze_udp_notif_pkt::decoded::UdpNotifPacketDecoded;
+use netgauze_udp_notif_pkt::decoded::{UdpNotifPacketDecoded, UdpNotifPayload};
 use netgauze_udp_notif_pkt::notification::{NotificationVariant, SubscriptionStartedModified};
 use netgauze_udp_notif_pkt::raw::UdpNotifPacket;
 use netgauze_udp_notif_service::OTL_UDP_NOTIF_PUBLISHER_ID_KEY;
@@ -583,7 +583,7 @@ impl ValidationActor {
         let mut peer_tags = Self::peer_tags_from_packet(peer, packet);
         let message_id = decoded.message_id();
         let publisher_id = decoded.publisher_id();
-
+        let is_legacy = matches!(decoded.payload(), UdpNotifPayload::NotificationLegacy(_));
         let extract_sub_info = self
             .extract_subscription_info(Arc::clone(&message), peer, &decoded)
             .await?;
@@ -615,6 +615,7 @@ impl ValidationActor {
                 cached_content_id.clone(),
                 &notification_type,
                 yang_ctx,
+                is_legacy,
             );
             // logging of error is handled in the [Self::validate_message]
             if validation_result.is_err() {
@@ -680,6 +681,7 @@ impl ValidationActor {
         cached_content_id: ContentId,
         notification_type: &String,
         yang_ctx: &yang4::context::Context,
+        is_legacy: bool,
     ) -> Result<(), yang4::Error> {
         let mut peer_tags = Self::peer_tags_from_packet(peer, packet);
         Self::extend_peer_targs_with_subscription_info(subscription_info, &mut peer_tags);
@@ -692,7 +694,9 @@ impl ValidationActor {
         {
             envelope_ext = Some(ext);
         }
-        if let Some(envelope_ext) = envelope_ext {
+        if let Some(envelope_ext) = envelope_ext
+            && !is_legacy
+        {
             let validation_result = yang4::data::DataTree::parse_ext_string(
                 &envelope_ext,
                 packet.payload(),
@@ -701,6 +705,9 @@ impl ValidationActor {
                 DataValidationFlags::PRESENT,
             );
             if let Err(err) = validation_result {
+                let v = packet.payload().clone();
+                let packet_payload =
+                    str::from_utf8(v.as_ref()).unwrap_or("unserializable packet payload");
                 warn!(
                     peer=%peer,
                     message_id,
@@ -711,6 +718,7 @@ impl ValidationActor {
                     cached_content_id,
                     notification_type,
                     error=%err,
+                    packet=packet_payload,
                     "Failed to validate UDP-Notif payload using draft-ietf-netconf-notif-envelope, dropping packet"
                 );
                 return Err(err);

--- a/crates/yang-push/src/validation/mod.rs
+++ b/crates/yang-push/src/validation/mod.rs
@@ -998,12 +998,16 @@ impl ValidationActor {
         Some(SubscriptionInfo::new(
             peer,
             sub_started.id(),
+            sub_started.target().clone(),
+            sub_started.stop_time().cloned(),
+            sub_started.transport().cloned(),
+            sub_started.encoding().cloned(),
+            sub_started.purpose().map(|x| x.into()),
+            modules,
             sub_started
                 .yang_library_content_id()
                 .map(|x| x.to_string())
                 .unwrap_or_default(),
-            sub_started.target().clone(),
-            modules,
         ))
     }
 
@@ -1178,6 +1182,7 @@ mod tests {
                             "ietf-yang-push:datastore-xpath-filter": "/ietf-interfaces:interfaces",
                             "transport": "ietf-udp-notif-transport:udp-notif",
                             "encoding": "encode-json",
+                            "purpose": "test subscription",
                             "ietf-distributed-notif:message-publisher-id": [
                                 16843789
                             ],

--- a/crates/yang-push/src/validation/mod.rs
+++ b/crates/yang-push/src/validation/mod.rs
@@ -120,6 +120,7 @@ use crate::{
     OTL_YANG_PUSH_SUBSCRIPTION_ID_KEY, OTL_YANG_PUSH_SUBSCRIPTION_ROUTER_CONTENT_ID_KEY,
     OTL_YANG_PUSH_SUBSCRIPTION_TARGET_KEY,
 };
+use netgauze_netconf_proto::yang_push::subscription::YangPushModuleVersion;
 use netgauze_netconf_proto::yang_push::types::SubscriptionId;
 use netgauze_udp_notif_pkt::decoded::UdpNotifPacketDecoded;
 use netgauze_udp_notif_pkt::notification::{NotificationVariant, SubscriptionStartedModified};
@@ -973,10 +974,13 @@ impl ValidationActor {
     ) -> Option<SubscriptionInfo> {
         let modules = match sub_started.module_version() {
             Some(modules) => {
-                let mut module_names: Vec<String> =
-                    modules.iter().map(|m| m.name().to_string()).collect();
-                module_names.push("ietf-subscribed-notifications".to_string());
-                module_names
+                let mut modules = modules.clone();
+                modules.push(YangPushModuleVersion::new(
+                    "ietf-subscribed-notifications".into(),
+                    None,
+                    None,
+                ));
+                modules.into_boxed_slice()
             }
             None => {
                 warn!(
@@ -1180,7 +1184,7 @@ mod tests {
                             "ietf-yang-push-revision:module-version": [
                                 {
                                     "name": "ietf-interfaces",
-                                    "revision": ""
+                                    "revision": "2018-02-20"
                                 }
                             ],
                             "ietf-yang-push-revision:yang-library-content-id": "test-content-id-1",

--- a/crates/yang-push/src/validation/mod.rs
+++ b/crates/yang-push/src/validation/mod.rs
@@ -1003,6 +1003,7 @@ impl ValidationActor {
             sub_started.transport().cloned(),
             sub_started.encoding().cloned(),
             sub_started.purpose().map(|x| x.into()),
+            sub_started.update_trigger().cloned(),
             modules,
             sub_started
                 .yang_library_content_id()


### PR DESCRIPTION
Extend SubscriptionInfo struct with additional fields, which is already cached on disk. Then for the YANG push enrichment it only uses the information form the subscription info. 

This allows NetGauze to always keep the state on disk and not depend on subscription started messages. And also benefit from the NETCONF get to obtain the subscription info from the router if the subscription started message is lost. 