### PR TITLE
bmp-pkt: use Box<[T]>/Box<str> for message collections

### DIFF
--- a/crates/bmp-pkt/src/codec.rs
+++ b/crates/bmp-pkt/src/codec.rs
@@ -369,7 +369,7 @@ mod tests {
     fn good_termination_wire() -> ([u8; 14], BmpMessage) {
         let wire = [3, 0, 0, 0, 14, 5, 0, 0, 0, 4, b't', b'e', b's', b't'];
         let msg = BmpMessage::V3(v3::BmpMessageValue::Termination(
-            v3::TerminationMessage::new(vec![TerminationInformation::String("test".to_string())]),
+            v3::TerminationMessage::new(vec![TerminationInformation::String("test".into())]),
         ));
         (wire, msg)
     }
@@ -499,8 +499,8 @@ mod tests {
     fn test_codec() -> Result<(), BmpMessageWritingError> {
         let msg = BmpMessage::V3(v3::BmpMessageValue::Initiation(v3::InitiationMessage::new(
             vec![
-                InitiationInformation::SystemDescription("test11".to_string()),
-                InitiationInformation::SystemName("PE2".to_string()),
+                InitiationInformation::SystemDescription("test11".into()),
+                InitiationInformation::SystemName("PE2".into()),
             ],
         )));
         let mut code = BmpCodec::default();
@@ -628,7 +628,7 @@ mod tests {
         ));
 
         let terminate = BmpMessage::V3(v3::BmpMessageValue::Termination(
-            v3::TerminationMessage::new(vec![TerminationInformation::String("test".to_string())]),
+            v3::TerminationMessage::new(vec![TerminationInformation::String("test".into())]),
         ));
 
         let mut codec = BmpCodec::default();

--- a/crates/bmp-pkt/src/v3.rs
+++ b/crates/bmp-pkt/src/v3.rs
@@ -36,10 +36,10 @@ pub enum BmpMessageValue {
     Initiation(InitiationMessage),
     Termination(TerminationMessage),
     RouteMirroring(RouteMirroringMessage),
-    Experimental251(Vec<u8>),
-    Experimental252(Vec<u8>),
-    Experimental253(Vec<u8>),
-    Experimental254(Vec<u8>),
+    Experimental251(Box<[u8]>),
+    Experimental252(Box<[u8]>),
+    Experimental253(Box<[u8]>),
+    Experimental254(Box<[u8]>),
 }
 
 impl BmpMessageValue {
@@ -74,15 +74,17 @@ impl BmpMessageValue {
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct InitiationMessage {
-    information: Vec<InitiationInformation>,
+    information: Box<[InitiationInformation]>,
 }
 
 impl InitiationMessage {
-    pub const fn new(information: Vec<InitiationInformation>) -> Self {
-        Self { information }
+    pub fn new(information: impl Into<Box<[InitiationInformation]>>) -> Self {
+        Self {
+            information: information.into(),
+        }
     }
 
-    pub const fn information(&self) -> &Vec<InitiationInformation> {
+    pub const fn information(&self) -> &[InitiationInformation] {
         &self.information
     }
 }
@@ -106,15 +108,15 @@ impl InitiationMessage {
 pub enum InitiationInformation {
     /// The Information field contains a free-form UTF-8 string whose length is
     /// given by the Information Length field.
-    String(String),
+    String(Box<str>),
 
     /// The Information field contains an ASCII string whose value MUST be set
     /// to be equal to the value of the sysDescr MIB-II [RFC1213](https://datatracker.ietf.org/doc/html/rfc1213).
-    SystemDescription(String),
+    SystemDescription(Box<str>),
 
     /// The Information field contains an ASCII string whose value MUST be set
     /// to be equal to the value of the sysName MIB-II [RFC1213](https://datatracker.ietf.org/doc/html/rfc1213).
-    SystemName(String),
+    SystemName(Box<str>),
 
     /// The Information field contains a UTF-8 string whose value MUST be
     /// equal to the value of the VRF or table name (e.g., RD instance name)
@@ -122,7 +124,7 @@ pub enum InitiationInformation {
     /// bytes.
     ///
     /// See [RFC9069](https://datatracker.ietf.org/doc/html/rfc9069)
-    VrfTableName(String),
+    VrfTableName(Box<str>),
 
     /// The Information field contains a free-form UTF-8 string whose byte
     /// length is given by the Information Length field. The value is
@@ -133,12 +135,12 @@ pub enum InitiationInformation {
     /// their order.
     ///
     /// See [RFC8671](https://datatracker.ietf.org/doc/html/rfc8671)
-    AdminLabel(String),
+    AdminLabel(Box<str>),
 
-    Experimental65531(Vec<u8>),
-    Experimental65532(Vec<u8>),
-    Experimental65533(Vec<u8>),
-    Experimental65534(Vec<u8>),
+    Experimental65531(Box<[u8]>),
+    Experimental65532(Box<[u8]>),
+    Experimental65533(Box<[u8]>),
+    Experimental65534(Box<[u8]>),
 }
 
 impl InitiationInformation {
@@ -174,15 +176,17 @@ impl InitiationInformation {
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct TerminationMessage {
-    information: Vec<TerminationInformation>,
+    information: Box<[TerminationInformation]>,
 }
 
 impl TerminationMessage {
-    pub const fn new(information: Vec<TerminationInformation>) -> Self {
-        Self { information }
+    pub fn new(information: impl Into<Box<[TerminationInformation]>>) -> Self {
+        Self {
+            information: information.into(),
+        }
     }
 
-    pub const fn information(&self) -> &Vec<TerminationInformation> {
+    pub const fn information(&self) -> &[TerminationInformation] {
         &self.information
     }
 }
@@ -203,12 +207,12 @@ impl TerminationMessage {
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum TerminationInformation {
-    String(String),
+    String(Box<str>),
     Reason(PeerTerminationCode),
-    Experimental65531(Vec<u8>),
-    Experimental65532(Vec<u8>),
-    Experimental65533(Vec<u8>),
-    Experimental65534(Vec<u8>),
+    Experimental65531(Box<[u8]>),
+    Experimental65532(Box<[u8]>),
+    Experimental65533(Box<[u8]>),
+    Experimental65534(Box<[u8]>),
 }
 
 impl TerminationInformation {
@@ -283,14 +287,14 @@ impl RouteMonitoringMessage {
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct RouteMirroringMessage {
     peer_header: PeerHeader,
-    mirrored: Vec<RouteMirroringValue>,
+    mirrored: Box<[RouteMirroringValue]>,
 }
 
 impl RouteMirroringMessage {
-    pub const fn new(peer_header: PeerHeader, mirrored: Vec<RouteMirroringValue>) -> Self {
+    pub fn new(peer_header: PeerHeader, mirrored: impl Into<Box<[RouteMirroringValue]>>) -> Self {
         Self {
             peer_header,
-            mirrored,
+            mirrored: mirrored.into(),
         }
     }
 
@@ -298,7 +302,7 @@ impl RouteMirroringMessage {
         &self.peer_header
     }
 
-    pub const fn mirrored(&self) -> &Vec<RouteMirroringValue> {
+    pub const fn mirrored(&self) -> &[RouteMirroringValue] {
         &self.mirrored
     }
 }
@@ -308,7 +312,7 @@ impl RouteMirroringMessage {
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum MirroredBgpMessage {
     Parsed(BgpMessage),
-    Raw(Vec<u8>),
+    Raw(Box<[u8]>),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -323,10 +327,10 @@ pub enum RouteMirroringValue {
     /// A 2-byte code that provides information about the mirrored message or
     /// message stream.
     Information(RouteMirroringInformation),
-    Experimental65531(Vec<u8>),
-    Experimental65532(Vec<u8>),
-    Experimental65533(Vec<u8>),
-    Experimental65534(Vec<u8>),
+    Experimental65531(Box<[u8]>),
+    Experimental65532(Box<[u8]>),
+    Experimental65533(Box<[u8]>),
+    Experimental65534(Box<[u8]>),
 }
 
 impl RouteMirroringValue {
@@ -376,7 +380,7 @@ pub struct PeerUpNotificationMessage {
     remote_port: Option<u16>,
     sent_message: BgpMessage,
     received_message: BgpMessage,
-    information: Vec<InitiationInformation>,
+    information: Box<[InitiationInformation]>,
 }
 
 /// Runtime errors when constructing a [`PeerUpNotificationMessage`]
@@ -401,7 +405,7 @@ impl PeerUpNotificationMessage {
         remote_port: Option<u16>,
         sent_message: BgpMessage,
         received_message: BgpMessage,
-        information: Vec<InitiationInformation>,
+        information: impl Into<Box<[InitiationInformation]>>,
     ) -> Result<Self, PeerUpNotificationMessageError> {
         if sent_message.get_type() != BgpMessageType::Open {
             return Err(PeerUpNotificationMessageError::UnexpectedSentMessageType(
@@ -422,7 +426,7 @@ impl PeerUpNotificationMessage {
             remote_port,
             sent_message,
             received_message,
-            information,
+            information: information.into(),
         })
     }
 
@@ -450,7 +454,7 @@ impl PeerUpNotificationMessage {
         &self.received_message
     }
 
-    pub const fn information(&self) -> &Vec<InitiationInformation> {
+    pub const fn information(&self) -> &[InitiationInformation] {
         &self.information
     }
 }
@@ -581,10 +585,10 @@ pub enum PeerDownNotificationReason {
     /// included if it was in the Peer Up.
     LocalSystemClosedTlvDataFollows(InitiationInformation),
 
-    Experimental251(Vec<u8>),
-    Experimental252(Vec<u8>),
-    Experimental253(Vec<u8>),
-    Experimental254(Vec<u8>),
+    Experimental251(Box<[u8]>),
+    Experimental252(Box<[u8]>),
+    Experimental253(Box<[u8]>),
+    Experimental254(Box<[u8]>),
 }
 
 impl PeerDownNotificationReason {
@@ -630,14 +634,14 @@ impl PeerDownNotificationReason {
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub struct StatisticsReportMessage {
     peer_header: PeerHeader,
-    counters: Vec<StatisticsCounter>,
+    counters: Box<[StatisticsCounter]>,
 }
 
 impl StatisticsReportMessage {
-    pub const fn new(peer_header: PeerHeader, counters: Vec<StatisticsCounter>) -> Self {
+    pub fn new(peer_header: PeerHeader, counters: impl Into<Box<[StatisticsCounter]>>) -> Self {
         Self {
             peer_header,
-            counters,
+            counters: counters.into(),
         }
     }
 
@@ -645,7 +649,7 @@ impl StatisticsReportMessage {
         &self.peer_header
     }
 
-    pub const fn counters(&self) -> &Vec<StatisticsCounter> {
+    pub const fn counters(&self) -> &[StatisticsCounter] {
         &self.counters
     }
 }
@@ -711,11 +715,11 @@ pub enum StatisticsCounter {
     NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutInvalidatedByRpki(AddressType, GaugeU64),
     NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutValidatedByRpki(AddressType, GaugeU64),
     NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound(AddressType, GaugeU64),
-    Experimental65531(Vec<u8>),
-    Experimental65532(Vec<u8>),
-    Experimental65533(Vec<u8>),
-    Experimental65534(Vec<u8>),
-    Unknown(u16, Vec<u8>),
+    Experimental65531(Box<[u8]>),
+    Experimental65532(Box<[u8]>),
+    Experimental65533(Box<[u8]>),
+    Experimental65534(Box<[u8]>),
+    Unknown(u16, Box<[u8]>),
 }
 
 impl StatisticsCounter {

--- a/crates/bmp-pkt/src/v4.rs
+++ b/crates/bmp-pkt/src/v4.rs
@@ -36,17 +36,17 @@ pub enum BmpMessageValue {
     Initiation(v3::InitiationMessage),
     Termination(v3::TerminationMessage),
     RouteMirroring(v3::RouteMirroringMessage),
-    Experimental251(Vec<u8>),
-    Experimental252(Vec<u8>),
-    Experimental253(Vec<u8>),
-    Experimental254(Vec<u8>),
+    Experimental251(Box<[u8]>),
+    Experimental252(Box<[u8]>),
+    Experimental253(Box<[u8]>),
+    Experimental254(Box<[u8]>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum PeerDownTlv {
-    Unknown { code: u16, value: Vec<u8> },
+    Unknown { code: u16, value: Box<[u8]> },
 }
 
 impl PeerDownTlv {
@@ -173,11 +173,11 @@ pub enum RouteMonitoringTlvType {
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum RouteMonitoringTlvValue {
     StatelessParsing(BgpCapability),
-    GroupTlv(Vec<u16>),
-    VrfTableName(String),
+    GroupTlv(Box<[u16]>),
+    VrfTableName(Box<str>),
     BgpUpdate(BgpMessage),
     PathMarking(PathMarking),
-    Unknown { code: u16, value: Vec<u8> },
+    Unknown { code: u16, value: Box<[u8]> },
 }
 
 /// Path Status TLV [draft-ietf-grow-bmp-path-marking-tlv](https://datatracker.ietf.org/doc/html/draft-ietf-grow-bmp-path-marking-tlv)
@@ -403,14 +403,14 @@ impl From<RouteMonitoringTlvError> for RouteMonitoringError {
 pub struct RouteMonitoringMessage {
     peer_header: PeerHeader,
     update_pdu: RouteMonitoringTlv,
-    tlvs: Vec<RouteMonitoringTlv>,
+    tlvs: Box<[RouteMonitoringTlv]>,
 }
 
 impl RouteMonitoringMessage {
     pub fn build(
         peer_header: PeerHeader,
         update_pdu: BgpMessage,
-        tlvs: Vec<RouteMonitoringTlv>,
+        tlvs: impl Into<Box<[RouteMonitoringTlv]>>,
     ) -> Result<Self, RouteMonitoringError> {
         let update_pdu =
             RouteMonitoringTlv::build(0, RouteMonitoringTlvValue::BgpUpdate(update_pdu))?;
@@ -418,7 +418,7 @@ impl RouteMonitoringMessage {
         Ok(Self {
             peer_header,
             update_pdu,
-            tlvs,
+            tlvs: tlvs.into(),
         })
     }
 
@@ -439,7 +439,7 @@ impl RouteMonitoringMessage {
         }
     }
 
-    pub const fn tlvs(&self) -> &Vec<RouteMonitoringTlv> {
+    pub const fn tlvs(&self) -> &[RouteMonitoringTlv] {
         &self.tlvs
     }
 }
@@ -450,14 +450,14 @@ impl RouteMonitoringMessage {
 pub struct PeerDownNotificationMessage {
     peer_header: PeerHeader,
     reason: v3::PeerDownNotificationReason,
-    tlvs: Vec<PeerDownTlv>,
+    tlvs: Box<[PeerDownTlv]>,
 }
 
 impl PeerDownNotificationMessage {
     pub fn build(
         peer_header: PeerHeader,
         reason: v3::PeerDownNotificationReason,
-        tlvs: Vec<PeerDownTlv>,
+        tlvs: impl Into<Box<[PeerDownTlv]>>,
     ) -> Result<Self, v3::PeerDownNotificationMessageError> {
         match &reason {
             v3::PeerDownNotificationReason::LocalSystemClosedNotificationPduFollows(msg)
@@ -491,7 +491,7 @@ impl PeerDownNotificationMessage {
         Ok(Self {
             peer_header,
             reason,
-            tlvs,
+            tlvs: tlvs.into(),
         })
     }
 
@@ -503,7 +503,7 @@ impl PeerDownNotificationMessage {
         &self.reason
     }
 
-    pub const fn tlvs(&self) -> &Vec<PeerDownTlv> {
+    pub const fn tlvs(&self) -> &[PeerDownTlv] {
         &self.tlvs
     }
 }

--- a/crates/bmp-pkt/src/wire/deserializer/mod.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/mod.rs
@@ -28,6 +28,35 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
+/// Counts the type+length+value tuples in a buffer using the 2-byte-type,
+/// 2-byte-length TLV framing shared by BMP's Initiation, Termination,
+/// Route Mirroring, Peer-Up, and Peer-Down information TLVs. Takes the
+/// reader by value (`SliceReader` is `Copy`), so it peeks without
+/// disturbing the caller's cursor, and never allocates.
+///
+/// Purely advisory: a malformed buffer stops the count early rather than
+/// returning an error, so it only ever affects the capacity hint, never
+/// what the real parsing loop reports.
+#[inline]
+pub(crate) fn count_tlvs_t16_l16(mut cur: SliceReader<'_>) -> usize {
+    let mut count = 0usize;
+    loop {
+        if cur.is_empty() {
+            return count;
+        }
+        let Ok(_tlv_type) = cur.read_u16_be() else {
+            return count;
+        };
+        let Ok(tlv_length) = cur.read_u16_be() else {
+            return count;
+        };
+        if cur.take_slice(tlv_length as usize).is_err() {
+            return count;
+        }
+        count += 1;
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, Serialize, Deserialize)]
 pub enum BmpMessageParsingError {
     #[error("while parsing BMP message: {0}")]

--- a/crates/bmp-pkt/src/wire/deserializer/v3.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/v3.rs
@@ -23,7 +23,7 @@ use netgauze_bgp_pkt::wire::deserializer::{BgpMessageParsingError, BgpParsingCon
 use netgauze_iana::address_family::{AddressFamily, AddressType, SubsequentAddressFamily};
 
 use crate::iana::*;
-use crate::wire::deserializer::BmpParsingContext;
+use crate::wire::deserializer::{BmpParsingContext, count_tlvs_t16_l16};
 use crate::{BmpPeerType, CounterU32, GaugeU64, PeerHeader, PeerKey, v3};
 use netgauze_parse_utils::error::ParseError;
 use netgauze_parse_utils::reader::SliceReader;
@@ -106,19 +106,19 @@ impl<'a> ParseFromWithOneInput<'a, &mut BmpParsingContext> for v3::BmpMessageVal
             }
             BmpMessageType::Experimental251 => {
                 let value = cur.read_bytes(cur.remaining())?;
-                v3::BmpMessageValue::Experimental251(value.to_vec())
+                v3::BmpMessageValue::Experimental251(value.into())
             }
             BmpMessageType::Experimental252 => {
                 let value = cur.read_bytes(cur.remaining())?;
-                v3::BmpMessageValue::Experimental252(value.to_vec())
+                v3::BmpMessageValue::Experimental252(value.into())
             }
             BmpMessageType::Experimental253 => {
                 let value = cur.read_bytes(cur.remaining())?;
-                v3::BmpMessageValue::Experimental253(value.to_vec())
+                v3::BmpMessageValue::Experimental253(value.into())
             }
             BmpMessageType::Experimental254 => {
                 let value = cur.read_bytes(cur.remaining())?;
-                v3::BmpMessageValue::Experimental254(value.to_vec())
+                v3::BmpMessageValue::Experimental254(value.into())
             }
         };
         Ok(msg)
@@ -135,7 +135,7 @@ impl<'a> ParseFrom<'a> for v3::InitiationMessage {
     type Error = InitiationMessageParsingError;
 
     fn parse(cur: &mut SliceReader<'a>) -> Result<Self, Self::Error> {
-        let mut information = Vec::new();
+        let mut information = Vec::with_capacity(count_tlvs_t16_l16(*cur));
         while !cur.is_empty() {
             let info = v3::InitiationInformation::parse(cur)?;
             information.push(info);
@@ -177,7 +177,7 @@ impl<'a> ParseFrom<'a> for v3::InitiationInformation {
             InitiationInformationTlvType::String => {
                 let offset = buf.offset();
                 match String::from_utf8(buf.read_bytes(buf.remaining())?.to_vec()) {
-                    Ok(s) => Ok(v3::InitiationInformation::String(s)),
+                    Ok(s) => Ok(v3::InitiationInformation::String(s.into_boxed_str())),
                     Err(error) => Err(InitiationInformationParsingError::FromUtf8Error {
                         offset,
                         error: error.to_string(),
@@ -187,7 +187,9 @@ impl<'a> ParseFrom<'a> for v3::InitiationInformation {
             InitiationInformationTlvType::SystemDescription => {
                 let offset = buf.offset();
                 match String::from_utf8(buf.read_bytes(buf.remaining())?.to_vec()) {
-                    Ok(s) => Ok(v3::InitiationInformation::SystemDescription(s)),
+                    Ok(s) => Ok(v3::InitiationInformation::SystemDescription(
+                        s.into_boxed_str(),
+                    )),
                     Err(error) => Err(InitiationInformationParsingError::FromUtf8Error {
                         offset,
                         error: error.to_string(),
@@ -197,7 +199,7 @@ impl<'a> ParseFrom<'a> for v3::InitiationInformation {
             InitiationInformationTlvType::SystemName => {
                 let offset = buf.offset();
                 match String::from_utf8(buf.read_bytes(buf.remaining())?.to_vec()) {
-                    Ok(s) => Ok(v3::InitiationInformation::SystemName(s)),
+                    Ok(s) => Ok(v3::InitiationInformation::SystemName(s.into_boxed_str())),
                     Err(error) => Err(InitiationInformationParsingError::FromUtf8Error {
                         offset,
                         error: error.to_string(),
@@ -207,7 +209,7 @@ impl<'a> ParseFrom<'a> for v3::InitiationInformation {
             InitiationInformationTlvType::VrfTableName => {
                 let offset = buf.offset();
                 match String::from_utf8(buf.read_bytes(buf.remaining())?.to_vec()) {
-                    Ok(s) => Ok(v3::InitiationInformation::VrfTableName(s)),
+                    Ok(s) => Ok(v3::InitiationInformation::VrfTableName(s.into_boxed_str())),
                     Err(error) => Err(InitiationInformationParsingError::FromUtf8Error {
                         offset,
                         error: error.to_string(),
@@ -217,7 +219,7 @@ impl<'a> ParseFrom<'a> for v3::InitiationInformation {
             InitiationInformationTlvType::AdminLabel => {
                 let offset = buf.offset();
                 match String::from_utf8(buf.read_bytes(buf.remaining())?.to_vec()) {
-                    Ok(s) => Ok(v3::InitiationInformation::AdminLabel(s)),
+                    Ok(s) => Ok(v3::InitiationInformation::AdminLabel(s.into_boxed_str())),
                     Err(error) => Err(InitiationInformationParsingError::FromUtf8Error {
                         offset,
                         error: error.to_string(),
@@ -226,22 +228,22 @@ impl<'a> ParseFrom<'a> for v3::InitiationInformation {
             }
             InitiationInformationTlvType::Experimental65531 => {
                 Ok(v3::InitiationInformation::Experimental65531(
-                    buf.read_bytes(buf.remaining())?.to_vec(),
+                    buf.read_bytes(buf.remaining())?.into(),
                 ))
             }
             InitiationInformationTlvType::Experimental65532 => {
                 Ok(v3::InitiationInformation::Experimental65532(
-                    buf.read_bytes(buf.remaining())?.to_vec(),
+                    buf.read_bytes(buf.remaining())?.into(),
                 ))
             }
             InitiationInformationTlvType::Experimental65533 => {
                 Ok(v3::InitiationInformation::Experimental65533(
-                    buf.read_bytes(buf.remaining())?.to_vec(),
+                    buf.read_bytes(buf.remaining())?.into(),
                 ))
             }
             InitiationInformationTlvType::Experimental65534 => {
                 Ok(v3::InitiationInformation::Experimental65534(
-                    buf.read_bytes(buf.remaining())?.to_vec(),
+                    buf.read_bytes(buf.remaining())?.into(),
                 ))
             }
         }
@@ -502,7 +504,7 @@ impl<'a> ParseFromWithOneInput<'a, &mut BmpParsingContext> for v3::PeerUpNotific
         let bgp_ctx = ctx.entry(peer_key).or_default();
         bgp_ctx.set_asn4(peer_header.is_asn4());
         let received_message = BgpMessage::parse(cur, bgp_ctx)?;
-        let mut information = Vec::new();
+        let mut information = Vec::with_capacity(count_tlvs_t16_l16(*cur));
         while !cur.is_empty() {
             let info = v3::InitiationInformation::parse(cur)?;
             information.push(info);
@@ -618,22 +620,22 @@ impl<'a> ParseFromWithOneInput<'a, &mut BgpParsingContext> for v3::PeerDownNotif
             }
             PeerDownReasonCode::Experimental251 => {
                 Ok(v3::PeerDownNotificationReason::Experimental251(
-                    cur.take_slice(cur.remaining())?.as_slice().to_vec(),
+                    cur.take_slice(cur.remaining())?.as_slice().into(),
                 ))
             }
             PeerDownReasonCode::Experimental252 => {
                 Ok(v3::PeerDownNotificationReason::Experimental252(
-                    cur.take_slice(cur.remaining())?.as_slice().to_vec(),
+                    cur.take_slice(cur.remaining())?.as_slice().into(),
                 ))
             }
             PeerDownReasonCode::Experimental253 => {
                 Ok(v3::PeerDownNotificationReason::Experimental253(
-                    cur.take_slice(cur.remaining())?.as_slice().to_vec(),
+                    cur.take_slice(cur.remaining())?.as_slice().into(),
                 ))
             }
             PeerDownReasonCode::Experimental254 => {
                 Ok(v3::PeerDownNotificationReason::Experimental254(
-                    cur.take_slice(cur.remaining())?.as_slice().to_vec(),
+                    cur.take_slice(cur.remaining())?.as_slice().into(),
                 ))
             }
         }
@@ -657,7 +659,7 @@ impl<'a> ParseFromWithOneInput<'a, &mut BmpParsingContext> for v3::RouteMirrorin
         let peer_key = PeerKey::from_peer_header(&peer_header);
         let bgp_ctx = ctx.entry(peer_key).or_default();
         bgp_ctx.set_asn4(peer_header.is_asn4());
-        let mut mirrored = Vec::new();
+        let mut mirrored = Vec::with_capacity(count_tlvs_t16_l16(*cur));
         while !cur.is_empty() {
             let element = v3::RouteMirroringValue::parse(cur, bgp_ctx)?;
             mirrored.push(element);
@@ -731,19 +733,19 @@ impl<'a> ParseFromWithOneInput<'a, &mut BgpParsingContext> for v3::RouteMirrorin
             }
             RouteMirroringTlvType::Experimental65531 => {
                 let data = buf.take_slice(length as usize)?;
-                v3::RouteMirroringValue::Experimental65531(data.as_slice().to_vec())
+                v3::RouteMirroringValue::Experimental65531(data.as_slice().into())
             }
             RouteMirroringTlvType::Experimental65532 => {
                 let data = buf.take_slice(length as usize)?;
-                v3::RouteMirroringValue::Experimental65532(data.as_slice().to_vec())
+                v3::RouteMirroringValue::Experimental65532(data.as_slice().into())
             }
             RouteMirroringTlvType::Experimental65533 => {
                 let data = buf.take_slice(length as usize)?;
-                v3::RouteMirroringValue::Experimental65533(data.as_slice().to_vec())
+                v3::RouteMirroringValue::Experimental65533(data.as_slice().into())
             }
             RouteMirroringTlvType::Experimental65534 => {
                 let data = buf.take_slice(length as usize)?;
-                v3::RouteMirroringValue::Experimental65534(data.as_slice().to_vec())
+                v3::RouteMirroringValue::Experimental65534(data.as_slice().into())
             }
         };
         if !buf.is_empty() {
@@ -770,7 +772,7 @@ impl<'a> ParseFrom<'a> for v3::TerminationMessage {
     type Error = TerminationMessageParsingError;
 
     fn parse(cur: &mut SliceReader<'a>) -> Result<Self, Self::Error> {
-        let mut information = Vec::new();
+        let mut information = Vec::with_capacity(count_tlvs_t16_l16(*cur));
         while !cur.is_empty() {
             let info = v3::TerminationInformation::parse(cur)?;
             information.push(info);
@@ -823,7 +825,7 @@ impl<'a> ParseFrom<'a> for v3::TerminationInformation {
             TerminationInformationTlvType::String => {
                 let offset = buf.offset();
                 match String::from_utf8(buf.read_bytes(buf.remaining())?.to_vec()) {
-                    Ok(s) => v3::TerminationInformation::String(s),
+                    Ok(s) => v3::TerminationInformation::String(s.into_boxed_str()),
                     Err(error) => {
                         return Err(TerminationInformationParsingError::FromUtf8Error {
                             offset,
@@ -849,22 +851,22 @@ impl<'a> ParseFrom<'a> for v3::TerminationInformation {
             }
             TerminationInformationTlvType::Experimental65531 => {
                 v3::TerminationInformation::Experimental65531(
-                    buf.read_bytes(buf.remaining())?.to_vec(),
+                    buf.read_bytes(buf.remaining())?.into(),
                 )
             }
             TerminationInformationTlvType::Experimental65532 => {
                 v3::TerminationInformation::Experimental65532(
-                    buf.read_bytes(buf.remaining())?.to_vec(),
+                    buf.read_bytes(buf.remaining())?.into(),
                 )
             }
             TerminationInformationTlvType::Experimental65533 => {
                 v3::TerminationInformation::Experimental65533(
-                    buf.read_bytes(buf.remaining())?.to_vec(),
+                    buf.read_bytes(buf.remaining())?.into(),
                 )
             }
             TerminationInformationTlvType::Experimental65534 => {
                 v3::TerminationInformation::Experimental65534(
-                    buf.read_bytes(buf.remaining())?.to_vec(),
+                    buf.read_bytes(buf.remaining())?.into(),
                 )
             }
         };
@@ -896,7 +898,11 @@ impl<'a> ParseFrom<'a> for v3::StatisticsReportMessage {
     fn parse(cur: &mut SliceReader<'a>) -> Result<Self, Self::Error> {
         let peer_header = PeerHeader::parse(cur)?;
         let stats_count = cur.read_u32_be()?;
-        let mut counters = Vec::new();
+        // Clamp the declared count against the smallest possible counter
+        // (a 4-byte T16/L16 header) so a malformed count can't request a
+        // huge allocation up front.
+        let capacity = (stats_count as usize).min(cur.remaining() / 4);
+        let mut counters = Vec::with_capacity(capacity);
         for _ in 0..stats_count {
             let counter = v3::StatisticsCounter::parse(cur)?;
             counters.push(counter);
@@ -1173,20 +1179,20 @@ impl<'a> ParseFrom<'a> for v3::StatisticsCounter {
                     v3::StatisticsCounter::NumberOfRoutesInPerAfiSafiPostPolicyAdjRibOutRpkiNotFound(address_type, GaugeU64::new(value))
                 }
                 BmpStatisticsType::Experimental65531 => {
-                    v3::StatisticsCounter::Experimental65531(buf.take_slice(buf.remaining())?.as_slice().to_vec())
+                    v3::StatisticsCounter::Experimental65531(buf.take_slice(buf.remaining())?.as_slice().into())
                 }
                 BmpStatisticsType::Experimental65532 => {
-                    v3::StatisticsCounter::Experimental65532(buf.take_slice(buf.remaining())?.as_slice().to_vec())
+                    v3::StatisticsCounter::Experimental65532(buf.take_slice(buf.remaining())?.as_slice().into())
                 }
                 BmpStatisticsType::Experimental65533 => {
-                    v3::StatisticsCounter::Experimental65533(buf.take_slice(buf.remaining())?.as_slice().to_vec())
+                    v3::StatisticsCounter::Experimental65533(buf.take_slice(buf.remaining())?.as_slice().into())
                 }
                 BmpStatisticsType::Experimental65534 => {
-                    v3::StatisticsCounter::Experimental65534(buf.take_slice(buf.remaining())?.as_slice().to_vec())
+                    v3::StatisticsCounter::Experimental65534(buf.take_slice(buf.remaining())?.as_slice().into())
                 }
             },
             Err(code) => {
-                v3::StatisticsCounter::Unknown(code.0, buf.take_slice(buf.remaining())?.as_slice().to_vec())
+                v3::StatisticsCounter::Unknown(code.0, buf.take_slice(buf.remaining())?.as_slice().into())
             }
         };
         if !buf.is_empty() {

--- a/crates/bmp-pkt/src/wire/deserializer/v4.rs
+++ b/crates/bmp-pkt/src/wire/deserializer/v4.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::iana::BmpMessageType;
-use crate::wire::deserializer::BmpParsingContext;
+use crate::wire::deserializer::{BmpParsingContext, count_tlvs_t16_l16};
 use crate::{BmpPeerType, PeerHeader, PeerKey, v3, v4};
 use netgauze_bgp_pkt::BgpMessage;
 use netgauze_bgp_pkt::wire::deserializer::capabilities::BgpCapabilityParsingError;
@@ -109,19 +109,19 @@ impl<'a> ParseFromWithOneInput<'a, &mut BmpParsingContext> for v4::BmpMessageVal
             }
             BmpMessageType::Experimental251 => {
                 let value = cur.read_bytes(cur.remaining())?;
-                v4::BmpMessageValue::Experimental251(value.to_vec())
+                v4::BmpMessageValue::Experimental251(value.into())
             }
             BmpMessageType::Experimental252 => {
                 let value = cur.read_bytes(cur.remaining())?;
-                v4::BmpMessageValue::Experimental252(value.to_vec())
+                v4::BmpMessageValue::Experimental252(value.into())
             }
             BmpMessageType::Experimental253 => {
                 let value = cur.read_bytes(cur.remaining())?;
-                v4::BmpMessageValue::Experimental253(value.to_vec())
+                v4::BmpMessageValue::Experimental253(value.into())
             }
             BmpMessageType::Experimental254 => {
                 let value = cur.read_bytes(cur.remaining())?;
-                v4::BmpMessageValue::Experimental254(value.to_vec())
+                v4::BmpMessageValue::Experimental254(value.into())
             }
         };
         Ok(msg)
@@ -141,7 +141,7 @@ impl<'a> ParseFrom<'a> for v4::PeerDownTlv {
             read_tlv_header_t16_l16::<PeerDownTlvParsingError>(cur)?;
         Ok(Self::Unknown {
             code: tlv_type,
-            value: value.read_bytes(value.remaining())?.to_vec(),
+            value: value.read_bytes(value.remaining())?.into(),
         })
     }
 }
@@ -303,7 +303,7 @@ impl<'a> ParseFromWithTwoInputs<'a, &mut BgpParsingContext, bool> for v4::RouteM
                 v4::RouteMonitoringTlvType::VrfTableName => {
                     let offset = data.offset();
                     match String::from_utf8(data.as_slice().to_vec()) {
-                        Ok(s) => v4::RouteMonitoringTlvValue::VrfTableName(s),
+                        Ok(s) => v4::RouteMonitoringTlvValue::VrfTableName(s.into_boxed_str()),
                         Err(error) => {
                             return Err(RouteMonitoringTlvParsingError::FromUtf8Error {
                                 offset,
@@ -321,7 +321,7 @@ impl<'a> ParseFromWithTwoInputs<'a, &mut BgpParsingContext, bool> for v4::RouteM
                     while !data.is_empty() {
                         values.push(data.read_u16_be()?);
                     }
-                    v4::RouteMonitoringTlvValue::GroupTlv(values)
+                    v4::RouteMonitoringTlvValue::GroupTlv(values.into())
                 }
                 v4::RouteMonitoringTlvType::StatelessParsing => {
                     let bgp_capability = BgpCapability::parse(&mut data)?;
@@ -335,7 +335,7 @@ impl<'a> ParseFromWithTwoInputs<'a, &mut BgpParsingContext, bool> for v4::RouteM
             },
             None => v4::RouteMonitoringTlvValue::Unknown {
                 code: tlv_type,
-                value: data.as_slice().to_vec(),
+                value: data.as_slice().into(),
             },
         };
 
@@ -376,7 +376,7 @@ impl<'a> ParseFromWithOneInput<'a, &mut BmpParsingContext> for v4::PeerDownNotif
         let bgp_ctx = ctx.entry(peer_key).or_default();
         bgp_ctx.set_asn4(peer_header.is_asn4());
         let reason = v3::PeerDownNotificationReason::parse(cur, bgp_ctx)?;
-        let mut tlvs = Vec::new();
+        let mut tlvs = Vec::with_capacity(count_tlvs_t16_l16(*cur));
         while !cur.is_empty() {
             let tlv = v4::PeerDownTlv::parse(cur)?;
             tlvs.push(tlv);

--- a/crates/bmp-pkt/src/wire/tests/v3.rs
+++ b/crates/bmp-pkt/src/wire/tests/v3.rs
@@ -336,15 +336,15 @@ fn test_initiation_information() -> Result<(), InitiationInformationWritingError
     let bad_eof_wire = [];
     let bad_undefined_type_wire = [0xff, 0xff];
 
-    let good_string = InitiationInformation::String("AB".to_string());
-    let good_sys_descr = InitiationInformation::SystemDescription("AB".to_string());
-    let good_sys_name = InitiationInformation::SystemName("AB".to_string());
-    let good_vrf_table = InitiationInformation::VrfTableName("AB".to_string());
-    let good_admin_label = InitiationInformation::AdminLabel("AB".to_string());
-    let good_experimental_65531 = InitiationInformation::Experimental65531(vec![0x01, 0x02]);
-    let good_experimental_65532 = InitiationInformation::Experimental65532(vec![0x01, 0x02]);
-    let good_experimental_65533 = InitiationInformation::Experimental65533(vec![0x01, 0x02]);
-    let good_experimental_65534 = InitiationInformation::Experimental65534(vec![0x01, 0x02]);
+    let good_string = InitiationInformation::String("AB".into());
+    let good_sys_descr = InitiationInformation::SystemDescription("AB".into());
+    let good_sys_name = InitiationInformation::SystemName("AB".into());
+    let good_vrf_table = InitiationInformation::VrfTableName("AB".into());
+    let good_admin_label = InitiationInformation::AdminLabel("AB".into());
+    let good_experimental_65531 = InitiationInformation::Experimental65531(vec![0x01, 0x02].into());
+    let good_experimental_65532 = InitiationInformation::Experimental65532(vec![0x01, 0x02].into());
+    let good_experimental_65533 = InitiationInformation::Experimental65533(vec![0x01, 0x02].into());
+    let good_experimental_65534 = InitiationInformation::Experimental65534(vec![0x01, 0x02].into());
 
     let bad_eof = InitiationInformationParsingError::Parse(ParseError::UnexpectedEof {
         offset: 0,
@@ -396,8 +396,8 @@ fn test_initiation_message() -> Result<(), InitiationMessageWritingError> {
     let bad_info_wire = [0xff, 0xff];
 
     let good = InitiationMessage::new(vec![
-        InitiationInformation::SystemDescription("AB".to_string()),
-        InitiationInformation::SystemName("CD".to_string()),
+        InitiationInformation::SystemDescription("AB".into()),
+        InitiationInformation::SystemName("CD".into()),
     ]);
 
     let bad_info = InitiationMessageParsingError::InitiationInformationError(
@@ -430,8 +430,8 @@ fn test_bmp_value_initiation_message() -> Result<(), BmpMessageValueWritingError
     ];
 
     let good = BmpMessageValue::Initiation(InitiationMessage::new(vec![
-        InitiationInformation::SystemDescription("test11".to_string()),
-        InitiationInformation::SystemName("PE2".to_string()),
+        InitiationInformation::SystemDescription("test11".into()),
+        InitiationInformation::SystemName("PE2".into()),
     ]));
     let bad_information = BmpMessageValueParsingError::InitiationMessageError(
         InitiationMessageParsingError::InitiationInformationError(
@@ -913,12 +913,12 @@ fn test_peer_down_reason() -> Result<(), PeerDownNotificationReasonWritingError>
     let good_remote_no_data = PeerDownNotificationReason::RemoteSystemClosedNoData;
     let good_peer_de_configured = PeerDownNotificationReason::PeerDeConfigured;
     let good_local_system_closed = PeerDownNotificationReason::LocalSystemClosedTlvDataFollows(
-        InitiationInformation::VrfTableName("vrf1".to_string()),
+        InitiationInformation::VrfTableName("vrf1".into()),
     );
-    let good_experimental_251 = PeerDownNotificationReason::Experimental251(vec![1, 3]);
-    let good_experimental_252 = PeerDownNotificationReason::Experimental252(vec![1, 3]);
-    let good_experimental_253 = PeerDownNotificationReason::Experimental253(vec![1, 3]);
-    let good_experimental_254 = PeerDownNotificationReason::Experimental254(vec![1, 3]);
+    let good_experimental_251 = PeerDownNotificationReason::Experimental251(vec![1, 3].into());
+    let good_experimental_252 = PeerDownNotificationReason::Experimental252(vec![1, 3].into());
+    let good_experimental_253 = PeerDownNotificationReason::Experimental253(vec![1, 3].into());
+    let good_experimental_254 = PeerDownNotificationReason::Experimental254(vec![1, 3].into());
 
     let bad_local_pdu_bgp = PeerDownNotificationReasonParsingError::BgpMessageError(
         BgpMessageParsingError::UndefinedBgpMessageType {
@@ -1196,10 +1196,10 @@ fn test_router_mirroring_value() -> Result<(), RouteMirroringValueWritingError> 
     let good_bgp =
         RouteMirroringValue::BgpMessage(MirroredBgpMessage::Parsed(BgpMessage::KeepAlive));
     let good_information = RouteMirroringValue::Information(RouteMirroringInformation::ErroredPdu);
-    let good_experimental_65531 = RouteMirroringValue::Experimental65531(vec![1, 2]);
-    let good_experimental_65532 = RouteMirroringValue::Experimental65532(vec![1, 2]);
-    let good_experimental_65533 = RouteMirroringValue::Experimental65533(vec![1, 2]);
-    let good_experimental_65534 = RouteMirroringValue::Experimental65534(vec![1, 2]);
+    let good_experimental_65531 = RouteMirroringValue::Experimental65531(vec![1, 2].into());
+    let good_experimental_65532 = RouteMirroringValue::Experimental65532(vec![1, 2].into());
+    let good_experimental_65533 = RouteMirroringValue::Experimental65533(vec![1, 2].into());
+    let good_experimental_65534 = RouteMirroringValue::Experimental65534(vec![1, 2].into());
 
     test_parsed_completely_with_one_input_bytes_reader(
         &good_bgp_wire,
@@ -1284,16 +1284,16 @@ fn test_termination_information() -> Result<(), TerminationInformationWritingErr
     let good_experimental_65533_wire = [0xff, 0xfd, 0, 4, 116, 101, 115, 116];
     let good_experimental_65534_wire = [0xff, 0xfe, 0, 4, 116, 101, 115, 116];
 
-    let good_string = TerminationInformation::String("test".to_string());
+    let good_string = TerminationInformation::String("test".into());
     let good_reason = TerminationInformation::Reason(PeerTerminationCode::AdministrativelyClosed);
     let good_experimental_65531 =
-        TerminationInformation::Experimental65531(vec![116, 101, 115, 116]);
+        TerminationInformation::Experimental65531(vec![116, 101, 115, 116].into());
     let good_experimental_65532 =
-        TerminationInformation::Experimental65532(vec![116, 101, 115, 116]);
+        TerminationInformation::Experimental65532(vec![116, 101, 115, 116].into());
     let good_experimental_65533 =
-        TerminationInformation::Experimental65533(vec![116, 101, 115, 116]);
+        TerminationInformation::Experimental65533(vec![116, 101, 115, 116].into());
     let good_experimental_65534 =
-        TerminationInformation::Experimental65534(vec![116, 101, 115, 116]);
+        TerminationInformation::Experimental65534(vec![116, 101, 115, 116].into());
 
     test_parsed_completely_bytes_reader(&good_string_wire, &good_string);
     test_parsed_completely_bytes_reader(&good_reason_wire, &good_reason);
@@ -1314,7 +1314,7 @@ fn test_termination_information() -> Result<(), TerminationInformationWritingErr
 #[test]
 fn test_termination_message() -> Result<(), TerminationMessageWritingError> {
     let good_wire = [0, 0, 0, 4, 116, 101, 115, 116];
-    let good = TerminationMessage::new(vec![TerminationInformation::String("test".to_string())]);
+    let good = TerminationMessage::new(vec![TerminationInformation::String("test".into())]);
 
     test_parsed_completely_bytes_reader(&good_wire, &good);
     test_write(&good, &good_wire)?;
@@ -1326,7 +1326,7 @@ fn test_bmp_termination() -> Result<(), BmpMessageWritingError> {
     let good_wire = [3, 0, 0, 0, 14, 5, 0, 0, 0, 4, 116, 101, 115, 116];
 
     let good = BmpMessage::V3(BmpMessageValue::Termination(TerminationMessage::new(vec![
-        TerminationInformation::String("test".to_string()),
+        TerminationInformation::String("test".into()),
     ])));
 
     test_parsed_completely_with_one_input_bytes_reader(&good_wire, &mut Default::default(), &good);
@@ -1342,7 +1342,7 @@ fn test_bmp_termination_with_reason() -> Result<(), BmpMessageWritingError> {
     ];
 
     let good = BmpMessage::V3(BmpMessageValue::Termination(TerminationMessage::new(vec![
-        TerminationInformation::String("config removed".to_string()),
+        TerminationInformation::String("config removed".into()),
         TerminationInformation::Reason(PeerTerminationCode::AdministrativelyClosed),
     ])));
 
@@ -1387,7 +1387,7 @@ fn test_bmp_statistics_report() -> Result<(), BmpMessageWritingError> {
                 )),
                 StatisticsCounter::NumberOfDuplicateWithdraws(CounterU32::new(0)),
                 StatisticsCounter::NumberOfUpdatesSubjectedToTreatAsWithdraw(CounterU32::new(6)),
-                StatisticsCounter::Experimental65531(vec![0, 0, 0, 0]),
+                StatisticsCounter::Experimental65531(vec![0, 0, 0, 0].into()),
             ],
         ),
     ));
@@ -1696,10 +1696,10 @@ fn test_bmp_value_experimental_messages() -> Result<(), BmpMessageValueWritingEr
         0x50, 0x45, 0x32,
     ];
 
-    let good_251 = BmpMessageValue::Experimental251(good_251_wire[1..].to_vec());
-    let good_252 = BmpMessageValue::Experimental252(good_252_wire[1..].to_vec());
-    let good_253 = BmpMessageValue::Experimental253(good_253_wire[1..].to_vec());
-    let good_254 = BmpMessageValue::Experimental254(good_254_wire[1..].to_vec());
+    let good_251 = BmpMessageValue::Experimental251(good_251_wire[1..].into());
+    let good_252 = BmpMessageValue::Experimental252(good_252_wire[1..].into());
+    let good_253 = BmpMessageValue::Experimental253(good_253_wire[1..].into());
+    let good_254 = BmpMessageValue::Experimental254(good_254_wire[1..].into());
 
     test_parsed_completely_with_one_input_bytes_reader(
         &good_251_wire,
@@ -1742,18 +1742,10 @@ fn test_bmp_experimental() -> Result<(), BmpMessageWritingError> {
     ];
     let good_254_wire = [0x03, 0x00, 0x00, 0x00, 0x06, 0xfe];
 
-    let good_251 = BmpMessage::V3(BmpMessageValue::Experimental251(
-        good_251_wire[6..].to_vec(),
-    ));
-    let good_252 = BmpMessage::V3(BmpMessageValue::Experimental252(
-        good_252_wire[6..].to_vec(),
-    ));
-    let good_253 = BmpMessage::V3(BmpMessageValue::Experimental253(
-        good_253_wire[6..].to_vec(),
-    ));
-    let good_254 = BmpMessage::V3(BmpMessageValue::Experimental254(
-        good_254_wire[6..].to_vec(),
-    ));
+    let good_251 = BmpMessage::V3(BmpMessageValue::Experimental251(good_251_wire[6..].into()));
+    let good_252 = BmpMessage::V3(BmpMessageValue::Experimental252(good_252_wire[6..].into()));
+    let good_253 = BmpMessage::V3(BmpMessageValue::Experimental253(good_253_wire[6..].into()));
+    let good_254 = BmpMessage::V3(BmpMessageValue::Experimental254(good_254_wire[6..].into()));
 
     test_parsed_completely_with_one_input_bytes_reader(
         &good_251_wire,

--- a/crates/bmp-pkt/src/wire/tests/v4.rs
+++ b/crates/bmp-pkt/src/wire/tests/v4.rs
@@ -107,14 +107,14 @@ fn test_bmp_v4_route_monitoring() -> Result<(), BmpMessageWritingError> {
             vec![
                 RouteMonitoringTlv::build(
                     0,
-                    RouteMonitoringTlvValue::VrfTableName("global".to_string()),
+                    RouteMonitoringTlvValue::VrfTableName("global".into()),
                 )
                 .unwrap(),
                 RouteMonitoringTlv::build(
                     0,
                     RouteMonitoringTlvValue::Unknown {
                         code: 9,
-                        value: vec![0x00, 0x00, 0x00, 0x0a],
+                        value: vec![0x00, 0x00, 0x00, 0x0a].into(),
                     },
                 )
                 .unwrap(),
@@ -194,19 +194,19 @@ fn test_bmp_v4_route_monitoring_with_groups() -> Result<(), BmpMessageWritingErr
             vec![
                 RouteMonitoringTlv::build(
                     BMPV4_TLV_GROUP_GBIT + 1024,
-                    RouteMonitoringTlvValue::GroupTlv(vec![1, 2, 3, 4]),
+                    RouteMonitoringTlvValue::GroupTlv(vec![1, 2, 3, 4].into()),
                 )
                 .unwrap(),
                 RouteMonitoringTlv::build(
                     0,
-                    RouteMonitoringTlvValue::VrfTableName("global".to_string()),
+                    RouteMonitoringTlvValue::VrfTableName("global".into()),
                 )
                 .unwrap(),
                 RouteMonitoringTlv::build(
                     0,
                     RouteMonitoringTlvValue::Unknown {
                         code: 9,
-                        value: vec![0x00, 0x00, 0x00, 0x0a],
+                        value: vec![0x00, 0x00, 0x00, 0x0a].into(),
                     },
                 )
                 .unwrap(),
@@ -437,7 +437,7 @@ fn test_bmp_v4_peer_down_notification() -> Result<(), BmpMessageWritingError> {
             v3::PeerDownNotificationReason::LocalSystemClosedFsmEventFollows(2),
             vec![PeerDownTlv::Unknown {
                 code: 16,
-                value: vec![0, 1, 2, 3, 4, 5, 6, 7],
+                value: vec![0, 1, 2, 3, 4, 5, 6, 7].into(),
             }],
         )
         .unwrap(),
@@ -553,11 +553,8 @@ fn test_bmp_v4_path_marking() -> Result<(), BmpMessageWritingError> {
                 ],
             )),
             vec![
-                RouteMonitoringTlv::build(
-                    0,
-                    RouteMonitoringTlvValue::VrfTableName("C10".to_string()),
-                )
-                .unwrap(),
+                RouteMonitoringTlv::build(0, RouteMonitoringTlvValue::VrfTableName("C10".into()))
+                    .unwrap(),
                 RouteMonitoringTlv::build(
                     0,
                     RouteMonitoringTlvValue::PathMarking(PathMarking::new(
@@ -681,11 +678,8 @@ fn test_bmp_v4_path_marking_invalid_with_reason() -> Result<(), BmpMessageWritin
                 ],
             )),
             vec![
-                RouteMonitoringTlv::build(
-                    0,
-                    RouteMonitoringTlvValue::VrfTableName("C10".to_string()),
-                )
-                .unwrap(),
+                RouteMonitoringTlv::build(0, RouteMonitoringTlvValue::VrfTableName("C10".into()))
+                    .unwrap(),
                 RouteMonitoringTlv::build(
                     0,
                     RouteMonitoringTlvValue::PathMarking(PathMarking::new(
@@ -828,10 +822,10 @@ fn test_bmp_value_experimental_messages() -> Result<(), BmpMessageValueWritingEr
         0x50, 0x45, 0x32,
     ];
 
-    let good_251 = BmpMessageValue::Experimental251(good_251_wire[1..].to_vec());
-    let good_252 = BmpMessageValue::Experimental252(good_252_wire[1..].to_vec());
-    let good_253 = BmpMessageValue::Experimental253(good_253_wire[1..].to_vec());
-    let good_254 = BmpMessageValue::Experimental254(good_254_wire[1..].to_vec());
+    let good_251 = BmpMessageValue::Experimental251(good_251_wire[1..].into());
+    let good_252 = BmpMessageValue::Experimental252(good_252_wire[1..].into());
+    let good_253 = BmpMessageValue::Experimental253(good_253_wire[1..].into());
+    let good_254 = BmpMessageValue::Experimental254(good_254_wire[1..].into());
 
     test_parsed_completely_with_one_input_bytes_reader(
         &good_251_wire,
@@ -874,18 +868,10 @@ fn test_bmp_experimental() -> Result<(), BmpMessageWritingError> {
     ];
     let good_254_wire = [0x04, 0x00, 0x00, 0x00, 0x06, 0xfe];
 
-    let good_251 = BmpMessage::V4(BmpMessageValue::Experimental251(
-        good_251_wire[6..].to_vec(),
-    ));
-    let good_252 = BmpMessage::V4(BmpMessageValue::Experimental252(
-        good_252_wire[6..].to_vec(),
-    ));
-    let good_253 = BmpMessage::V4(BmpMessageValue::Experimental253(
-        good_253_wire[6..].to_vec(),
-    ));
-    let good_254 = BmpMessage::V4(BmpMessageValue::Experimental254(
-        good_254_wire[6..].to_vec(),
-    ));
+    let good_251 = BmpMessage::V4(BmpMessageValue::Experimental251(good_251_wire[6..].into()));
+    let good_252 = BmpMessage::V4(BmpMessageValue::Experimental252(good_252_wire[6..].into()));
+    let good_253 = BmpMessage::V4(BmpMessageValue::Experimental253(good_253_wire[6..].into()));
+    let good_254 = BmpMessage::V4(BmpMessageValue::Experimental254(good_254_wire[6..].into()));
 
     test_parsed_completely_with_one_input_bytes_reader(
         &good_251_wire,

--- a/crates/bmp-service/src/actor/tests.rs
+++ b/crates/bmp-service/src/actor/tests.rs
@@ -24,7 +24,7 @@ use tokio_util::codec::FramedWrite;
 fn create_test_message() -> BmpMessage {
     BmpMessage::V3(netgauze_bmp_pkt::v3::BmpMessageValue::Initiation(
         InitiationMessage::new(vec![InitiationInformation::SystemDescription(
-            "NetGauze Test Actor".to_string(),
+            "NetGauze Test Actor".into(),
         )]),
     ))
 }

--- a/crates/bmp-service/src/supervisor/tests.rs
+++ b/crates/bmp-service/src/supervisor/tests.rs
@@ -26,7 +26,7 @@ use tokio_util::codec::FramedWrite;
 fn create_test_message() -> BmpMessage {
     BmpMessage::V3(netgauze_bmp_pkt::v3::BmpMessageValue::Initiation(
         InitiationMessage::new(vec![InitiationInformation::SystemDescription(
-            "NetGauze Test Actor".to_string(),
+            "NetGauze Test Actor".into(),
         )]),
     ))
 }

--- a/crates/bmp-service/src/transport.rs
+++ b/crates/bmp-service/src/transport.rs
@@ -150,7 +150,7 @@ mod tests {
     async fn read() {
         let good_wire = [3, 0, 0, 0, 14, 5, 0, 0, 0, 4, 116, 101, 115, 116];
         let good = BmpMessage::V3(BmpMessageValue::Termination(TerminationMessage::new(vec![
-            TerminationInformation::String("test".to_string()),
+            TerminationInformation::String("test".into()),
         ])));
         let bad_wire1 = [0x03, 0x00, 0x00, 0x00, 0x01, 0xff];
         let bad_wire2 = [0xff];

--- a/crates/collector/src/bmp/pmacct_schema.rs
+++ b/crates/collector/src/bmp/pmacct_schema.rs
@@ -988,11 +988,11 @@ fn convert_initiation(
 
     for info in msg.information() {
         match info {
-            v3::InitiationInformation::String(s) => bmp_init_info_string = Some(s.clone()),
+            v3::InitiationInformation::String(s) => bmp_init_info_string = Some(s.to_string()),
             v3::InitiationInformation::SystemDescription(s) => {
-                bmp_init_info_sysdescr = Some(s.clone())
+                bmp_init_info_sysdescr = Some(s.to_string())
             }
-            v3::InitiationInformation::SystemName(s) => bmp_init_info_sysname = Some(s.clone()),
+            v3::InitiationInformation::SystemName(s) => bmp_init_info_sysname = Some(s.to_string()),
             other => {
                 let reserved = bmp_init_info_reserved.get_or_insert_with(String::new);
                 if !reserved.is_empty() {
@@ -1036,7 +1036,7 @@ fn convert_termination(
 
     for info in msg.information() {
         match info {
-            v3::TerminationInformation::String(s) => bmp_term_info_string = Some(s.clone()),
+            v3::TerminationInformation::String(s) => bmp_term_info_string = Some(s.to_string()),
             v3::TerminationInformation::Reason(code) => {
                 bmp_term_info_reason = Some(code.to_string())
             }
@@ -1085,12 +1085,12 @@ fn convert_peer_up(
 
     for info in msg.information() {
         match info {
-            v3::InitiationInformation::String(s) => bmp_peer_up_info_string = Some(s.clone()),
+            v3::InitiationInformation::String(s) => bmp_peer_up_info_string = Some(s.to_string()),
             v3::InitiationInformation::VrfTableName(s) => {
-                bmp_peer_up_info_vrf_table_name = Some(s.clone())
+                bmp_peer_up_info_vrf_table_name = Some(s.to_string())
             }
             v3::InitiationInformation::AdminLabel(s) => {
-                bmp_peer_up_info_admin_label = Some(s.clone())
+                bmp_peer_up_info_admin_label = Some(s.to_string())
             }
             other => {
                 let reserved = bmp_peer_up_info_reserved.get_or_insert_with(String::new);

--- a/crates/pcap-decoder/src/handlers/bmp.rs
+++ b/crates/pcap-decoder/src/handlers/bmp.rs
@@ -116,9 +116,9 @@ mod tests {
                 flow_key,
                 BmpMessage::V3(BmpMessageValue::Initiation(InitiationMessage::new(vec![
                     InitiationInformation::SystemDescription(
-                        "Cisco IOS XR Software, Version 5.2.2.21I[Default]\nCopyright (c) 2014 by Cisco Systems, Inc.".to_string()
+                        "Cisco IOS XR Software, Version 5.2.2.21I[Default]\nCopyright (c) 2014 by Cisco Systems, Inc.".into()
                     ),
-                    InitiationInformation::SystemName("xr3".to_string())
+                    InitiationInformation::SystemName("xr3".into())
                 ])))
             ))]),
         );
@@ -173,9 +173,9 @@ mod tests {
                 flow_key,
                 BmpMessage::V3(BmpMessageValue::Initiation(InitiationMessage::new(vec![
                     InitiationInformation::SystemDescription(
-                        "Cisco IOS XR Software, Version 5.2.2.21I[Default]\nCopyright (c) 2014 by Cisco Systems, Inc.".to_string()
+                        "Cisco IOS XR Software, Version 5.2.2.21I[Default]\nCopyright (c) 2014 by Cisco Systems, Inc.".into()
                     ),
-                    InitiationInformation::SystemName("xr3".to_string())
+                    InitiationInformation::SystemName("xr3".into())
                 ])))
             ))]),
         );
@@ -223,9 +223,9 @@ mod tests {
 
         let expected_initiation = InitiationMessage::new(vec![
             InitiationInformation::SystemDescription(
-                "Cisco IOS XR Software, Version 5.2.2.21I[Default]\nCopyright (c) 2014 by Cisco Systems, Inc.".to_string()
+                "Cisco IOS XR Software, Version 5.2.2.21I[Default]\nCopyright (c) 2014 by Cisco Systems, Inc.".into()
             ),
-            InitiationInformation::SystemName("xr3".to_string())
+            InitiationInformation::SystemName("xr3".into())
         ]);
 
         assert_eq!(


### PR DESCRIPTION
Applies the same memory optimization already done in bgp-pkt to bmp-pkt: every owned collection and string in the BMP message model moves from `Vec<T>`/`String` to `Box<[T]>`/`Box<str>`, trimming 8 bytes of per-field overhead (pointer+len vs pointer+len+cap) on every retained message.

Performance (vs. the last nom-based version, performance governor, 52 microbenchmarks): decode 1.25× geomean (every benchmark faster, up to 1.53×), streaming 1.25× geomean. Encode is ~flat (1.04×) with three small regressions on route-monitoring encode paths that wrap and re-encode a BGP UPDATE ; inherited from the BGP write path, not introduced here.

