### PR TITLE
pcap-reader: support VLAN-tagged frames, stop panicking on unknown frames

### DIFF
--- a/crates/pcap-reader/src/lib.rs
+++ b/crates/pcap-reader/src/lib.rs
@@ -65,6 +65,57 @@ pub enum TransportProtocol {
     UDP,
 }
 
+/// EtherType values we dispatch on.
+///
+/// See the [IANA IEEE 802 numbers registry](https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml).
+mod ether_type {
+    pub const IPV4: u16 = 0x0800;
+    pub const IPV6: u16 = 0x86DD;
+    /// IEEE 802.1Q customer VLAN tag (C-TAG).
+    pub const VLAN: u16 = 0x8100;
+    /// IEEE 802.1ad service VLAN tag (S-TAG, "QinQ").
+    pub const VLAN_QINQ: u16 = 0x88A8;
+    /// Pre-standard QinQ TPID still emitted by some vendors.
+    pub const VLAN_LEGACY_QINQ: u16 = 0x9100;
+
+    pub const fn is_vlan(ether_type: u16) -> bool {
+        ether_type == VLAN || ether_type == VLAN_QINQ || ether_type == VLAN_LEGACY_QINQ
+    }
+}
+
+/// Octets a VLAN tag occupies *after* the EtherType that introduced it has
+/// already been consumed: 2 octets of Tag Control Information (PCP/DEI/VID)
+/// followed by 2 octets carrying the EtherType of whatever it encapsulates,
+/// which may be another tag, for stacked VLANs / QinQ.
+const VLAN_TAG_REMAINDER_LEN: usize = 4;
+
+/// Upper bound on stacked VLAN tags, so a malformed frame claiming an endless
+/// chain of tags can't spin here. Double tagging (QinQ) is the deepest stack
+/// seen in practice; the extra headroom costs nothing.
+const MAX_VLAN_TAGS: usize = 4;
+
+/// Walk past any 802.1Q/802.1ad VLAN tags, returning the EtherType of the
+/// encapsulated protocol and the payload positioned at its first octet.
+///
+/// `ether_type` is the EtherType *preceding* `payload`, so on entry `payload`
+/// starts at the tag's TCI when `ether_type` is a VLAN TPID.
+///
+/// Returns `None` if the frame is truncated mid-tag or stacks more tags than
+/// [`MAX_VLAN_TAGS`].
+fn strip_vlan_tags(mut ether_type: u16, mut payload: &[u8]) -> Option<(u16, &[u8])> {
+    for _ in 0..=MAX_VLAN_TAGS {
+        if !ether_type::is_vlan(ether_type) {
+            return Some((ether_type, payload));
+        }
+        if payload.len() < VLAN_TAG_REMAINDER_LEN {
+            return None;
+        }
+        ether_type = u16::from_be_bytes([payload[2], payload[3]]);
+        payload = &payload[VLAN_TAG_REMAINDER_LEN..];
+    }
+    None
+}
+
 /// Iterator over pcap files
 pub struct PcapIter<'a> {
     reader: Box<dyn PcapReaderIterator + 'a>,
@@ -105,7 +156,13 @@ impl Iterator for PcapIter<'_> {
                             );
                             let result = PcapIter::parse_packet(packet_data);
                             self.reader.consume(offset);
-                            return result;
+                            // A frame we don't extract from (ARP, ICMP, a
+                            // non-IP EtherType, ...) must not end iteration
+                            // skip it and keep reading.
+                            if result.is_some() {
+                                return result;
+                            }
+                            continue;
                         }
                         PcapBlockOwned::LegacyHeader(header) => {
                             self.reader.consume(offset);
@@ -128,7 +185,12 @@ impl Iterator for PcapIter<'_> {
                             );
                             let result = PcapIter::parse_packet(packet_data);
                             self.reader.consume(offset);
-                            return result;
+                            // See the legacy-block arm above: skipped frames
+                            // must not terminate iteration.
+                            if result.is_some() {
+                                return result;
+                            }
+                            continue;
                         }
                         PcapBlockOwned::NG(Block::SimplePacket(_)) => {
                             todo!()
@@ -163,33 +225,55 @@ impl<'a> PcapIter<'a> {
         match data {
             None => None,
             Some(PacketData::L2(l2_pkt)) => Self::parse_ethernet(l2_pkt),
+            // Link types that hand us a bare L3 payload plus its EtherType;
+            // notably Linux cooked capture (LINKTYPE_LINUX_SLL), where a
+            // VLAN-tagged frame surfaces as EtherType 0x8100 with the tag
+            // still in front of the IP header.
             Some(PacketData::L3(ether_type, data)) => {
-                match ether_type {
-                    // See for ethernet numbers https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml
-                    0x0800 => Self::parse_ipv4(Ipv4Pdu::new(data).expect("Invalid IPv4")),
-                    0x86DD => Self::parse_ipv6(Ipv6Pdu::new(data).expect("Invalid IPv6")),
-                    _ => unimplemented!("Only IPv4 and IPv6 packets are supported"),
-                }
+                let (ether_type, data) = strip_vlan_tags(ether_type, data)?;
+                Self::parse_l3(ether_type, data)
             }
-            Some(PacketData::L4(_, _)) => unimplemented!("Only Ethernet packets are supported"),
-            Some(PacketData::Unsupported(_)) => {
-                unimplemented!("Only Ethernet and L3 packets are supported")
-            }
+            // Anything else (raw L4, or a link type pcap-parser can't
+            // classify) is skipped rather than aborting the whole capture.
+            Some(PacketData::L4(_, _)) | Some(PacketData::Unsupported(_)) => None,
+        }
+    }
+
+    /// Dispatch an L3 payload on its EtherType. Non-IP frames (ARP, LLDP, …)
+    /// and malformed IP headers are skipped, matching how the Ethernet path
+    /// already treats ARP.
+    fn parse_l3(
+        ether_type: u16,
+        data: &'a [u8],
+    ) -> Option<(IpAddr, u16, IpAddr, u16, TransportProtocol, Vec<u8>)> {
+        match ether_type {
+            ether_type::IPV4 => Ipv4Pdu::new(data).ok().and_then(Self::parse_ipv4),
+            ether_type::IPV6 => Ipv6Pdu::new(data).ok().and_then(Self::parse_ipv6),
+            _ => None,
         }
     }
 
     fn parse_ethernet(
         l2_pkt: &'a [u8],
     ) -> Option<(IpAddr, u16, IpAddr, u16, TransportProtocol, Vec<u8>)> {
-        pdu::EthernetPdu::new(l2_pkt)
-            .map(|eth_pdu| match eth_pdu.inner() {
-                Err(_) => None,
-                Ok(Ethernet::Raw(_)) => unimplemented!(),
-                Ok(Ethernet::Arp(_)) => None,
-                Ok(Ethernet::Ipv4(ipv4_pdu)) => Self::parse_ipv4(ipv4_pdu),
-                Ok(Ethernet::Ipv6(ipv6_pdu)) => Self::parse_ipv6(ipv6_pdu),
-            })
-            .unwrap()
+        let eth_pdu = pdu::EthernetPdu::new(l2_pkt).ok()?;
+        // Captured before `into_inner` consumes the PDU; only needed for the
+        // `Raw` arm below.
+        let outer_ether_type = eth_pdu.ethertype();
+        match eth_pdu.into_inner() {
+            Err(_) => None,
+            Ok(Ethernet::Arp(_)) => None,
+            Ok(Ethernet::Ipv4(ipv4_pdu)) => Self::parse_ipv4(ipv4_pdu),
+            Ok(Ethernet::Ipv6(ipv6_pdu)) => Self::parse_ipv6(ipv6_pdu),
+            // `pdu` transparently unwraps a single 802.1Q tag, but leaves
+            // stacked/QinQ tags (and anything non-IP) as `Raw`. `ethertype()`
+            // is then the outermost unhandled TPID and `payload` starts at its
+            // TCI, which is exactly what `strip_vlan_tags` expects.
+            Ok(Ethernet::Raw(payload)) => {
+                let (ether_type, payload) = strip_vlan_tags(outer_ether_type, payload)?;
+                Self::parse_l3(ether_type, payload)
+            }
+        }
     }
 
     fn parse_ipv4(
@@ -296,38 +380,192 @@ impl<'a> PcapIter<'a> {
 #[cfg(test)]
 mod tests {
     use std::fs::File;
+    use std::io::Cursor;
 
     use super::*;
 
-    #[allow(clippy::while_let_on_iterator)]
+    /// LINKTYPE_LINUX_SLL: Linux "cooked" capture, what you get from
+    /// `tcpdump -i any`. Hands us an L3 payload plus an EtherType, so a
+    /// VLAN-tagged frame arrives with the tag still in front of the IP header.
+    const LINKTYPE_LINUX_SLL: u32 = 113;
+    const LINKTYPE_ETHERNET: u32 = 1;
+
+    /// Minimal IPv4 + UDP datagram carrying `payload`. Checksums are left
+    /// zero; nothing in the read path verifies them.
+    fn ipv4_udp(src_port: u16, dst_port: u16, payload: &[u8]) -> Vec<u8> {
+        let udp_len = 8 + payload.len();
+        let total_len = 20 + udp_len;
+        let mut out = Vec::with_capacity(total_len);
+        out.extend_from_slice(&[0x45, 0x00]);
+        out.extend_from_slice(&(total_len as u16).to_be_bytes());
+        out.extend_from_slice(&[0x00, 0x01, 0x40, 0x00, 0x40, 17, 0x00, 0x00]);
+        out.extend_from_slice(&[10, 0, 0, 1]); // src
+        out.extend_from_slice(&[10, 0, 0, 2]); // dst
+        out.extend_from_slice(&src_port.to_be_bytes());
+        out.extend_from_slice(&dst_port.to_be_bytes());
+        out.extend_from_slice(&(udp_len as u16).to_be_bytes());
+        out.extend_from_slice(&[0x00, 0x00]); // checksum
+        out.extend_from_slice(payload);
+        out
+    }
+
+    /// One 802.1Q/802.1ad tag: TCI then the EtherType it encapsulates.
+    fn vlan_tag(vid: u16, inner_ether_type: u16) -> Vec<u8> {
+        let mut out = Vec::with_capacity(4);
+        out.extend_from_slice(&vid.to_be_bytes());
+        out.extend_from_slice(&inner_ether_type.to_be_bytes());
+        out
+    }
+
+    /// Linux cooked-capture header whose protocol field is `ether_type`.
+    fn sll_header(ether_type: u16) -> Vec<u8> {
+        let mut out = Vec::with_capacity(16);
+        out.extend_from_slice(&[0x00, 0x00]); // packet type
+        out.extend_from_slice(&[0x00, 0x01]); // ARPHRD
+        out.extend_from_slice(&[0x00, 0x06]); // address length
+        out.extend_from_slice(&[0xcc, 0xed, 0x4d, 0xaf, 0x01, 0x80, 0x00, 0x00]); // address
+        out.extend_from_slice(&ether_type.to_be_bytes());
+        out
+    }
+
+    fn ethernet_header(ether_type: u16) -> Vec<u8> {
+        let mut out = Vec::with_capacity(14);
+        out.extend_from_slice(&[0x02, 0, 0, 0, 0, 2]); // dst MAC
+        out.extend_from_slice(&[0x02, 0, 0, 0, 0, 1]); // src MAC
+        out.extend_from_slice(&ether_type.to_be_bytes());
+        out
+    }
+
+    /// Wrap `frames` into an in-memory legacy pcap with the given link type.
+    fn build_pcap(link_type: u32, frames: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&0xa1b2c3d4u32.to_le_bytes());
+        out.extend_from_slice(&2u16.to_le_bytes());
+        out.extend_from_slice(&4u16.to_le_bytes());
+        out.extend_from_slice(&0i32.to_le_bytes());
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&65535u32.to_le_bytes());
+        out.extend_from_slice(&link_type.to_le_bytes());
+        for (i, f) in frames.iter().enumerate() {
+            out.extend_from_slice(&(i as u32).to_le_bytes()); // ts_sec
+            out.extend_from_slice(&0u32.to_le_bytes()); // ts_usec
+            out.extend_from_slice(&(f.len() as u32).to_le_bytes()); // incl_len
+            out.extend_from_slice(&(f.len() as u32).to_le_bytes()); // orig_len
+            out.extend_from_slice(f);
+        }
+        out
+    }
+
+    fn collect(pcap: &[u8]) -> Vec<(IpAddr, u16, IpAddr, u16, TransportProtocol, Vec<u8>)> {
+        let reader = LegacyPcapReader::new(165_536, Cursor::new(pcap)).unwrap();
+        PcapIter::new(Box::new(reader)).collect()
+    }
+
+    #[test]
+    fn sll_vlan_tagged_is_parsed() {
+        let mut frame = sll_header(ether_type::VLAN);
+        frame.extend_from_slice(&vlan_tag(100, ether_type::IPV4));
+        frame.extend_from_slice(&ipv4_udp(4444, 10100, b"hello"));
+        let results = collect(&build_pcap(LINKTYPE_LINUX_SLL, &[frame]));
+        assert_eq!(results.len(), 1, "VLAN-tagged SLL frame should be parsed");
+        assert_eq!(results[0].3, 10100);
+        assert_eq!(results[0].4, TransportProtocol::UDP);
+        assert_eq!(results[0].5, b"hello");
+    }
+
+    #[test]
+    fn sll_untagged_still_parsed() {
+        let mut frame = sll_header(ether_type::IPV4);
+        frame.extend_from_slice(&ipv4_udp(4444, 10100, b"plain"));
+        let results = collect(&build_pcap(LINKTYPE_LINUX_SLL, &[frame]));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].5, b"plain");
+    }
+
+    #[test]
+    fn sll_qinq_double_tagged_is_parsed() {
+        let mut frame = sll_header(ether_type::VLAN_QINQ);
+        frame.extend_from_slice(&vlan_tag(10, ether_type::VLAN)); // S-TAG
+        frame.extend_from_slice(&vlan_tag(20, ether_type::IPV4)); // C-TAG
+        frame.extend_from_slice(&ipv4_udp(4444, 10100, b"qinq"));
+        let results = collect(&build_pcap(LINKTYPE_LINUX_SLL, &[frame]));
+        assert_eq!(
+            results.len(),
+            1,
+            "QinQ double-tagged frame should be parsed"
+        );
+        assert_eq!(results[0].5, b"qinq");
+    }
+
+    #[test]
+    fn ethernet_qinq_double_tagged_is_parsed() {
+        // `pdu` unwraps a single 802.1Q tag itself, but leaves QinQ as `Raw`.
+        let mut frame = ethernet_header(ether_type::VLAN_QINQ);
+        frame.extend_from_slice(&vlan_tag(10, ether_type::VLAN));
+        frame.extend_from_slice(&vlan_tag(20, ether_type::IPV4));
+        frame.extend_from_slice(&ipv4_udp(4444, 10100, b"eth-qinq"));
+        let results = collect(&build_pcap(LINKTYPE_ETHERNET, &[frame]));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].5, b"eth-qinq");
+    }
+
+    #[test]
+    fn non_ip_ether_type_is_skipped_not_panic() {
+        // 0x0806 = ARP. Previously any non-IP EtherType hit `unimplemented!()`
+        // and took down the whole capture.
+        let mut frame = sll_header(0x0806);
+        frame.extend_from_slice(&[0u8; 28]);
+        let mut ok_frame = sll_header(ether_type::IPV4);
+        ok_frame.extend_from_slice(&ipv4_udp(4444, 10100, b"after-arp"));
+        let results = collect(&build_pcap(LINKTYPE_LINUX_SLL, &[frame, ok_frame]));
+        assert_eq!(results.len(), 1, "ARP skipped, following frame still read");
+        assert_eq!(results[0].5, b"after-arp");
+    }
+
+    #[test]
+    fn truncated_vlan_tag_is_skipped() {
+        let mut frame = sll_header(ether_type::VLAN);
+        frame.extend_from_slice(&[0x00, 0x64]); // TCI only, EtherType missing
+        let results = collect(&build_pcap(LINKTYPE_LINUX_SLL, &[frame]));
+        assert!(results.is_empty(), "truncated tag should be skipped");
+    }
+
+    #[test]
+    fn strip_vlan_tags_bounds_stacked_tags() {
+        // A frame claiming an endless chain of tags must terminate.
+        let mut payload = Vec::new();
+        for _ in 0..(MAX_VLAN_TAGS + 2) {
+            payload.extend_from_slice(&vlan_tag(1, ether_type::VLAN));
+        }
+        assert_eq!(strip_vlan_tags(ether_type::VLAN, &payload), None);
+    }
+
+    #[test]
+    fn strip_vlan_tags_passes_through_untagged() {
+        let payload = [0x45u8, 0x00, 0x00, 0x14];
+        assert_eq!(
+            strip_vlan_tags(ether_type::IPV4, &payload),
+            Some((ether_type::IPV4, &payload[..]))
+        );
+    }
+
     #[test]
     fn it_pcap() {
         let mut path = env!("CARGO_MANIFEST_DIR").to_owned();
         path.push_str("/data/bgp.pcap");
         let file = File::open(path).unwrap();
         let reader = LegacyPcapReader::new(165536, file).unwrap();
-        let reader = Box::new(reader);
-        let mut iter = PcapIter::new(reader);
-        let mut results = vec![];
-        while let Some(val) = iter.next() {
-            results.push(val);
-        }
+        let results: Vec<_> = PcapIter::new(Box::new(reader)).collect();
         assert_eq!(results.len(), 20)
     }
 
-    #[allow(clippy::while_let_on_iterator)]
     #[test]
     fn it_pcapng() {
         let mut path = env!("CARGO_MANIFEST_DIR").to_owned();
         path.push_str("/data/bmp.pcapng");
         let file = File::open(path).unwrap();
         let reader = PcapNGReader::new(165536, file).unwrap();
-        let reader = Box::new(reader);
-        let mut iter = PcapIter::new(reader);
-        let mut results = vec![];
-        while let Some(val) = iter.next() {
-            results.push(val);
-        }
+        let results: Vec<_> = PcapIter::new(Box::new(reader)).collect();
         assert_eq!(results.len(), 9)
     }
 }


### PR DESCRIPTION
Reading a Linux cooked capture (LINKTYPE_LINUX_SLL) containing 802.1Q VLAN-tagged frames aborted the whole capture:
    not implemented: Only IPv4 and IPv6 packets are supported

The L3 dispatch accepted only 0x0800/0x86DD and `unimplemented!()`'d on everything else, including the 0x8100 VLAN TPID.

Add `strip_vlan_tags`, which walks past 802.1Q (0x8100), 802.1ad/QinQ (0x88A8) and the pre-standard 0x9100 TPID before dispatching on the encapsulated EtherType. Stacked tags are handled and bounded by MAX_VLAN_TAGS so a malformed frame can't spin. Both entry paths need it: the L3 path had no VLAN handling at all, and while `pdu` transparently unwraps a single 802.1Q tag on the Ethernet path, it leaves QinQ as `Ethernet::Raw` — which also hit `unimplemented!()`.

Frames we can't extract from (non-IP EtherTypes, malformed IP headers, raw L4, unsupported link types) are now skipped instead of panicking. That exposed a latent bug: `next()` returned `parse_packet`'s `None` directly, and for an Iterator `None` means iteration is finished, so a single skipped frame silently truncated the rest of the capture.