### PR TITLE
Fix parsing of RFC 4684 Route Target Constraint withdrawals

### DIFF
--- a/crates/bgp-pkt/src/wire/deserializer/path_attribute/path_attribute.rs
+++ b/crates/bgp-pkt/src/wire/deserializer/path_attribute/path_attribute.rs
@@ -1118,7 +1118,7 @@ impl<'a>
             Ok(addr_type @ AddressType::RouteTargetConstrains) => {
                 let add_path = add_path_map.get(&addr_type).is_some_and(|x| *x);
                 let (_, nlri) = parse_till_empty_into_with_one_input_located(mp_buf, add_path)?;
-                Ok((buf, MpUnreach::L2Evpn { nlri }))
+                Ok((buf, MpUnreach::RouteTargetMembership { nlri }))
             }
             Ok(addr_type @ AddressType::BgpLs) => {
                 let add_path = add_path_map.get(&addr_type).is_some_and(|x| *x);

--- a/crates/bgp-pkt/src/wire/tests/path_attribute.rs
+++ b/crates/bgp-pkt/src/wire/tests/path_attribute.rs
@@ -2537,6 +2537,60 @@ fn test_path_attr_route_target_membership() -> Result<(), PathAttributeWritingEr
 }
 
 #[test]
+fn test_path_attr_mp_unreach_route_target_membership() -> Result<(), PathAttributeWritingError> {
+    // MP_UNREACH_NLRI carrying RFC 4684 Route Target Constraint withdrawals:
+    //   - Attribute flags 0x90 (Optional + Extended Length)
+    //   - Attribute type 0x0f (MP_UNREACH_NLRI = 15)
+    //   - Attribute length 0x001d (29 bytes of value: 3 AFI/SAFI + 2 * 13 NLRI)
+    //   - AFI 0x0001 (IPv4)
+    //   - SAFI 0x84 (132, Route Target Constraint)
+    //   - Two RTC NLRIs, each {prefix-len=96, origin AS=65484, RT 65484:4018 /
+    //     65484:4003}
+    let good_wire = [
+        0x90, 0x0f, 0x00, 0x1d, 0x00, 0x01, 0x84, 0x60, 0x00, 0x00, 0xff, 0xcc, 0x00, 0x02, 0xff,
+        0xcc, 0x00, 0x00, 0x0f, 0xb2, 0x60, 0x00, 0x00, 0xff, 0xcc, 0x00, 0x02, 0xff, 0xcc, 0x00,
+        0x00, 0x0f, 0xa3,
+    ];
+
+    let mp_unreach = MpUnreach::RouteTargetMembership {
+        nlri: vec![
+            RouteTargetMembershipAddress::new(
+                None,
+                Some(RouteTargetMembership::new(
+                    65484,
+                    vec![0x00, 0x02, 0xff, 0xcc, 0x00, 0x00, 0x0f, 0xb2],
+                )),
+            ),
+            RouteTargetMembershipAddress::new(
+                None,
+                Some(RouteTargetMembership::new(
+                    65484,
+                    vec![0x00, 0x02, 0xff, 0xcc, 0x00, 0x00, 0x0f, 0xa3],
+                )),
+            ),
+        ],
+    };
+
+    let good = PathAttribute::from(
+        true,
+        false,
+        false,
+        true,
+        PathAttributeValue::MpUnreach(mp_unreach),
+    )
+    .unwrap();
+
+    test_parsed_completely_with_one_input(
+        &good_wire,
+        &mut BgpParsingContext::asn2_default(),
+        &good,
+    );
+
+    test_write(&good, &good_wire)?;
+    Ok(())
+}
+
+#[test]
 fn test_otc_path_attribute() -> Result<(), PathAttributeWritingError> {
     let good_wire = [0xc0, 0x23, 0x04, 0x00, 0x00, 0xfd, 0xe9];
     let good = PathAttribute::from(


### PR DESCRIPTION
The RouteTargetConstrains arm of the MpUnreach deserializer was returning MpUnreach::L2Evpn instead of MpUnreach::RouteTargetMembership, a copy-paste error from the EVPN arm immediately above. As a result, parsing an MP_UNREACH_NLRI with AFI=1/SAFI=132 attempted to decode the RTC NLRI bytes as Vec<L2EvpnAddress> and failed (the 0x60 prefix-length byte is not a valid EVPN route type), so RTC withdrawals could not be round-tripped through the parser.

Add a regression test test_path_attr_mp_unreach_route_target_membership mirroring the existing test_path_attr_route_target_membership (MpReach) to lock in both halves of the round-trip.