### PR TITLE
Revert workaround solution to handle augmented-by that are declared as import-only

### DIFF
--- a/crates/netconf-proto/src/client.rs
+++ b/crates/netconf-proto/src/client.rs
@@ -617,12 +617,6 @@ impl<T: AsyncRead + AsyncWrite + Unpin> NetConfSshClient<T> {
                     && !visited.contains(dev_module.name())
                 {
                     to_process.push_back(ModuleType::Full(dev_module.clone()));
-                } else if let Some(dev_modules) = yang_lib.find_import_module(deviation_name) {
-                    for dev_module in dev_modules {
-                        if !visited.contains(dev_module.name()) {
-                            to_process.push_back(ModuleType::ImportOnly(dev_module.clone()));
-                        }
-                    }
                 }
             }
 
@@ -632,12 +626,6 @@ impl<T: AsyncRead + AsyncWrite + Unpin> NetConfSshClient<T> {
                     && !visited.contains(augmented_by.name())
                 {
                     to_process.push_back(ModuleType::Full(augmented_by.clone()));
-                } else if let Some(augmented_bys) = yang_lib.find_import_module(augmentation_name) {
-                    for augmented_by in augmented_bys {
-                        if !visited.contains(augmented_by.name()) {
-                            to_process.push_back(ModuleType::ImportOnly(augmented_by.clone()));
-                        }
-                    }
                 }
             }
             match module {

--- a/crates/netconf-proto/src/client.rs
+++ b/crates/netconf-proto/src/client.rs
@@ -618,20 +618,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin> NetConfSshClient<T> {
                 {
                     to_process.push_back(ModuleType::Full(dev_module.clone()));
                 } else if let Some(dev_modules) = yang_lib.find_import_module(deviation_name) {
-                    // Temporary solution see  https://github.com/NetGauze/NetGauze/issues/449
                     for dev_module in dev_modules {
                         if !visited.contains(dev_module.name()) {
-                            let module = Module::new(
-                                dev_module.name().into(),
-                                dev_module.revision().map(|x| x.into()),
-                                dev_module.namespace().into(),
-                                Box::new([]),
-                                Box::new([]),
-                                Box::new([]),
-                                Box::new([]),
-                                dev_module.locations().to_vec().into_boxed_slice(),
-                            );
-                            to_process.push_back(ModuleType::Full(module));
+                            to_process.push_back(ModuleType::ImportOnly(dev_module.clone()));
                         }
                     }
                 }
@@ -644,20 +633,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin> NetConfSshClient<T> {
                 {
                     to_process.push_back(ModuleType::Full(augmented_by.clone()));
                 } else if let Some(augmented_bys) = yang_lib.find_import_module(augmentation_name) {
-                    // Temporary solution see  https://github.com/NetGauze/NetGauze/issues/449
                     for augmented_by in augmented_bys {
                         if !visited.contains(augmented_by.name()) {
-                            let module = Module::new(
-                                augmented_by.name().into(),
-                                augmented_by.revision().map(|x| x.into()),
-                                augmented_by.namespace().into(),
-                                Box::new([]),
-                                Box::new([]),
-                                Box::new([]),
-                                Box::new([]),
-                                augmented_by.locations().to_vec().into_boxed_slice(),
-                            );
-                            to_process.push_back(ModuleType::Full(module));
+                            to_process.push_back(ModuleType::ImportOnly(augmented_by.clone()));
                         }
                     }
                 }


### PR DESCRIPTION
The PRs #430  and #454  are introduced as temporary fix to get around a vendor bug. Now this bug is solved.

Closes #449 