### PR TITLE
YANG & NETCONF XML parser support empty strings `<tag></tag>`  and strings in self-closing tags `<tag />`

### DIFF
--- a/crates/netconf-proto/src/xml_utils.rs
+++ b/crates/netconf-proto/src/xml_utils.rs
@@ -459,16 +459,11 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
     }
 
     #[inline]
-    fn ensure_parent_has_child(&self) -> Result<(), ParsingError> {
-        match self.parent_has_child() {
-            true => Ok(()),
-            false => Err(ParsingError::Recoverable),
-        }
-    }
-
-    #[inline]
     pub fn tag_string(&mut self) -> Result<Box<str>, ParsingError> {
-        self.ensure_parent_has_child()?;
+        // Support self-closing tags (i.e. <tag />)
+        if !self.parent_has_child() {
+            return Ok("".into());
+        }
         let mut accumulator = String::new();
         loop {
             match self.peek() {
@@ -495,7 +490,11 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
                     accumulator.push_str(replaced);
                     self.next_event()?
                 }
-                Event::End(_) | Event::Start(_) | Event::Empty(_) => {
+                Event::End(_) => {
+                    // Support empty tags (i.e. <tag></tag>)
+                    return Ok(accumulator.into());
+                }
+                Event::Start(_) | Event::Empty(_) => {
                     if accumulator.is_empty() {
                         return Err(ParsingError::WrongToken {
                             expecting: "text".to_string(),
@@ -1188,6 +1187,32 @@ mod tests {
         parser.open(None, "child").unwrap();
         // Empty element doesn't count as having children
         assert!(!parser.parent_has_child());
+    }
+
+    /// `tag_string()` called immediately after `open()`-ing a self-closing tag
+    /// must return an empty string (not an error), because `<purpose/>` is
+    /// semantically equivalent to `<purpose></purpose>`.
+    #[test]
+    fn test_tag_string_returns_empty_string_for_self_closing_tag() {
+        let xml = r#"<root><purpose/></root>"#;
+        let mut parser = create_parser(xml);
+        parser.open(None, "root").unwrap();
+        parser.open(None, "purpose").unwrap();
+
+        let result = parser.tag_string();
+        assert_eq!(result, Ok("".into()));
+    }
+
+    /// Same as above but using explicit empty content `<purpose></purpose>`.
+    #[test]
+    fn test_tag_string_returns_empty_string_for_explicit_empty_tag() {
+        let xml = r#"<root><purpose></purpose></root>"#;
+        let mut parser = create_parser(xml);
+        parser.open(None, "root").unwrap();
+        parser.open(None, "purpose").unwrap();
+
+        let result = parser.tag_string();
+        assert_eq!(result, Ok("".into()));
     }
 
     #[test]


### PR DESCRIPTION
Issue which we experienced: 
```
2026-05-20T15:05:30.316722Z DEBUG netgauze_yang_push::cache::actor: sent error response to requester due to fetch failure peer=10.190.64.79:10100 subscription_id=14 router_content_id="EMPTY" target={ datastore: EMPTY, datastore-xpath-filter: EMPTY } error=failed to connect to netconf server: Error in XML parsing the <rpc-reply> message: Recoverable
```

Now we do not experience it anymore:
```
2026-05-21T08:25:39.396008Z  INFO netgauze_yang_push::cache::fetcher: YANG Library fetched from device host=10.190.64.79:830 peer=10.190.64.79:10100 subscription_id=24 router_content_id="bcda49ca12973c1644ebbe8f20cf72d98b01c76c1425b0dafff3f27f4deef7f3" target={ datastore: ietf-datastores:operational, datastore-xpath-filter: /if:interfaces-state/if:interface/bbf-xponani:ani/bbf-xpon-ani-state:running-info } cached_content_id="bcda49ca12973c1644ebbe8f20cf72d98b01c76c1425b0dafff3f27f4deef7f3" schema_count=352
2026-05-21T08:25:39.396762Z  INFO netgauze_yang_push::cache::actor: fetched yang library from device successfully subscription_id=24 router_content_id="22934" target={ datastore: ietf-datastores:operational, datastore-xpath-filter: /if:interfaces-state/if:interface/bbf-xponani:ani/bbf-xpon-ani-state:running-info } modules_count=352 cached_content_id="bcda49ca12973c1644ebbe8f20cf72d98b01c76c1425b0dafff3f27f4deef7f3"
```