### PR TITLE
udp-notif-pkt: fix UDP-Notif spec compliance bugs

### DIFF
--- a/crates/udp-notif-pkt/src/codec.rs
+++ b/crates/udp-notif-pkt/src/codec.rs
@@ -254,6 +254,14 @@ impl UdpPacketCodec {
         Ok(Some((header_len, message_length)))
     }
 
+    /// Segment number and last-segment flag for `options`.
+    ///
+    /// It is the *absence of the Segmentation Option* that marks a message as
+    /// unsegmented, and therefore complete in a single datagram, whichever
+    /// other options the header happens to carry is irrelevant. Such a message
+    /// is reported as segment 0 with the last-segment flag set, so the caller
+    /// delivers it immediately instead of waiting for segments that will never
+    /// arrive.
     #[inline]
     fn extract_segment_info(options: &HashMap<UdpNotifOptionCode, UdpNotifOption>) -> (u16, bool) {
         options
@@ -265,7 +273,7 @@ impl UdpPacketCodec {
                     unreachable!()
                 }
             })
-            .unwrap_or((0, options.is_empty()))
+            .unwrap_or((0, true))
     }
 
     #[inline]
@@ -395,6 +403,63 @@ mod tests {
         let mut buf = BytesMut::new();
         codec.encode(pkt, &mut buf).expect("encode failed");
         assert_eq!(buf, expected);
+    }
+
+    /// A message without a Segmentation Option is complete in one datagram
+    /// and must be delivered, even when the header carries other options.
+    /// Regression: the unsegmented case used to be inferred from "the header
+    /// has no options at all", so any other option made the codec treat a
+    /// complete message as segment 0 of a series that never arrives, and it
+    /// was silently swallowed until the reassembly timeout.
+    #[test]
+    fn test_decode_unsegmented_with_other_option() {
+        let mut codec = UdpPacketCodec::default();
+        let value: Vec<u8> = vec![
+            0x21, // version 1, no private space, Media type: 1 = YANG data JSON
+            0x10, // Header length (12 + 4 for the option below)
+            0x00, 0x14, // Message length
+            0x01, 0x00, 0x00, 0x01, // Publisher ID
+            0x02, 0x00, 0x00, 0x02, // Message ID
+            0x03, 0x04, 0xaa, 0xbb, // an option that is NOT the Segmentation Option
+            0xff, 0xff, 0xff, 0xff, // dummy payload
+        ];
+        let pkt = UdpNotifPacket::new(
+            MediaType::YangDataJson,
+            0x01000001,
+            0x02000002,
+            HashMap::from([(
+                UdpNotifOptionCode::Unknown(3),
+                UdpNotifOption::Unknown {
+                    typ: 3,
+                    value: vec![0xaa, 0xbb].into(),
+                },
+            )]),
+            Bytes::from(&[0xff, 0xff, 0xff, 0xff][..]),
+        );
+        let mut buf = BytesMut::from(&value[..]);
+
+        assert_eq!(codec.decode(&mut buf), Ok(Some(pkt)));
+        // Nothing should have been parked awaiting reassembly.
+        assert!(codec.incomplete_messages.is_empty());
+    }
+
+    /// The no-options case must keep working; it is the common one.
+    #[test]
+    fn test_decode_unsegmented_without_options() {
+        let mut codec = UdpPacketCodec::default();
+        let value: Vec<u8> = vec![
+            0x21, // version 1, no private space, Media type: 1 = YANG data JSON
+            0x0c, // Header length
+            0x00, 0x0e, // Message length
+            0x01, 0x00, 0x00, 0x01, // Publisher ID
+            0x02, 0x00, 0x00, 0x02, // Message ID
+            0xff, 0xff, // dummy payload
+        ];
+        let mut buf = BytesMut::from(&value[..]);
+
+        let decoded = codec.decode(&mut buf).expect("decode failed");
+        assert!(decoded.is_some());
+        assert!(codec.incomplete_messages.is_empty());
     }
 
     #[test]

--- a/crates/udp-notif-pkt/src/raw.rs
+++ b/crates/udp-notif-pkt/src/raw.rs
@@ -28,6 +28,17 @@ use strum_macros::Display;
 pub const UDP_NOTIF_V1: u8 = 1;
 
 /// Media Type of the UDP Notif paylaod
+///
+/// The 4-bit MT field is interpreted against one of two disjoint spaces,
+/// selected by the S-flag of the message header
+/// ([draft-ietf-netconf-udp-notif](https://datatracker.ietf.org/doc/html/draft-ietf-netconf-udp-notif) Section 3.3):
+///
+/// - S-flag clear: the standard space, i.e. the values registered with IANA.
+/// - S-flag set: a private space, where *all* 16 values are available and their
+///   meaning is agreed out-of-band between publisher and receiver. These are
+///   represented by [`MediaType::Private`], deliberately distinct from the
+///   standard variants so that a private payload is never mistaken for (say)
+///   `yang-data+json` just because it happens to use value 1.
 #[derive(
     Display,
     Debug,
@@ -53,11 +64,21 @@ pub enum MediaType {
     /// media type application/yang-data+cbor
     YangDataCbor,
 
+    /// A value in the standard space that is not (yet) registered with IANA.
     Unknown(u8),
+
+    /// A value in the private space, i.e. carried with the S-flag set. The
+    /// meaning of the value is not defined by the specification.
+    Private(u8),
 }
 
-impl From<u8> for MediaType {
-    fn from(value: u8) -> Self {
+impl MediaType {
+    /// Interpret a raw 4-bit MT field. `private` is the S-flag of the message
+    /// header, which selects which space `value` belongs to.
+    pub const fn from_wire(value: u8, private: bool) -> Self {
+        if private {
+            return MediaType::Private(value);
+        }
         match value {
             0 => MediaType::Reserved,
             1 => MediaType::YangDataJson,
@@ -65,6 +86,20 @@ impl From<u8> for MediaType {
             3 => MediaType::YangDataCbor,
             value => MediaType::Unknown(value),
         }
+    }
+
+    /// Whether this media type belongs to the private space, i.e. whether the
+    /// S-flag must be set when serializing it.
+    pub const fn is_private(&self) -> bool {
+        matches!(self, MediaType::Private(_))
+    }
+}
+
+impl From<u8> for MediaType {
+    /// Interpret `value` in the standard space. Use [`MediaType::from_wire`]
+    /// when the S-flag is known.
+    fn from(value: u8) -> Self {
+        MediaType::from_wire(value, false)
     }
 }
 
@@ -75,7 +110,7 @@ impl From<MediaType> for u8 {
             MediaType::YangDataJson => 1,
             MediaType::YangDataXml => 2,
             MediaType::YangDataCbor => 3,
-            MediaType::Unknown(value) => value,
+            MediaType::Unknown(value) | MediaType::Private(value) => value,
         }
     }
 }

--- a/crates/udp-notif-pkt/src/wire/deserialize.rs
+++ b/crates/udp-notif-pkt/src/wire/deserialize.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::raw::{MediaType, MediaTypeNames, UdpNotifOption, UdpNotifOptionCode, UdpNotifPacket};
+use crate::raw::{MediaType, UdpNotifOption, UdpNotifOptionCode, UdpNotifPacket};
 use bytes::Bytes;
 use netgauze_parse_utils::error::ParseError;
 use netgauze_parse_utils::reader::SliceReader;
@@ -67,6 +67,9 @@ pub enum UdpNotifPacketParsingError {
     #[error("Invalid UDP-Notif version {0}")]
     InvalidVersion(u8),
 
+    /// No longer produced: when the S-flag is set every MT value is valid,
+    /// because the whole field is private space. Retained so that previously
+    /// serialized errors still deserialize.
     #[error("UDP-Notif with invalid S-Flag")]
     InvalidSFlag,
 
@@ -79,6 +82,9 @@ pub enum UdpNotifPacketParsingError {
     #[error("UDP-Notif with invalid message length {0}")]
     InvalidMessageLength(u16),
 
+    /// No longer produced: the "Private Encoding Option" this checked for was
+    /// removed from the draft, private encoding being signalled by the S-flag
+    /// alone. Retained so that previously serialized errors still deserialize.
     #[error("S Flag is set without private encoding option")]
     PrivateEncodingOptionIsNotPresent,
 }
@@ -117,11 +123,11 @@ impl<'a> ParseFrom<'a> for UdpNotifHeader {
         if version != 1 {
             return Err(UdpNotifPacketParsingError::InvalidVersion(version));
         }
+        // The S-flag selects which space the MT field is read against: when
+        // set, all 16 values are private and their meaning is agreed
+        // out-of-band, so no value is invalid here.
         let s_flag = (first_octet & 0b00010000) != 0;
-        let media_type: MediaType = (first_octet & 0b00001111).into();
-        if s_flag && MediaTypeNames::from(media_type) != MediaTypeNames::Unknown {
-            return Err(UdpNotifPacketParsingError::InvalidSFlag);
-        }
+        let media_type = MediaType::from_wire(first_octet & 0b00001111, s_flag);
 
         let header_len = cur.read_u8()?;
         if header_len < 2 {
@@ -137,20 +143,16 @@ impl<'a> ParseFrom<'a> for UdpNotifHeader {
         let publisher_id = header_buf.read_u32_be()?;
         let message_id = header_buf.read_u32_be()?;
 
+        // Private encoding is signalled by the S-flag alone; there is no
+        // option to look for. Earlier revisions of the draft defined a
+        // "Private Encoding Option", but it was removed and the IANA
+        // UDP-Notif Option Types registry now assigns only 0 (Reserved) and
+        // 1 (Segmentation). Type 2 is still parsed, as an unknown option, for
+        // compatibility with senders built against those revisions.
         let mut options = HashMap::new();
-        // As per UDP-Notif RFC: When S is set, MT represents a private space to be
-        // freely used for non-standard encodings. When S is set, the Private
-        // Encoding Option SHOULD be present in the UDP-Notif message header.
-        let mut private_is_correct = !s_flag;
         while !header_buf.is_empty() {
             let option = UdpNotifOption::parse(&mut header_buf)?;
-            if s_flag && option.code() == UdpNotifOptionCode::PrivateEncoding {
-                private_is_correct = true;
-            }
             options.insert(option.code(), option);
-        }
-        if !private_is_correct {
-            return Err(UdpNotifPacketParsingError::PrivateEncodingOptionIsNotPresent);
         }
 
         Ok(UdpNotifHeader {

--- a/crates/udp-notif-pkt/src/wire/serialize.rs
+++ b/crates/udp-notif-pkt/src/wire/serialize.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::raw::{MediaTypeNames, UdpNotifOption, UdpNotifPacket};
+use crate::raw::{UdpNotifOption, UdpNotifPacket};
 use byteorder::{NetworkEndian, WriteBytesExt};
 use netgauze_parse_utils::{WritablePdu, impl_from_io_error};
 use std::io::Write;
@@ -97,7 +97,10 @@ impl WritablePdu<UdpNotifPacketWritingError> for UdpNotifPacket {
     fn write<T: Write>(&self, writer: &mut T) -> Result<(), UdpNotifPacketWritingError> {
         let version: u8 = 0x01;
         let mut first_byte: u8 = version << 5;
-        if MediaTypeNames::from(self.media_type()) == MediaTypeNames::Unknown {
+        // The S-flag says which space the MT value belongs to, so it follows
+        // the media type itself rather than whether the value is registered:
+        // an unregistered value in the standard space keeps S clear.
+        if self.media_type().is_private() {
             first_byte |= 0x10;
         }
         let mt: u8 = self.media_type().into();

--- a/crates/udp-notif-pkt/src/wire/test/mod.rs
+++ b/crates/udp-notif-pkt/src/wire/test/mod.rs
@@ -51,20 +51,55 @@ fn test_simple() -> Result<(), UdpNotifPacketWritingError> {
 }
 
 #[test]
-fn test_invalid_s_flat() {
-    let bad_wire = [
-        0x31, // version 1, private space set, Media type: 1 = YANG data JSON
+/// When the S-flag is set the whole 4-bit MT space is private, so a low
+/// value such as 1 does *not* mean `yang-data+json` — it means whatever the
+/// two endpoints agreed. It must decode as [`MediaType::Private`] and round
+/// trip, rather than being rejected for colliding with a registered value.
+fn test_private_encoding_low_media_type() -> Result<(), UdpNotifPacketWritingError> {
+    let good_wire = [
+        0x31, // version 1, private space set, Media type: 1 (private meaning)
         0x0c, // Header length
         0x00, 0x0e, // Message length
         0x01, 0x00, 0x00, 0x01, // Publisher ID
         0x02, 0x00, 0x00, 0x02, // Message ID
         0xff, 0xff, // dummy payload
     ];
-
-    test_parse_error_bytes_reader::<UdpNotifPacket, UdpNotifPacketParsingError>(
-        &bad_wire,
-        &UdpNotifPacketParsingError::InvalidSFlag,
+    let good = UdpNotifPacket::new(
+        MediaType::Private(1),
+        0x01000001,
+        0x02000002,
+        HashMap::new(),
+        Bytes::from(&[0xff, 0xff][..]),
     );
+
+    test_parsed_completely_bytes_reader(&good_wire, &good);
+    test_write(&good, &good_wire)?;
+    Ok(())
+}
+
+#[test]
+/// An unregistered value in the *standard* space (S-flag clear) stays
+/// [`MediaType::Unknown`] and must keep the S-flag clear when written back.
+fn test_unknown_standard_media_type_keeps_s_flag_clear() -> Result<(), UdpNotifPacketWritingError> {
+    let good_wire = [
+        0x2a, // version 1, S-flag clear, Media type: 10 (unregistered)
+        0x0c, // Header length
+        0x00, 0x0e, // Message length
+        0x01, 0x00, 0x00, 0x01, // Publisher ID
+        0x02, 0x00, 0x00, 0x02, // Message ID
+        0xff, 0xff, // dummy payload
+    ];
+    let good = UdpNotifPacket::new(
+        MediaType::Unknown(0xa),
+        0x01000001,
+        0x02000002,
+        HashMap::new(),
+        Bytes::from(&[0xff, 0xff][..]),
+    );
+
+    test_parsed_completely_bytes_reader(&good_wire, &good);
+    test_write(&good, &good_wire)?;
+    Ok(())
 }
 
 #[test]
@@ -176,7 +211,7 @@ fn test_private_encoding() -> Result<(), UdpNotifPacketWritingError> {
         0xff, 0xff, 0xff, 0xff, // dummy payload
     ];
     let good = UdpNotifPacket::new(
-        MediaType::Unknown(0xa),
+        MediaType::Private(0xa),
         0x01000001,
         0x02000002,
         HashMap::from([(
@@ -192,8 +227,12 @@ fn test_private_encoding() -> Result<(), UdpNotifPacketWritingError> {
 }
 
 #[test]
-fn test_private_encoding_pen_not_present() {
-    let bad_wire = [
+/// Private encoding is signalled by the S-flag alone. The draft's earlier
+/// "Private Encoding Option" was removed (the IANA registry now assigns only
+/// 0 Reserved and 1 Segmentation), so a private message carrying no options
+/// at all is well formed and must decode.
+fn test_private_encoding_without_options() -> Result<(), UdpNotifPacketWritingError> {
+    let good_wire = [
         0x3a, // version 1, private space, Media type: 10 (just arbitrary picked)
         0x0c, // Header length
         0x00, 0x0e, // Message length
@@ -201,9 +240,15 @@ fn test_private_encoding_pen_not_present() {
         0x02, 0x00, 0x00, 0x02, // Message ID
         0xff, 0xff, // dummy payload
     ];
-
-    test_parse_error_bytes_reader::<UdpNotifPacket, UdpNotifPacketParsingError>(
-        &bad_wire,
-        &UdpNotifPacketParsingError::PrivateEncodingOptionIsNotPresent,
+    let good = UdpNotifPacket::new(
+        MediaType::Private(0xa),
+        0x01000001,
+        0x02000002,
+        HashMap::new(),
+        Bytes::from(&[0xff, 0xff][..]),
     );
+
+    test_parsed_completely_bytes_reader(&good_wire, &good);
+    test_write(&good, &good_wire)?;
+    Ok(())
 }


### PR DESCRIPTION
Two decode bugs found while checking udp-notif-pkt against draft-ietf-netconf-udp-notif-25. Both caused conformant traffic to be dropped, neither produced an error the caller could act on.

1. Unsegmented messages carrying any other option were silently swallowed. Whether a message was unsegmented was inferred from "the header has no options at all `(options.is_empty())` instead of "the header has no Segmentation Option". A complete message carrying any other option was therefore treated as segment 0 of a series that never arrives: parked in the reassembly buffer, returned as `Ok(None)`, and discarded at the timeout. No error, no log, the message simply never reached the application.

2. Private-encoding messages could not be decoded at all. Parsing demanded an option of type 2  a "Private Encoding Option" that older revisions of the draft defined but which has since been removed; the IANA registry now assigns only 0 (Reserved) and 1 (Segmentation). It also rejected the S-flag combined with an MT value of 0–3. Since draft-25 signals private encoding by the S-flag alone, and makes the whole 4-bit MT field private when it is set, both checks reject legal packets. The two bugs also compounded: sending the conformant form (no option) hit the first check, and adding the obsolete option to satisfy it then tripped bug 1 above, so no unsegmented private-encoding message could get through by any route.