### PR TITLE
service-core: new shared-nothing worker supervision crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
+      - name: Install autotools (vendored hwloc runs autoreconf)
+        run: brew install autoconf automake libtool
       - name: Enable type layout randomization
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.6.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +230,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "password-hash",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-channel"
@@ -267,6 +282,15 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "autotools"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -355,6 +379,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -806,6 +836,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +869,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
 
 [[package]]
 name = "cpubits"
@@ -1209,6 +1259,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-xid",
+]
+
+[[package]]
 name = "des"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1512,16 @@ name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1795,6 +1878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1977,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hwlocality"
+version = "1.0.0-alpha.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2e65a48d3b300843ac84a2fe8e166bb5a5b00f30054593bcee8157e4b465fd"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "derive_more",
+ "errno",
+ "hwlocality-sys",
+ "libc",
+ "strum 0.28.0",
+ "thiserror",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hwlocality-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507b4c70a812b6ed5907db7d59726118f4e17708fbc09e32a872ac8e3b5bafaf"
+dependencies = [
+ "autotools",
+ "cmake",
+ "flate2",
+ "libc",
+ "pkg-config",
+ "sha3 0.12.0",
+ "tar",
+ "ureq",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,7 +2078,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2978,6 +3101,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "netgauze-service-core"
+version = "0.13.0"
+dependencies = [
+ "arc-swap",
+ "core_affinity",
+ "futures",
+ "hwlocality",
+ "opentelemetry",
+ "raw-cpuid",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-test",
+]
+
+[[package]]
 name = "netgauze-udp-notif-pkt"
 version = "0.13.0"
 dependencies = [
@@ -3213,6 +3353,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3881,7 +4031,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37587d5a8a1b3dc9863403d084fc2254b91ab75a702207098837950767e2260b"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "prost 0.13.5",
  "prost-reflect-derive",
  "prost-types 0.13.5",
@@ -4122,6 +4272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4263,7 +4422,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -4524,7 +4683,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4641,7 +4802,7 @@ dependencies = [
  "apache-avro",
  "async-recursion",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "dashmap 6.2.1",
@@ -4901,7 +5062,7 @@ version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -5340,6 +5501,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5603,7 +5775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -5824,6 +5996,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5858,6 +6036,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5868,6 +6075,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6054,6 +6267,15 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6397,6 +6619,16 @@ name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yang5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/yang-push",
     "crates/pcap-decoder",
     "crates/netconf-proto",
+    "crates/service-core",
     "fuzz",
 ]
 resolver = "2"
@@ -107,8 +108,12 @@ petgraph = { version = "0.8", default-features = false }
 sha2 = { version = "0.11" }
 schema-registry-client = { version = "0.4" }
 bitflags = { version = "2.13" }
-axum = { version = "0.8"}
+axum = { version = "0.8" }
 schemars = { version = "1.2", features = ["derive"] }
+arc-swap = { version = "1.9" }
+raw-cpuid = { version = "11.6" }
+core_affinity = "0.8.3"
+hwlocality = { version = "1.0.0-alpha.12" }
 
 [profile.release]
 codegen-units = 1

--- a/crates/service-core/Cargo.toml
+++ b/crates/service-core/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "netgauze-service-core"
+version = "0.13.0"
+edition = "2024"
+authors = ["Ahmed Elhassany <a.hassany@gmail.com>"]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/NetGauze/NetGauze"
+homepage = "https://github.com/NetGauze/NetGauze"
+description = """
+Shared-nothing, thread-per-core service scaffolding for NetGauze
+collectors: worker trait, supervisor, CPU affinity, and core assignment.
+"""
+keywords = ["supervisor", "thread-per-core", "affinity"]
+categories = ["network-programming", "concurrency"]
+
+[dependencies]
+tokio = { workspace = true, default-features = false, features = ["sync", "rt", "time", "macros"] }
+opentelemetry = { workspace = true }
+core_affinity = { workspace = true }
+hwlocality = { workspace = true, features = ["hwloc-latest", "vendored"] }
+thiserror = { workspace = true }
+futures = { workspace = true }
+arc-swap = { workspace = true }
+tracing = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+raw-cpuid = { workspace = true }
+
+
+[dev-dependencies]
+tokio = { workspace = true, default-features = false, features = ["rt"] }
+tracing-test = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/service-core/README.md
+++ b/crates/service-core/README.md
@@ -1,0 +1,68 @@
+# NetGauze Service Core
+
+[![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
+[![Apache licensed][apache-badge]][apache-url]
+
+
+[crates-badge]: https://img.shields.io/crates/v/netgauze-service-core.svg
+
+[crates-url]: https://crates.io/crates/netgauze-service-core
+
+[apache-badge]: https://img.shields.io/badge/license-Apache-blue.svg
+
+[apache-url]: https://github.com/NetGauze/NetGauze/blob/main/LICENSE
+
+[docs-badge]: https://docs.rs/netgauze-service-core/badge.svg
+
+[docs-url]: https://docs.rs/netgauze-service-core
+
+
+Shared-nothing, thread-per-core service scaffolding for NetGauze
+collectors: the `Worker` trait, a supervising `CollectionSupervisor`
+(pinned spawn, in-thread panic capture, budgeted respawn, graceful
+shutdown, concurrent admin plane), CPU affinity strategies with
+environment auto-detection, NUMA-aware core assignment, and shared
+drain-loop batch knobs (`BatchConfig`).
+
+## Modules
+
+- `worker` — the `Worker` trait a protocol service implements
+  (`build_stats` once per slot, `build`/`run` per incarnation on the
+  pinned thread) and the `WorkerContext` it receives.
+- `supervisor` — `CollectionSupervisor::start/supervise/shutdown`,
+  `RestartPolicy` (respawn budget + the `min_live_workers` valve),
+  `SuperviseExit`, and the cloneable `AdminHandle`
+  (`route`/`try_route`/`broadcast`, failed/done slot mirrors).
+- `affinity` — `AffinityStrategy` (`PinnedAffinity`/`NoAffinity`,
+  extensible via `PinOutcome`) and `AffinityConfig::Auto` environment
+  detection (container/quota/exclusive-cpuset heuristics).
+- `assignment` — `CoreAssignment::explicit` and NUMA-ordered
+  physical-core discovery (`numa_ordered`, behind the default-on `numa`
+  feature; disable default features to skip the vendored hwloc build).
+- `batch` — validated drain-loop knobs for UDP-shaped workers.
+
+## Shape
+
+```rust,ignore
+let mut sup = CollectionSupervisor::<MyWorker>::start(
+    config,
+    SupervisorOptions::new(CoreAssignment::numa_ordered(8)?)
+        .with_affinity(AffinityConfig::Auto.resolve())
+        .with_policy(RestartPolicy::default().with_min_live_workers(6)),
+    meter,
+)?;
+let admin = sup.admin_handle(); // serve queries while supervising
+match sup.supervise(&mut shutdown_rx).await {
+    SuperviseExit::ShutdownRequested => { /* orderly teardown */ }
+    SuperviseExit::BelowMinimumWorkers { .. } => { /* fail the site */ }
+    _ => {}
+}
+sup.shutdown(Duration::from_secs(5)).await; // ALWAYS end via shutdown()
+```
+
+Workers are detached threads; every exit (clean, error, or panic —
+caught in-thread) reaches the supervisor over an exit channel, and
+`shutdown()` is the only correct teardown once `AdminHandle` clones
+exist. Construct at most one supervisor per worker type per process:
+metric callbacks are registered permanently.

--- a/crates/service-core/src/affinity.rs
+++ b/crates/service-core/src/affinity.rs
@@ -1,0 +1,274 @@
+// Copyright (C) 2022-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utils to detect and specify the CPU core affinity.
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::info;
+
+/// Core ID identify physical CPU core placement; see [AffinityStrategy],
+/// [crate::assignment::CoreAssignment]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CoreId(usize);
+
+impl CoreId {
+    /// Core ID can be created only by this crate for safety.
+    /// Everything else has a read-only access.
+    pub(crate) const fn new(id: usize) -> Self {
+        Self(id)
+    }
+    pub const fn get(&self) -> usize {
+        self.0
+    }
+}
+
+impl std::fmt::Display for CoreId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// The result of [`AffinityStrategy::apply`]: distinguishes "deliberately
+/// unpinned" from "tried to pin and failed", because only the latter
+/// requires the caller (e.g., supervisor) to take an action such as warning or
+/// retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinOutcome {
+    /// The thread is actually pinned to this core; becomes
+    /// `WorkerContext.core_id = Some(..)`.
+    Pinned(CoreId),
+    /// The strategy deliberately does not pin (e.g. [`NoAffinity`]). Not
+    /// a failure; nothing is logged.
+    Unpinned,
+    /// The strategy TRIED to pin and could not (invalid core id,
+    /// restricted cpuset); the supervisor logs a warning and the worker
+    /// runs unpinned.
+    Failed,
+}
+
+/// How, or whether, a worker thread claims a specific physical core.
+pub trait AffinityStrategy: Send + Sync {
+    /// Strategy name for logging and debugging purposes
+    fn name(&self) -> &str;
+
+    /// Called as the FIRST statement on the spawned thread, before the
+    /// runtime or any allocation.
+    fn apply(&self, core_id: CoreId) -> PinOutcome;
+}
+
+/// Strategy that pins the worker thread into a specific CPU core.
+/// When successful, it returns the [CoreId] for the pinned core,
+/// or `None`
+pub struct PinnedAffinity;
+
+impl AffinityStrategy for PinnedAffinity {
+    fn name(&self) -> &str {
+        "pinned"
+    }
+
+    fn apply(&self, core_id: CoreId) -> PinOutcome {
+        // core_affinity::set_for_current returns bool. An invalid core id or a
+        // restricted cpu-set can make even PinnedAffinity fail to pin; that
+        // failure reaches WorkerContext as None.
+        if core_affinity::set_for_current(core_affinity::CoreId { id: core_id.get() }) {
+            PinOutcome::Pinned(core_id)
+        } else {
+            PinOutcome::Failed
+        }
+    }
+}
+
+/// For `Burstable`/shared-node k8s, or anywhere pinning cannot deliver real
+/// isolation, there's no need for CPU Core pinning.
+pub struct NoAffinity;
+
+impl AffinityStrategy for NoAffinity {
+    fn name(&self) -> &str {
+        "unpinned"
+    }
+
+    fn apply(&self, _core_id: CoreId) -> PinOutcome {
+        PinOutcome::Unpinned
+    }
+}
+
+/// Configure which Affinity strategy to use.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AffinityConfig {
+    /// `Auto` detects the deployment environment at startup
+    #[default]
+    Auto,
+
+    /// Pin workers to a fixed set of CPU cores
+    Pinned,
+
+    /// No pinning, the OS is free to schedule the workers
+    Unpinned,
+}
+
+impl AffinityConfig {
+    pub fn resolve(self) -> Arc<dyn AffinityStrategy> {
+        match self {
+            Self::Pinned => Arc::new(PinnedAffinity),
+            Self::Unpinned => Arc::new(NoAffinity),
+            Self::Auto => {
+                let env = detect_environment();
+                let strategy = env.recommended_strategy();
+                info!(
+                    virtualized = env.virtualized,
+                    containerized = env.containerized,
+                    exclusive_cpuset = env.exclusive_cpuset,
+                    decision = strategy.name(),
+                );
+                strategy
+            }
+        }
+    }
+}
+
+/// Helper struct to carry information about the auto detection of the
+/// environment, in which the services are running.
+#[derive(Debug, Clone, Copy)]
+pub struct DetectedEnvironment {
+    /// Diagnostic only, does not feed the decision below: hypervisor bit
+    /// in `/proc/cpuinfo`'s `flags` line (kernel-exposed, no need to read
+    /// raw CPUID ourselves), or a DMI `sys_vendor`/`product_name` match
+    /// (`/sys/class/dmi/id/*`) against known cloud/hypervisor strings.
+    pub virtualized: bool,
+    /// Diagnostic only: `KUBERNETES_SERVICE_HOST` (injected into every pod
+    /// by k8s itself -- the single most reliable signal available, no
+    /// filesystem parsing needed), `/.dockerenv`, or a `kubepods`/`docker`/
+    /// `containerd` path segment in `/proc/self/cgroup`.
+    pub containerized: bool,
+    /// Is true when CPU core pinning can be used (e.g., bare-metal)
+    pub exclusive_cpuset: bool,
+    /// Load-bearing with `containerized`: the affinity mask is strictly
+    /// narrower than the host's online CPUs; the visible signature of a
+    /// dedicated cpuset grant (k8s static CPU Manager) as opposed to a
+    /// shared-everything container that simply has no limits set.
+    pub exclusive_grant: bool,
+}
+
+impl DetectedEnvironment {
+    pub const fn should_pin(&self) -> bool {
+        self.exclusive_cpuset && (!self.containerized || self.exclusive_grant)
+    }
+
+    pub fn recommended_strategy(&self) -> Arc<dyn AffinityStrategy> {
+        if self.should_pin() {
+            Arc::new(PinnedAffinity)
+        } else {
+            Arc::new(NoAffinity)
+        }
+    }
+}
+
+/// Detect what type of environment this process is running at.
+///
+/// Any error anywhere degrades to the "don't pin" answer and never a failure,
+/// since the user can always configure a fixed strategy.
+fn detect_environment() -> DetectedEnvironment {
+    // Affinity-mask size WITHOUT quota mixed in, as the comparison's other
+    // side. core_affinity::get_core_ids() wraps sched_getaffinity; the
+    // same crate already used by PinnedAffinity, no new dependency.
+    let affinity_mask_size = core_affinity::get_core_ids()
+        .map(|ids| ids.len())
+        .unwrap_or(0);
+
+    // Quota-aware count from std (min of quota and affinity, per above).
+    let effective = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(0);
+
+    // Both sides zero/errored => can't tell => don't pin.
+    let exclusive_cpuset = affinity_mask_size > 0 && effective >= affinity_mask_size;
+
+    // Host online-CPU count from sysfs ("0-47" ranges). In containers
+    // this shows the HOST, which is the point: a mask as wide as the host
+    // inside a container is shared capacity, not an exclusive grant. On
+    // read/parse failure degrade to "not exclusive" (don't pin).
+    let host_online = std::fs::read_to_string("/sys/devices/system/cpu/online")
+        .ok()
+        .and_then(|s| parse_cpu_list_count(s.trim()));
+
+    let exclusive_grant = match host_online {
+        Some(host) => affinity_mask_size > 0 && affinity_mask_size < host,
+        None => false,
+    };
+    // Diagnostic-only fields (see struct docs). x86: the `raw-cpuid` crate
+    // reads the hypervisor CPUID bit + vendor leaf, giving "KVM"/"Xen"/
+    // "VMware" for the startup log rather than a bare bool; non-x86 falls
+    // back to the DMI read. Neither is worth failing over.
+    #[cfg(target_arch = "x86_64")]
+    let virtualized = raw_cpuid::CpuId::new()
+        .get_feature_info()
+        .is_some_and(|f| f.has_hypervisor());
+    #[cfg(not(target_arch = "x86_64"))]
+    let virtualized = std::fs::read_to_string("/sys/class/dmi/id/sys_vendor")
+        .map(|v| {
+            [
+                "QEMU",
+                "KVM",
+                "VMware",
+                "Xen",
+                "Microsoft",
+                "Amazon EC2",
+                "Google",
+            ]
+            .iter()
+            .any(|s| v.contains(s))
+        })
+        .unwrap_or(false);
+
+    let containerized = std::env::var_os("KUBERNETES_SERVICE_HOST").is_some()
+        || std::path::Path::new("/.dockerenv").exists()
+        || std::fs::read_to_string("/proc/self/cgroup")
+            .map(|c| {
+                ["kubepods", "docker", "containerd", "crio"]
+                    .iter()
+                    .any(|s| c.contains(s))
+            })
+            .unwrap_or(false);
+
+    DetectedEnvironment {
+        virtualized,
+        containerized,
+        exclusive_cpuset,
+        exclusive_grant,
+    }
+}
+
+/// Count of CPUs in a sysfs cpu-list string like "0-47" or "0-3,8-11".
+fn parse_cpu_list_count(s: &str) -> Option<usize> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut count = 0usize;
+    for part in s.split(',') {
+        match part.split_once('-') {
+            Some((a, b)) => {
+                let (a, b): (usize, usize) = (a.trim().parse().ok()?, b.trim().parse().ok()?);
+                count += b.checked_sub(a)?.checked_add(1)?;
+            }
+            None => {
+                let _: usize = part.trim().parse().ok()?;
+                count += 1;
+            }
+        }
+    }
+    Some(count)
+}

--- a/crates/service-core/src/assignment.rs
+++ b/crates/service-core/src/assignment.rs
@@ -1,0 +1,185 @@
+// Copyright (C) 2022-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utils for assigning worker to specific CPU cores based on the
+//! [crate::affinity::AffinityStrategy].
+//!
+//! These Utils are meant to be used within a
+//! [crate::supervisor::CollectionSupervisor] context.
+
+use crate::affinity::CoreId;
+use crate::worker::WorkerIndex;
+use hwlocality::Topology;
+use hwlocality::object::types::ObjectType;
+use tracing::warn;
+
+/// Which physical core each worker thread pins to, indexed by worker_index:
+/// `cores.core_id(0)` is worker 0's core, `cores.core_id(1)` is worker 1's,
+/// etc.
+///
+/// [crate::supervisor::CollectionSupervisor::start] spawns exactly
+/// `cores.len()` workers.
+pub struct CoreAssignment(Box<[CoreId]>);
+
+impl CoreAssignment {
+    /// Explicit Operator-supplied worker assignment: a config value, not
+    /// discovered. No validation: an out-of-range core id does NOT fail
+    /// the spawn since the [crate::affinity::AffinityStrategy::apply] reports
+    /// [crate::affinity::PinOutcome::Failed], the supervisor can choose
+    /// what policy to apply on failure there.
+    pub fn explicit(cores: impl Into<Box<[usize]>>) -> Self {
+        Self(
+            cores
+                .into()
+                .into_iter()
+                .map(CoreId::new)
+                .collect::<Box<[CoreId]>>(),
+        )
+    }
+
+    /// NUMA-aware assignment that DEGRADES instead of failing, so callers
+    /// never need a fallback path of their own:
+    ///
+    /// 1. Preferred: hwloc topology discovery: one PU per PHYSICAL core (never
+    ///    SMT siblings of one core, which would silently halve per-worker
+    ///    capacity), cores ordered by the NUMA node whose cpuset contains them
+    ///    (node 0's cores first, then node 1's, ...).
+    /// 2. Fallback (topology discovery failed or reported fewer cores than
+    ///    requested: e.g. a container without host topology visibility): assume
+    ///    ONE NUMA node and take the first `count` schedulable CPUs from the
+    ///    process affinity mask, or sequential ids `0..count` as the last
+    ///    resort. The fallback cannot distinguish SMT siblings; a warning is
+    ///    logged so a surprising throughput profile is diagnosable from the
+    ///    logs.
+    ///
+    /// Always returns exactly `count` entries. Oversubscription (asking
+    /// for more cores than the machine has) is therefore NOT an error
+    /// here: the surplus ids simply fail to pin at spawn
+    /// (`PinOutcome::Failed`, warned per worker, worker runs unpinned);
+    /// the same degrade-don't-abort contract as
+    /// [`CoreAssignment::explicit`].
+    pub fn numa_ordered(count: usize) -> Self {
+        match Self::hwloc_physical_cores(count) {
+            Ok(cores) => Self(cores.into_boxed_slice()),
+            Err(reason) => {
+                warn!(
+                    count,
+                    reason, "NUMA-aware core discovery unavailable; assuming a single NUMA node"
+                );
+                let mut ids: Vec<usize> = core_affinity::get_core_ids()
+                    .map(|v| v.into_iter().map(|c| c.id).collect())
+                    .unwrap_or_default();
+                if ids.len() < count {
+                    // Affinity mask unavailable or too small: sequential
+                    // ids; unpinnable ones degrade to unpinned workers.
+                    ids = (0..count).collect();
+                }
+                ids.truncate(count);
+                Self(ids.into_iter().map(CoreId::new).collect())
+            }
+        }
+    }
+
+    /// The hwloc half of [`CoreAssignment::numa_ordered`]: (node rank,
+    /// first PU os-index) per physical core; cores outside every reported
+    /// NUMA node (possible on odd topologies) sort last -- which also
+    /// means a topology with NO NUMA nodes degrades naturally to a flat
+    /// physical-core list ("one numa").
+    fn hwloc_physical_cores(count: usize) -> Result<Vec<CoreId>, String> {
+        let topology = Topology::new().map_err(|e| e.to_string())?;
+        let node_cpusets: Vec<_> = topology
+            .objects_with_type(ObjectType::NUMANode)
+            .filter_map(|n| n.cpuset().map(|c| c.clone_target()))
+            .collect();
+        let mut ranked: Vec<(usize, usize)> = topology
+            .objects_with_type(ObjectType::Core)
+            .filter_map(|core| {
+                let cpuset = core.cpuset()?;
+                let first_pu = cpuset.first_set()?;
+                let rank = node_cpusets
+                    .iter()
+                    .position(|n| n.includes(cpuset))
+                    .unwrap_or(usize::MAX);
+                Some((rank, usize::from(first_pu)))
+            })
+            .collect();
+        ranked.sort_unstable();
+        if ranked.len() < count {
+            return Err(format!(
+                "requested {count} cores, hwloc only reports {} physical cores",
+                ranked.len()
+            ));
+        }
+        let mut cores: Vec<CoreId> = ranked.into_iter().map(|(_, pu)| CoreId::new(pu)).collect();
+        cores.truncate(count);
+        Ok(cores)
+    }
+
+    pub fn core_id(&self, worker_index: WorkerIndex) -> Option<CoreId> {
+        self.0.get(worker_index.get()).copied()
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (WorkerIndex, CoreId)> + '_ {
+        self.0
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(i, c)| (WorkerIndex::new(i), c)) // (worker_index, core_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_maps_indices() {
+        let cores = CoreAssignment::explicit(vec![3usize, 7, 1]);
+        assert_eq!(cores.len(), 3);
+        assert_eq!(cores.core_id(WorkerIndex::new(0)), Some(CoreId::new(3)));
+        assert_eq!(cores.core_id(WorkerIndex::new(2)), Some(CoreId::new(1)));
+        // Out of range: None, not a panic.
+        assert_eq!(cores.core_id(WorkerIndex::new(3)), None);
+        let collected: Vec<_> = cores.iter().collect();
+        assert_eq!(collected[1], (WorkerIndex::new(1), CoreId::new(7)));
+    }
+
+    #[test]
+    fn numa_ordered_is_infallible_and_exact() {
+        // The contract: exactly `count` entries, always -- discovery
+        // failures and oversubscription degrade (fallback ids that later
+        // fail to pin), they never error.
+        let small = CoreAssignment::numa_ordered(2);
+        assert_eq!(small.len(), 2);
+        let a = small.core_id(WorkerIndex::new(0)).expect("first core");
+        let b = small.core_id(WorkerIndex::new(1)).expect("second core");
+        // Whichever path produced them (hwloc physical cores, affinity
+        // mask, or sequential), two workers never share one id.
+        assert_ne!(a, b);
+
+        // Absurd oversubscription still yields exactly count ids (the
+        // one-numa fallback), not an error.
+        let big = CoreAssignment::numa_ordered(1_000);
+        assert_eq!(big.len(), 1_000);
+    }
+}

--- a/crates/service-core/src/batch.rs
+++ b/crates/service-core/src/batch.rs
@@ -1,0 +1,226 @@
+// Copyright (C) 2022-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+/// Headroom reserved before every receive so a maximum-size UDP
+/// datagram can never be truncated; the arena must exceed a full
+/// cycle by at least this much.
+pub(crate) const MAX_DATAGRAM_SIZE: usize = 65_536;
+/// Default per-datagram arena budget: comfortable margin over the
+/// jumbo 9216 B MTU typical for flow export traffic.
+pub(crate) const DEFAULT_ARENA_PER_DATAGRAM: usize = 9_216;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct BatchConfig {
+    /// BATCH_CAP: max datagrams drained per readiness wakeup.
+    /// Default 1024: at ~1us/packet decode that is ~1ms of
+    /// worst-case monopoly.
+    #[serde(default = "default_batch_capacity")]
+    pub cap: usize,
+
+    #[serde(default = "default_yield_every")]
+    pub yield_every: usize,
+
+    /// Initial reserve of receive arena, so build() faults the
+    /// pages in on the worker's core. Default ~9.5 MiB
+    /// (~cap x a jumbo ~9216 B datagram, rounded); reserve() converges
+    /// it to the real working size regardless, so this only tunes the
+    /// first cycles.
+    #[serde(default = "default_initial_arean_size")]
+    pub initial_arena: usize,
+}
+
+const fn default_batch_capacity() -> usize {
+    1024
+}
+
+const fn default_yield_every() -> usize {
+    64
+}
+
+const fn default_initial_arean_size() -> usize {
+    default_batch_capacity()
+        .saturating_mul(DEFAULT_ARENA_PER_DATAGRAM)
+        .saturating_add(MAX_DATAGRAM_SIZE)
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self {
+            cap: default_batch_capacity(),
+            yield_every: default_yield_every(),
+            initial_arena: default_initial_arean_size(),
+        }
+    }
+}
+
+impl BatchConfig {
+    /// Admission-time check (config load), reject
+    /// early with a named error, never re-validate per cycle.
+    /// cap >= 1; 1 <= yield_every <= cap.
+    pub const fn validate(&self) -> Result<(), BatchConfigError> {
+        if self.cap == 0 {
+            return Err(BatchConfigError::ZeroCap);
+        }
+        if self.yield_every == 0 {
+            return Err(BatchConfigError::ZeroYieldEvery);
+        }
+        if self.yield_every > self.cap {
+            return Err(BatchConfigError::YieldEveryExceedsCap {
+                yield_every: self.yield_every,
+                cap: self.cap,
+            });
+        }
+        // 1500 B floor: the smallest per-datagram budget that keeps MTU
+        // traffic allocation-free for a full cycle (see `initial_arena`).
+        // Saturating: an absurd `cap` must be REJECTED here, not wrap to
+        // a tiny minimum that then dies in Vec::with_capacity.
+        let minimum = self
+            .cap
+            .saturating_mul(1500)
+            .saturating_add(MAX_DATAGRAM_SIZE);
+        let resolved = self.initial_arena;
+        if resolved < minimum {
+            return Err(BatchConfigError::ArenaTooSmallForCap {
+                initial_arena: resolved,
+                cap: self.cap,
+                minimum,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum BatchConfigError {
+    #[error("batch.cap must be >= 1: a zero cap makes the drain loop's batch bound unreachable")]
+    ZeroCap,
+
+    #[error(
+        "batch.yield_every must be >= 1: computed as `i % yield_every`,\
+         and `% 0` panics on the hot path"
+    )]
+    ZeroYieldEvery,
+
+    #[error(
+        "batch.yield_every ({yield_every}) must be <= batch.cap ({cap}): \
+        a cadence beyond the cap never fires within a batch, \
+        silently disabling cooperative yielding"
+    )]
+    YieldEveryExceedsCap { yield_every: usize, cap: usize },
+
+    #[error(
+        "batch.initial_arena ({initial_arena}) is too small for batch.cap ({cap}): \
+        one cycle's datagrams pin the arena until cycle end, \
+        so it needs at least cap x 1500 B + 64 KiB ({minimum}); \
+        undersized, the drain loop silently allocates per packet;\
+         the exact cost the arena exists to avoid"
+    )]
+    ArenaTooSmallForCap {
+        initial_arena: usize,
+        cap: usize,
+        minimum: usize,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_valid() {
+        assert_eq!(BatchConfig::default().validate(), Ok(()));
+    }
+
+    #[test]
+    fn zero_cap_rejected() {
+        let config = BatchConfig {
+            cap: 0,
+            ..Default::default()
+        };
+        assert_eq!(config.validate(), Err(BatchConfigError::ZeroCap));
+    }
+
+    #[test]
+    fn zero_yield_every_rejected() {
+        let config = BatchConfig {
+            yield_every: 0,
+            ..Default::default()
+        };
+        assert_eq!(config.validate(), Err(BatchConfigError::ZeroYieldEvery));
+    }
+
+    #[test]
+    fn yield_every_beyond_cap_rejected() {
+        let config = BatchConfig {
+            cap: 64,
+            yield_every: 65,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.validate(),
+            Err(BatchConfigError::YieldEveryExceedsCap {
+                yield_every: 65,
+                cap: 64,
+            })
+        );
+    }
+
+    #[test]
+    fn arena_undersized_for_cap_rejected() {
+        // Default is self-consistent.
+        assert_eq!(BatchConfig::default().validate(), Ok(()));
+
+        // The default arena is sized for the DEFAULT cap, so raising cap
+        // alone eventually outgrows it is rejected loudly, with the minimum
+        // named, rather than silently allocating per packet mid-cycle.
+        let outgrown = BatchConfig {
+            cap: 8192,
+            ..Default::default()
+        };
+        assert!(matches!(
+            outgrown.validate(),
+            Err(BatchConfigError::ArenaTooSmallForCap { .. })
+        ));
+
+        // Raising cap within the default arena's headroom stays valid
+        // (default covers cap <= (1024*9216)/1500 ~= 6291).
+        let within = BatchConfig {
+            cap: 4096,
+            ..Default::default()
+        };
+        assert_eq!(within.validate(), Ok(()));
+
+        // Sizing the arena with the cap is what an operator must do.
+        let sized = BatchConfig {
+            cap: 8192,
+            initial_arena: 8192 * DEFAULT_ARENA_PER_DATAGRAM + MAX_DATAGRAM_SIZE,
+            ..Default::default()
+        };
+        assert_eq!(sized.validate(), Ok(()));
+    }
+
+    #[test]
+    fn boundary_yield_every_equals_cap_accepted() {
+        let config = BatchConfig {
+            cap: 64,
+            yield_every: 64,
+            ..Default::default()
+        };
+        assert_eq!(config.validate(), Ok(()));
+    }
+}

--- a/crates/service-core/src/lib.rs
+++ b/crates/service-core/src/lib.rs
@@ -1,0 +1,42 @@
+// Copyright (C) 2022-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared-nothing, thread-per-core collection service scaffolding, shared
+//! by every NetGauze protocol service (flow, BMP, UDP-Notif): the
+//! [`worker::Worker`] trait, the supervising
+//! [`supervisor::CollectionSupervisor`] (pinned spawn, panic detection,
+//! budgeted respawn, graceful shutdown, concurrent admin plane), CPU
+//! [`affinity`] strategies with environment auto-detection, NUMA-aware
+//! core [`assignment`], and the drain-loop [`batch`] knobs.
+//!
+//! Protocol crates implement [`worker::Worker`] for their own I/O loop and
+//! command enum; everything else, e.g., spawning, pinning, restart policy,
+//! metrics lifecycle, is identical across protocols and lives here.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub mod affinity;
+pub mod assignment;
+pub mod batch;
+pub mod supervisor;
+pub mod worker;
+
+#[inline(always)]
+pub(crate) fn unix_ms_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}

--- a/crates/service-core/src/supervisor.rs
+++ b/crates/service-core/src/supervisor.rs
@@ -1,0 +1,1302 @@
+// Copyright (C) 2022-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::affinity::{AffinityStrategy, CoreId, NoAffinity, PinOutcome};
+use crate::assignment::CoreAssignment;
+use crate::unix_ms_now;
+use crate::worker::{Worker, WorkerContext, WorkerIndex};
+use arc_swap::{ArcSwap, ArcSwapOption};
+use opentelemetry::metrics::Meter;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+use std::{io, thread};
+use tokio::runtime::Builder;
+use tokio::sync::{mpsc, oneshot, watch};
+use tracing::{error, info, warn};
+
+/// Everything about HOW to run a worker fleet, apart from the worker's
+/// own `Config`: the growable half of [`CollectionSupervisor::start`]'s
+/// signature.
+#[non_exhaustive]
+pub struct SupervisorOptions {
+    /// One worker per entry; `worker_index` order.
+    pub cores: CoreAssignment,
+    /// Per-worker command-channel capacity (control-plane rate: small).
+    pub mailbox: usize,
+    pub affinity: Arc<dyn AffinityStrategy>,
+    pub policy: RestartPolicy,
+    /// Instance name to be used in logs and telemetry
+    pub name: Box<str>,
+}
+
+impl SupervisorOptions {
+    pub const DEFAULT_MAILBOX: usize = 64;
+
+    pub fn new(cores: CoreAssignment, name: &str) -> Self {
+        Self {
+            cores,
+            mailbox: Self::DEFAULT_MAILBOX,
+            affinity: Arc::new(NoAffinity),
+            policy: RestartPolicy::default(),
+            name: Box::from(name),
+        }
+    }
+
+    pub fn with_mailbox(mut self, mailbox: usize) -> Self {
+        self.mailbox = mailbox;
+        self
+    }
+
+    pub fn with_affinity(mut self, affinity: Arc<dyn AffinityStrategy>) -> Self {
+        self.affinity = affinity;
+        self
+    }
+
+    pub fn with_policy(mut self, policy: RestartPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SlotExitInfo {
+    pub kind: SlotExitKind,
+    /// The error's `Display`, or the panic message; empty for `Clean`.
+    pub message: String,
+    /// Wall-clock stamp (Unix epoch ms) of when the supervisor processed
+    /// the exit.
+    pub at_unix_ms: u64,
+    /// Restarts consumed in the slot's current window at stamp time.
+    pub restarts: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SlotExitKind {
+    Clean,
+    Error,
+    Panic,
+}
+
+#[derive(Debug)]
+enum ExitReason {
+    /// `Worker::run` returned `Ok(())`;  command channel closed, or an
+    /// explicit Shutdown was handled inside `run`. Not respawned.
+    Clean,
+    /// `Worker::run` returned `Err`. Respawn per `RestartPolicy`.
+    Error(Box<dyn std::error::Error + Send + Sync>),
+    /// The thread panicked: `std::thread::Result`'s own payload type.
+    /// Respawn per `RestartPolicy`; `panic_message` best-efforts a string
+    /// out of the common `&str`/`String` payload shapes for logging.
+    Panic(Box<dyn std::any::Any + Send>),
+}
+
+/// Which worker exited and for what reason
+struct WorkerExit {
+    worker_index: WorkerIndex,
+    reason: ExitReason,
+}
+
+/// The supervisor-private record of one spawned thread, one per
+/// incarnation (a respawn replaces the whole record). Deliberately NOT
+/// `Clone` and never exported: the `JoinHandle` must not be joinable out
+/// from under the supervisor, and handing out `cmd_tx` directly would
+/// open an unsupervised, stale-on-respawn path to the worker's mailbox.
+struct WorkerThread<Cmd> {
+    cmd_tx: mpsc::Sender<Cmd>,
+}
+
+/// Per-slot supervision bookkeeping, kept apart from `WorkerThread`
+/// because it must survive respawns (a fresh `WorkerThread` replaces the
+/// old one; the restart budget must not reset with it).
+struct SlotState {
+    restarts: usize,
+    window_start: Instant,
+    /// Restart budget exhausted: the slot is left dead ("give up loudly"),
+    /// `route()` to it returns `WorkerGone`.
+    failed: bool,
+    /// Exited via `ExitReason::Clean`; deliberately not respawned.
+    done: bool,
+}
+
+/// Respawn budget for crashed workers: up to `max_restarts` restarts
+/// within any `window`, pacing each respawn by `backoff`; past the budget
+/// the slot is given up loudly ([AdminHandle::failed_slots]).
+///
+/// `#[non_exhaustive]` + [`RestartPolicy::new`], so future knobs (e.g.,
+/// respawn-on-clean for connection-oriented protocols, jittered backoff)
+/// are additive rather than breaking.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RestartPolicy {
+    max_restarts: usize, // within `window`, before giving up loudly
+    window: Duration,
+    backoff: Duration,
+    min_live_workers: usize,
+}
+
+impl RestartPolicy {
+    pub const fn new(max_restarts: usize, window: Duration, backoff: Duration) -> Self {
+        Self {
+            max_restarts,
+            window,
+            backoff,
+            min_live_workers: 0,
+        }
+    }
+
+    pub const fn with_min_live_workers(mut self, min_live_workers: usize) -> Self {
+        self.min_live_workers = min_live_workers;
+        self
+    }
+
+    /// The budget must be REACHABLE: each respawn takes at least
+    /// `backoff`, so a crash loop can only exhaust `max_restarts` inside
+    /// `window` when `backoff * (max_restarts + 1) <= window`. Otherwise,
+    /// the rolling window resets the count before it can ever exceed the
+    /// budget and "give up loudly" is dead code which can cause an eternal
+    /// crash loop that [AdminHandle::failed_slots] never reports.
+    pub fn validate(&self) -> Result<(), RestartPolicyError> {
+        if self.window.is_zero() {
+            return Err(RestartPolicyError::ZeroWindow);
+        }
+        if self.backoff.is_zero() {
+            return Err(RestartPolicyError::ZeroBackoff);
+        }
+        let budget_time = self
+            .backoff
+            .saturating_mul(u32::try_from(self.max_restarts).unwrap_or(u32::MAX));
+        if budget_time > self.window {
+            return Err(RestartPolicyError::UnreachableBudget {
+                backoff: self.backoff,
+                max_restarts: self.max_restarts,
+                window: self.window,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl Default for RestartPolicy {
+    /// 3 restarts per 60s window, 100ms backoff.
+    fn default() -> Self {
+        Self::new(3, Duration::from_secs(60), Duration::from_millis(100))
+    }
+}
+
+/// Why [`CollectionSupervisor::supervise`] returned. The embedder decides
+/// what each means for the process; `BelowMinimumWorkers` is the signal
+/// to tear the whole service down (call `shutdown()` for the survivors'
+/// flush, then exit non-zero).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive] // future exit reasons must be additive, like RestartPolicy's knobs
+#[must_use = "BelowMinimumWorkers means the service should shut itself down; ignoring it defeats the min-live check"]
+pub enum SuperviseExit {
+    /// The shutdown signal fired (or its sender dropped): normal
+    /// teardown, proceed to `shutdown()`.
+    ShutdownRequested,
+    /// Live workers (neither failed nor cleanly done) dropped below
+    /// `RestartPolicy::min_live_workers`.
+    BelowMinimumWorkers { live: usize, minimum: usize },
+}
+
+/// Error in routing commands from the Supervisor to the worker threads
+#[derive(Debug, thiserror::Error)]
+pub enum RouteError {
+    #[error("no worker at index {0}")]
+    UnknownWorker(WorkerIndex),
+    #[error(
+        "worker {0}'s command channel is closed (thread exited: mid-respawn, done, or failed; check done_slots()/failed_slots())"
+    )]
+    WorkerGone(WorkerIndex),
+    #[error("worker {0}'s command mailbox is full")]
+    MailboxFull(WorkerIndex),
+}
+
+/// The concurrent-admin side of a supervisor: cloneable, usable WHILE
+/// `supervise()` holds the supervisor mutably, where an admin surface
+/// serves queries as supervision runs.
+/// Per-slot senders live behind `ArcSwap` so a respawn refreshes them in place:
+/// an admin holding this handle transparently reaches the NEW worker
+/// after a restart, and gets `WorkerGone` only in the dead window.
+pub struct AdminHandle<Cmd> {
+    senders: Arc<[ArcSwap<mpsc::Sender<Cmd>>]>,
+    failed: Arc<[AtomicBool]>,
+    done: Arc<[AtomicBool]>,
+    /// Per-slot record of the most recent exit (RCU: supervisor stores,
+    /// admins load); `None` until a slot's first exit.
+    last_exits: Arc<[ArcSwapOption<SlotExitInfo>]>,
+    /// Name used for logging and OTEL metrics
+    name: Box<str>,
+}
+
+/// Manually implemented since Cmd doesn't need to be clonable
+impl<Cmd> Clone for AdminHandle<Cmd> {
+    fn clone(&self) -> Self {
+        Self {
+            senders: Arc::clone(&self.senders),
+            failed: Arc::clone(&self.failed),
+            done: Arc::clone(&self.done),
+            last_exits: Arc::clone(&self.last_exits),
+            name: self.name.clone(),
+        }
+    }
+}
+
+impl<Cmd> AdminHandle<Cmd> {
+    pub fn worker_count(&self) -> usize {
+        self.senders.len()
+    }
+
+    /// The supervisor's instance name: the same value stamped on its log
+    /// lines, so embedder-side admin surfaces can label their own output
+    /// with the supervisor a reply came from.
+    pub const fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Worker whose restart budget is exhausted they are not going to be
+    /// retried to start again.
+    pub fn failed_slots(&self) -> Vec<WorkerIndex> {
+        self.failed
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| f.load(Ordering::Relaxed))
+            .map(|(i, _)| WorkerIndex::new(i))
+            .collect()
+    }
+
+    /// Slots whose worker exited cleanly and is deliberately not
+    /// respawned.
+    pub fn done_slots(&self) -> Vec<WorkerIndex> {
+        self.done
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| f.load(Ordering::Relaxed))
+            .map(|(i, _)| WorkerIndex::new(i))
+            .collect()
+    }
+
+    pub fn last_exit(&self, worker_index: WorkerIndex) -> Option<Arc<SlotExitInfo>> {
+        self.last_exits.get(worker_index.get())?.load_full()
+    }
+
+    /// A blocking send a message for one worker. If the mailbox of the worker
+    /// is full, this method will block (potentially for infinity), thus,
+    /// it's recommended for callers to wrap the calls to this method with a
+    /// timeout.
+    pub async fn route(&self, worker_index: WorkerIndex, cmd: Cmd) -> Result<(), RouteError> {
+        let slot = self
+            .senders
+            .get(worker_index.get())
+            .ok_or(RouteError::UnknownWorker(worker_index))?;
+        let sender = slot.load_full();
+        sender
+            .send(cmd)
+            .await
+            .map_err(|_| RouteError::WorkerGone(worker_index))
+    }
+
+    /// A non-blocking send for a message to a given worker.
+    pub fn try_route(&self, worker_index: WorkerIndex, cmd: Cmd) -> Result<(), RouteError> {
+        let slot = self
+            .senders
+            .get(worker_index.get())
+            .ok_or(RouteError::UnknownWorker(worker_index))?;
+        let sender = slot.load_full();
+        sender.try_send(cmd).map_err(|e| match e {
+            mpsc::error::TrySendError::Full(_) => RouteError::MailboxFull(worker_index),
+            mpsc::error::TrySendError::Closed(_) => RouteError::WorkerGone(worker_index),
+        })
+    }
+
+    /// A util function to run one async operation per worker CONCURRENTLY,
+    /// each bounded by `timeout`, collecting whatever the operation yields.
+    ///
+    /// The shared scaffolding behind [`Self::broadcast`] and [`Self::fan_out`]:
+    /// N wedged workers cost ONE timeout, not a serial stack of them.
+    async fn each_worker<F, Fut, T>(&self, timeout: Duration, f: F) -> Vec<(WorkerIndex, T)>
+    where
+        F: Fn(WorkerIndex) -> Fut,
+        Fut: Future<Output = Option<T>>,
+    {
+        let calls = (0..self.senders.len()).map(|i| {
+            let worker_index = WorkerIndex::new(i);
+            let call = f(worker_index); // built here, owned by the future below
+            async move {
+                match tokio::time::timeout(timeout, call).await {
+                    Ok(Some(value)) => Some((worker_index, value)),
+                    Ok(None) => None, // dead slot or no reply: skipped
+                    Err(_) => {
+                        warn!(
+                            supervisor = %self.name,
+                            worker_index = worker_index.get(),
+                            "admin command timed out; worker wedged or overloaded -- skipping"
+                        );
+                        None
+                    }
+                }
+            }
+        });
+        futures::future::join_all(calls)
+            .await
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+
+    /// A reliable concurrent broadcast function that collects the
+    /// replies from each worker within `timeout`.
+    ///
+    /// `make_cmd` builds the command from a fresh reply channel,
+    /// so each worker answers on its own oneshot.
+    ///
+    /// Dead or unreachable slots (respawning, failed, cleanly exited) are
+    /// skipped silently.
+    ///
+    /// TIMEOUT IS NOT A NO-OP for mutating commands: a worker may accept
+    /// and execute the command while its reply misses the deadline, in
+    /// which case it is absent from the result. Treat the result as
+    /// "confirmed", not "performed".
+    pub async fn fan_out<R>(
+        &self,
+        timeout: Duration,
+        make_cmd: impl Fn(oneshot::Sender<R>) -> Cmd,
+    ) -> Vec<(WorkerIndex, R)> {
+        self.each_worker(timeout, |worker_index| {
+            let (tx, rx) = oneshot::channel();
+            let cmd = make_cmd(tx);
+            async move {
+                // NOTE: route() AWAITS mailbox capacity (MailboxFull is a
+                // try_route-only error), so a live-but-backlogged worker
+                // is bounded by `timeout` rather than skipped fast.
+                match self.route(worker_index, cmd).await {
+                    Ok(()) => rx.await.ok(),
+                    Err(_) => None, // dead slot: skipped
+                }
+            }
+        })
+        .await
+    }
+
+    /// Supervisor-side stamp (single writer); admins only load.
+    fn record_exit(&self, idx: usize, kind: SlotExitKind, message: String, restarts: usize) {
+        if let Some(cell) = self.last_exits.get(idx) {
+            cell.store(Some(Arc::new(SlotExitInfo {
+                kind,
+                message,
+                at_unix_ms: unix_ms_now(),
+                restarts,
+            })));
+        }
+    }
+}
+
+/// Why a [`RestartPolicy`] failed validation. Typed so an embedder can
+/// distinguish which knob is wrong without string matching.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum RestartPolicyError {
+    #[error("restart policy window must be > 0")]
+    ZeroWindow,
+    #[error("restart policy backoff must be > 0 (zero backoff allows an un-paced crash loop)")]
+    ZeroBackoff,
+    #[error(
+        "restart budget is unreachable: backoff ({backoff:?}) x max_restarts ({max_restarts}) exceeds window ({window:?}); a crash loop would roll the window forever and never trip the budget"
+    )]
+    UnreachableBudget {
+        backoff: Duration,
+        max_restarts: usize,
+        window: Duration,
+    },
+}
+
+/// Why [`CollectionSupervisor::start`] refused to start.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StartError {
+    #[error("CoreAssignment is empty: nothing to supervise")]
+    EmptyCoreAssignment,
+    #[error("mailbox capacity must be > 0 (tokio's bounded channel panics on 0)")]
+    ZeroMailbox,
+    #[error("min_live_workers ({minimum}) exceeds the worker count ({workers})")]
+    MinLiveExceedsWorkers { minimum: usize, workers: usize },
+    #[error("invalid restart policy: {0}")]
+    Policy(#[from] RestartPolicyError),
+    #[error("failed to spawn worker thread: {0}")]
+    ThreadSpawn(#[source] io::Error),
+}
+
+pub struct CollectionSupervisor<W: Worker> {
+    // Fixed-size, same reasoning as CoreAssignment: one slot per core,
+    // never added to or removed from. `supervise()` replaces a slot in
+    // place on respawn.
+    workers: Box<[WorkerThread<W::Command>]>,
+
+    slots: Box<[SlotState]>,
+
+    /// Shared with every `AdminHandle`; respawn stores the fresh sender,
+    /// budget exhaustion flips the failed flag.
+    admin: AdminHandle<W::Command>,
+
+    /// Per-slot metrics state, created once by `W::build_stats` at start and
+    /// NEVER recreated on respawn.
+    stats: Box<[Arc<W::Stats>]>,
+
+    config: W::Config,
+
+    cores: CoreAssignment,
+    affinity: Arc<dyn AffinityStrategy>,
+    /// per-worker command channel capacity
+    mailbox: usize,
+    policy: RestartPolicy,
+    exit_rx: mpsc::Receiver<WorkerExit>,
+    /// kept so it can be cloned into each spawn_pinned call
+    exit_tx: mpsc::Sender<WorkerExit>,
+    meter: Meter,
+}
+
+impl<W: Worker> CollectionSupervisor<W> {
+    pub fn start(
+        config: W::Config,
+        options: SupervisorOptions,
+        meter: Meter,
+    ) -> Result<Self, StartError> {
+        let SupervisorOptions {
+            cores,
+            mailbox,
+            affinity,
+            policy,
+            name,
+        } = options;
+        if cores.is_empty() {
+            return Err(StartError::EmptyCoreAssignment);
+        }
+        policy.validate()?;
+        if mailbox == 0 {
+            return Err(StartError::ZeroMailbox);
+        }
+        if policy.min_live_workers > cores.len() {
+            return Err(StartError::MinLiveExceedsWorkers {
+                minimum: policy.min_live_workers,
+                workers: cores.len(),
+            });
+        }
+        let stats: Box<[Arc<W::Stats>]> = (0..cores.len())
+            .map(|i| W::build_stats(WorkerIndex::new(i), &config, &meter))
+            .collect();
+        // Channel capacity is the number of workers, since each worker expected to
+        // send max one exit message.
+        let (exit_tx, exit_rx) = mpsc::channel(cores.len());
+
+        let workers: io::Result<Vec<WorkerThread<W::Command>>> = cores
+            .iter()
+            .map(|(worker_index, core_id)| {
+                Self::spawn_pinned(
+                    worker_index,
+                    core_id,
+                    meter.clone(),
+                    config.clone(),
+                    Arc::clone(&stats[worker_index.get()]),
+                    mailbox,
+                    Arc::clone(&affinity),
+                    exit_tx.clone(),
+                    name.clone(),
+                )
+            })
+            .collect();
+        let workers = workers.map_err(StartError::ThreadSpawn)?.into_boxed_slice();
+
+        let senders: Arc<[ArcSwap<mpsc::Sender<W::Command>>]> = workers
+            .iter()
+            .map(|w| ArcSwap::from_pointee(w.cmd_tx.clone()))
+            .collect();
+        let failed: Arc<[AtomicBool]> = (0..cores.len()).map(|_| AtomicBool::new(false)).collect();
+        let done: Arc<[AtomicBool]> = (0..cores.len()).map(|_| AtomicBool::new(false)).collect();
+        let last_exits: Arc<[ArcSwapOption<SlotExitInfo>]> =
+            (0..cores.len()).map(|_| ArcSwapOption::empty()).collect();
+        let admin = AdminHandle {
+            senders,
+            failed,
+            done,
+            last_exits,
+            name: name.clone(),
+        };
+
+        let now = Instant::now();
+        let slots: Box<[SlotState]> = (0..cores.len())
+            .map(|_| SlotState {
+                restarts: 0,
+                window_start: now,
+                failed: false,
+                done: false,
+            })
+            .collect();
+
+        Ok(Self {
+            workers,
+            slots,
+            admin,
+            stats,
+            config,
+            cores,
+            affinity,
+            mailbox,
+            policy,
+            exit_rx,
+            exit_tx,
+            meter,
+        })
+    }
+
+    pub fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+
+    /// A cloneable admin side that stays valid while `supervise()` holds
+    /// this supervisor mutably
+    pub fn admin_handle(&self) -> AdminHandle<W::Command> {
+        self.admin.clone()
+    }
+
+    /// name to be used in logs and OTEL telemetry
+    pub const fn name(&self) -> &str {
+        self.admin.name()
+    }
+
+    /// Slots whose restart budget is exhausted
+    pub fn failed_slots(&self) -> Vec<WorkerIndex> {
+        self.admin.failed_slots()
+    }
+
+    /// See [AdminHandle::route]
+    pub async fn route(
+        &self,
+        worker_index: WorkerIndex,
+        cmd: W::Command,
+    ) -> Result<(), RouteError> {
+        self.admin.route(worker_index, cmd).await
+    }
+
+    /// The supervision loop.
+    pub async fn supervise(&mut self, shutdown: &mut watch::Receiver<bool>) -> SuperviseExit {
+        loop {
+            tokio::select! {
+                biased;
+                changed = shutdown.changed() => {
+                    // A closed shutdown channel means the signaller is
+                    // gone; treat that as shutdown rather than supervising
+                    // unstoppably.
+                    if changed.is_err() || *shutdown.borrow() {
+                        return SuperviseExit::ShutdownRequested;
+                    }
+                }
+                exit = self.exit_rx.recv() => {
+                    match exit {
+                        None => return SuperviseExit::ShutdownRequested,
+                        Some(exit) => {
+                            if self.handle_exit(exit, shutdown).await {
+                                return SuperviseExit::ShutdownRequested;
+                            }
+                            if let Some(below) = self.check_min_live() {
+                                if *shutdown.borrow() {
+                                    return SuperviseExit::ShutdownRequested
+                                }
+                                return below
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn check_min_live(&self) -> Option<SuperviseExit> {
+        let minimum = self.policy.min_live_workers;
+        if minimum == 0 {
+            return None;
+        }
+        let live = self.slots.iter().filter(|s| !s.failed && !s.done).count();
+        if live < minimum {
+            error!(
+                supervisor = self.name(),
+                live,
+                minimum,
+                "live workers below the configured minimum; ending supervision so the embedder can fail the whole service"
+            );
+            return Some(SuperviseExit::BelowMinimumWorkers { live, minimum });
+        }
+        None
+    }
+
+    /// Graceful teardown
+    ///
+    /// This is the ONLY correct teardown: it first swaps every
+    /// [`AdminHandle`] sender for a pre-closed one, which is what lets
+    /// the workers' channels actually close while admin clones live on.
+    /// Dropping the supervisor instead leaks the detached workers.
+    pub async fn shutdown(self, deadline: Duration) {
+        let Self {
+            workers,
+            slots,
+            admin,
+            exit_tx,
+            mut exit_rx,
+            ..
+        } = self;
+        // Log-only bookkeeping
+        let expected = slots.iter().filter(|s| !s.failed && !s.done).count();
+
+        // AdminHandle clones hold sender clones that would keep every
+        // command channel open past the drop below.
+        // Swap each slot to a pre-closed sender first,
+        // so admins get WorkerGone from here on and the workers' channels actually
+        // close.
+        for slot in admin.senders.iter() {
+            let (dead_tx, dead_rx) = mpsc::channel(1);
+            drop(dead_rx);
+            slot.store(Arc::new(dead_tx));
+        }
+
+        // Dropping the workers drops the last live cmd_tx per worker
+        drop(workers);
+
+        // Drop our own exit_tx so exit_rx terminates (None) once every
+        // worker thread's clone is gone.
+        drop(exit_tx);
+
+        // Counted OUTSIDE the future: on the deadline branch the drain
+        // future is dropped, and a count owned by it would be lost.
+        let clean = std::sync::atomic::AtomicUsize::new(0);
+        let drain = async {
+            while let Some(exit) = exit_rx.recv().await {
+                let idx = exit.worker_index.get();
+                let restarts = slots.get(idx).map_or(0, |s| s.restarts);
+                match exit.reason {
+                    ExitReason::Clean => {
+                        clean.fetch_add(1, Ordering::Relaxed);
+                        admin.record_exit(idx, SlotExitKind::Clean, String::new(), restarts);
+                        info!(
+                            supervisor = admin.name(),
+                            worker_index = exit.worker_index.get(),
+                            "worker shut down cleanly"
+                        );
+                    }
+                    ExitReason::Error(e) => {
+                        warn!(
+                            supervisor = admin.name(),
+                            worker_index = exit.worker_index.get(),
+                            error = %e,
+                            "worker errored during shutdown"
+                        );
+                        admin.record_exit(idx, SlotExitKind::Error, e.to_string(), restarts);
+                    }
+                    ExitReason::Panic(p) => {
+                        error!(
+                            supervisor = admin.name(),
+                            worker_index = exit.worker_index.get(),
+                            panic = panic_message(p.as_ref()),
+                            "worker panicked during shutdown"
+                        );
+                        admin.record_exit(
+                            idx,
+                            SlotExitKind::Panic,
+                            panic_message(p.as_ref()).to_string(),
+                            restarts,
+                        );
+                    }
+                }
+            }
+        };
+
+        match tokio::time::timeout(deadline, drain).await {
+            Ok(()) => {
+                info!(
+                    supervisor = admin.name(),
+                    clean = clean.load(Ordering::Relaxed),
+                    expected,
+                    "supervisor shutdown complete"
+                );
+            }
+            Err(_) => {
+                warn!(
+                    supervisor = admin.name(),
+                    clean = clean.load(Ordering::Relaxed),
+                    expected,
+                    "supervisor shutdown deadline expired; abandoning remaining workers"
+                );
+            }
+        }
+    }
+
+    /// Returns `true` when the shutdown signal was observed during the
+    /// respawn backoff (the caller must then end supervision).
+    async fn handle_exit(
+        &mut self,
+        exit: WorkerExit,
+        shutdown: &mut watch::Receiver<bool>,
+    ) -> bool {
+        let worker_index = exit.worker_index;
+        let idx = worker_index.get();
+        let restarts_now = self.slots.get(idx).map_or(0, |s| s.restarts);
+        match exit.reason {
+            ExitReason::Clean => {
+                info!(
+                    supervisor = self.name(),
+                    worker_index = idx,
+                    "worker exited cleanly; not respawning"
+                );
+                self.admin
+                    .record_exit(idx, SlotExitKind::Clean, String::new(), restarts_now);
+                if let Some(slot) = self.slots.get_mut(idx) {
+                    slot.done = true;
+                    self.admin.done[idx].store(true, Ordering::Relaxed);
+                }
+                false
+            }
+            ExitReason::Error(e) => {
+                warn!(supervisor = self.name(), worker_index = idx, error = %e, "worker failed");
+                self.admin
+                    .record_exit(idx, SlotExitKind::Error, e.to_string(), restarts_now);
+                self.respawn(worker_index, shutdown).await
+            }
+            ExitReason::Panic(p) => {
+                error!(
+                    supervisor = self.name(),
+                    worker_index = idx,
+                    panic = panic_message(p.as_ref()),
+                    "worker panicked"
+                );
+                self.admin.record_exit(
+                    idx,
+                    SlotExitKind::Panic,
+                    panic_message(p.as_ref()).to_string(),
+                    restarts_now,
+                );
+                self.respawn(worker_index, shutdown).await
+            }
+        }
+    }
+
+    async fn respawn(
+        &mut self,
+        worker_index: WorkerIndex,
+        shutdown: &mut watch::Receiver<bool>,
+    ) -> bool {
+        let idx = worker_index.get();
+        let supervisor = self.name().to_string().into_boxed_str();
+        let (Some(slot), Some(core_id)) =
+            (self.slots.get_mut(idx), self.cores.core_id(worker_index))
+        else {
+            return false;
+        };
+        if slot.failed {
+            return false;
+        }
+        if slot.window_start.elapsed() > self.policy.window {
+            slot.restarts = 0;
+            slot.window_start = Instant::now();
+        }
+        slot.restarts += 1;
+        if slot.restarts > self.policy.max_restarts {
+            slot.failed = true;
+            self.admin.failed[idx].store(true, Ordering::Relaxed);
+            error!(
+                supervisor,
+                worker_index = idx,
+                restarts = slot.restarts,
+                window_secs = self.policy.window.as_secs(),
+                "restart budget exhausted; giving up on this slot"
+            );
+            return false;
+        }
+        tokio::select! {
+            biased;
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    info!(
+                        supervisor,
+                        worker_index = idx,
+                        "shutdown during respawn backoff; not respawning"
+                    );
+                    return true;
+                }
+                // A change that is NOT shutdown (send(false)): proceed to
+                // the respawn without the rest of the backoff -- harmless,
+                // and simpler than re-arming the sleep.
+            }
+            _ = tokio::time::sleep(self.policy.backoff) => {}
+        }
+        let spawn_pinned_result = Self::spawn_pinned(
+            worker_index,
+            core_id,
+            self.meter.clone(),
+            self.config.clone(),
+            Arc::clone(&self.stats[idx]),
+            self.mailbox,
+            Arc::clone(&self.affinity),
+            self.exit_tx.clone(),
+            supervisor.clone(),
+        );
+        match spawn_pinned_result {
+            Ok(worker) => {
+                info!(
+                    supervisor,
+                    worker_index = idx,
+                    restart = slot.restarts,
+                    "worker respawned"
+                );
+                // Refresh the admin side FIRST: from here on, admin sends
+                // reach the new incarnation.
+                self.admin.senders[idx].store(Arc::new(worker.cmd_tx.clone()));
+                self.workers[idx] = worker;
+            }
+            Err(e) => {
+                slot.failed = true;
+                self.admin.failed[idx].store(true, Ordering::Relaxed);
+                self.admin.record_exit(
+                    idx,
+                    SlotExitKind::Error,
+                    format!("thread spawn failed on respawn: {e}"),
+                    slot.restarts,
+                );
+                error!(
+                    supervisor = self.name(),
+                    worker_index = worker_index.get(),
+                    error = %e,
+                    "thread spawn failed on respawn; giving up on this slot"
+                );
+            }
+        }
+        false
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_pinned(
+        worker_index: WorkerIndex,
+        core_id: CoreId, // candidate/target; not yet a confirmed outcome
+        meter: Meter,
+        config: W::Config,
+        stats: Arc<W::Stats>, // per-slot, from build_stats; SAME Arc on every respawn
+        mailbox: usize,
+        affinity: Arc<dyn AffinityStrategy>,
+        exit_tx: mpsc::Sender<WorkerExit>,
+        name: Box<str>,
+    ) -> io::Result<WorkerThread<W::Command>> {
+        let (cmd_tx, cmd_rx) = mpsc::channel(mailbox);
+
+        let join = thread::Builder::new()
+            .name(format!("{}-{worker_index}", W::NAME)) // worker_index: stable regardless of pin outcome
+            .spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let core_id = match affinity.apply(core_id) {
+                        PinOutcome::Pinned(actual) => Some(actual),
+                        PinOutcome::Unpinned => None,
+                        PinOutcome::Failed => {
+                            warn!(
+                                supervisor = name,
+                                worker_index = worker_index.get(),
+                                requested_core = core_id.get(),
+                                "CPU pin failed; worker runs unpinned"
+                            );
+                            None
+                        }
+                    };
+
+                    let ctx = WorkerContext::new(worker_index, core_id, meter);
+
+                    match Builder::new_current_thread().enable_all().build() {
+                        Ok(rt) => match rt.block_on(async move {
+                            W::build(&ctx, config, stats)?.run(cmd_rx).await
+                        }) {
+                            Ok(()) => ExitReason::Clean,
+                            Err(e) => ExitReason::Error(Box::new(e)),
+                        },
+                        Err(e) => ExitReason::Error(Box::new(e)),
+                    }
+                }));
+                let reason = result.unwrap_or_else(ExitReason::Panic);
+                let _ = exit_tx.blocking_send(WorkerExit {
+                    worker_index,
+                    reason,
+                });
+            })?;
+        // detached the JoinHandle deliberately since every exit, including
+        // panics, is caught in the code above and the exit channel communicates the
+        // exit reason.
+        drop(join);
+
+        Ok(WorkerThread { cmd_tx })
+    }
+}
+
+/// Best-effort extraction of a printable message from a panic payload --
+/// the two shapes `panic!` actually produces. Anything else is opaque.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::affinity::NoAffinity;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    /// A worker whose behavior is steered by shared state in its Config:
+    /// counts builds, optionally panics exactly once (whichever incarnation
+    /// claims the flag), then runs until its command channel closes.
+    struct TestWorker {
+        cfg: TestConfig,
+    }
+    #[derive(Clone)]
+    struct TestConfig {
+        builds: Arc<AtomicUsize>,
+        panic_once: Arc<AtomicBool>,
+        /// One incarnation returns Ok immediately: the clean-exit path.
+        exit_clean_once: Arc<AtomicBool>,
+        /// Never read the command channel: mailbox fills, worker wedges.
+        stall: bool,
+        /// What build() observed as ctx.core_id(): -2 = build never ran,
+        /// -1 = ran unpinned (None), >= 0 = the pinned core.
+        saw_core_id: Arc<std::sync::atomic::AtomicI64>,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test worker error")]
+    struct TestError;
+
+    impl Worker for TestWorker {
+        type Command = ();
+        type Config = TestConfig;
+        type Stats = ();
+        type Error = TestError;
+        const NAME: &'static str = "test";
+
+        fn build_stats(
+            _worker_index: WorkerIndex,
+            _config: &TestConfig,
+            _meter: &Meter,
+        ) -> Arc<()> {
+            Arc::new(())
+        }
+
+        fn build(
+            ctx: &WorkerContext,
+            config: TestConfig,
+            _stats: Arc<()>,
+        ) -> Result<Self, TestError> {
+            config.builds.fetch_add(1, Ordering::SeqCst);
+            config.saw_core_id.store(
+                ctx.core_id().map_or(-1, |c| c.get() as i64),
+                Ordering::SeqCst,
+            );
+            Ok(Self { cfg: config })
+        }
+
+        async fn run(self, mut cmd_rx: mpsc::Receiver<()>) -> Result<(), TestError> {
+            // Exactly one incarnation across all slots claims the panic.
+            if self.cfg.panic_once.swap(false, Ordering::SeqCst) {
+                panic!("deliberate test panic");
+            }
+            if self.cfg.exit_clean_once.swap(false, Ordering::SeqCst) {
+                return Ok(()); // clean exit while supervised
+            }
+            if self.cfg.stall {
+                std::future::pending::<()>().await; // wedged worker
+            }
+            while cmd_rx.recv().await.is_some() {}
+            Ok(())
+        }
+    }
+
+    fn default_test_config() -> TestConfig {
+        TestConfig {
+            builds: Arc::new(AtomicUsize::new(0)),
+            panic_once: Arc::new(AtomicBool::new(false)),
+            exit_clean_once: Arc::new(AtomicBool::new(false)),
+            stall: false,
+            saw_core_id: Arc::new(std::sync::atomic::AtomicI64::new(-2)),
+        }
+    }
+
+    fn test_supervisor_with(
+        cfg: TestConfig,
+        workers: usize,
+        mailbox: usize,
+        max_restarts: usize,
+    ) -> (CollectionSupervisor<TestWorker>, TestConfig) {
+        let sup = CollectionSupervisor::<TestWorker>::start(
+            cfg.clone(),
+            SupervisorOptions::new(
+                CoreAssignment::explicit(vec![0usize; workers]),
+                "test-supervisor",
+            )
+            .with_mailbox(mailbox)
+            .with_affinity(Arc::new(NoAffinity))
+            .with_policy(RestartPolicy::new(
+                max_restarts,
+                Duration::from_secs(60),
+                Duration::from_millis(10),
+            )),
+            opentelemetry::global::meter("test"),
+        )
+        .expect("supervisor start");
+        (sup, cfg)
+    }
+
+    fn test_supervisor(
+        panic_once: bool,
+        workers: usize,
+        max_restarts: usize,
+    ) -> (CollectionSupervisor<TestWorker>, TestConfig) {
+        let cfg = TestConfig {
+            panic_once: Arc::new(AtomicBool::new(panic_once)),
+            ..default_test_config()
+        };
+        test_supervisor_with(cfg, workers, 4, max_restarts)
+    }
+    async fn wait_for(deadline: Duration, mut cond: impl FnMut() -> bool) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < deadline {
+            if cond() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        cond()
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn panic_is_detected_and_respawned_once() {
+        let (mut sup, cfg) = test_supervisor(true, 2, 3);
+        let admin = sup.admin_handle();
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+        let supervise = async {
+            let _ = sup.supervise(&mut shutdown_rx).await;
+            sup
+        };
+        let checks = async {
+            // 2 initial builds + exactly 1 respawn after the panic.
+            let builds = Arc::clone(&cfg.builds);
+            assert!(
+                wait_for(Duration::from_secs(5), || builds.load(Ordering::SeqCst)
+                    == 3)
+                .await,
+                "expected exactly one respawn (3 builds), got {}",
+                builds.load(Ordering::SeqCst)
+            );
+            // Give the respawn a beat to prove it does NOT keep respawning
+            // (the panic flag was consumed; no further exits should occur).
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            assert_eq!(cfg.builds.load(Ordering::SeqCst), 3);
+            // Triage record: exactly one slot's last exit is the panic,
+            // with the payload message preserved for readiness surfaces.
+            let panics: Vec<_> = (0..2)
+                .filter_map(|i| admin.last_exit(WorkerIndex::new(i)))
+                .filter(|e| e.kind == SlotExitKind::Panic)
+                .collect();
+            assert_eq!(panics.len(), 1, "exactly one slot panicked");
+            assert_eq!(panics[0].message, "deliberate test panic");
+            assert!(panics[0].at_unix_ms > 0);
+            shutdown_tx.send(true).expect("signal shutdown");
+        };
+        let (sup, ()) = tokio::join!(supervise, checks);
+        assert!(sup.failed_slots().is_empty(), "no slot should be failed");
+        // The log trail is part of the contract: the panic is reported
+        // (with its message) and the respawn is announced.
+        assert!(logs_contain("worker panicked"));
+        assert!(logs_contain("deliberate test panic"));
+        assert!(logs_contain("worker respawned"));
+        sup.shutdown(Duration::from_secs(5)).await;
+    }
+
+    #[test]
+    fn start_rejects_min_live_above_worker_count() {
+        let cfg = default_test_config();
+        let result = CollectionSupervisor::<TestWorker>::start(
+            cfg,
+            SupervisorOptions::new(CoreAssignment::explicit(vec![0usize; 2]), "test-supervisor")
+                .with_mailbox(4)
+                .with_affinity(Arc::new(NoAffinity))
+                .with_policy(RestartPolicy::default().with_min_live_workers(3)),
+            opentelemetry::global::meter("test"),
+        );
+        match result {
+            Ok(_) => panic!("min_live_workers above worker count must be rejected"),
+            Err(err) => assert!(matches!(
+                err,
+                StartError::MinLiveExceedsWorkers {
+                    minimum: 3,
+                    workers: 2
+                }
+            )),
+        }
+    }
+
+    #[test]
+    fn restart_policy_zero_backoff_rejected() {
+        // Zero backoff would permit an un-paced crash loop that the
+        // reachability check cannot see (budget_time == 0 passes).
+        assert!(
+            RestartPolicy::new(3, Duration::from_secs(60), Duration::ZERO)
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn start_rejects_zero_mailbox() {
+        // tokio's bounded channel panics on capacity 0; start() must turn
+        // that config value into InvalidInput, not a panic.
+        let cfg = default_test_config();
+        let result = CollectionSupervisor::<TestWorker>::start(
+            cfg,
+            SupervisorOptions::new(CoreAssignment::explicit(vec![0usize]), "test-supervisor")
+                .with_mailbox(0)
+                .with_affinity(Arc::new(NoAffinity))
+                .with_policy(RestartPolicy::default()),
+            opentelemetry::global::meter("test"),
+        );
+        match result {
+            Ok(_) => panic!("zero mailbox must be rejected"),
+            Err(err) => assert!(matches!(err, StartError::ZeroMailbox)),
+        }
+    }
+
+    #[test]
+    fn start_rejects_unreachable_restart_budget() {
+        let cfg = default_test_config();
+        let result = CollectionSupervisor::<TestWorker>::start(
+            cfg,
+            SupervisorOptions::new(CoreAssignment::explicit(vec![0usize]), "test-supervisor")
+                .with_mailbox(4)
+                .with_affinity(Arc::new(NoAffinity))
+                .with_policy(RestartPolicy::new(
+                    3,
+                    Duration::from_millis(10),
+                    Duration::from_secs(60),
+                )),
+            opentelemetry::global::meter("test"),
+        );
+        match result {
+            Ok(_) => panic!("unreachable budget must be rejected"),
+            Err(err) => assert!(matches!(
+                err,
+                StartError::Policy(RestartPolicyError::UnreachableBudget { .. })
+            )),
+        }
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn clean_exit_marks_slot_done_for_admins() {
+        let cfg = TestConfig {
+            exit_clean_once: Arc::new(AtomicBool::new(true)),
+            ..default_test_config()
+        };
+        let (mut sup, cfg) = test_supervisor_with(cfg, 2, 4, 3);
+        let admin = sup.admin_handle();
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let supervise = tokio::spawn(async move {
+            let _ = sup.supervise(&mut shutdown_rx).await;
+            sup
+        });
+
+        // One incarnation exits cleanly; the slot must become visible as
+        // done to admin-plane readiness, must NOT be respawned (builds
+        // stays at the initial 2), and must NOT count as failed.
+        assert!(
+            wait_for(Duration::from_secs(5), || admin.done_slots().len() == 1).await,
+            "clean exit never became visible via done_slots()"
+        );
+        assert!(admin.failed_slots().is_empty());
+        // Both INITIAL builds must have happened: worker 1 builds on its
+        // own OS thread, unsynchronized with worker 0's done flag, so
+        // asserting == 2 immediately is a race (seen flaking as == 1)...
+        let builds = Arc::clone(&cfg.builds);
+        assert!(
+            wait_for(Duration::from_secs(5), || builds.load(Ordering::SeqCst)
+                == 2)
+            .await,
+            "both workers must build once"
+        );
+        // ...and a respawn of the done slot would push it to 3: hold a
+        // beat to prove it stays at 2.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(cfg.builds.load(Ordering::SeqCst), 2, "done slot respawned");
+
+        let _ = shutdown_tx.send(true);
+        let sup = supervise.await.expect("supervise task");
+        sup.shutdown(Duration::from_secs(5)).await;
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn try_route_reports_full_mailbox_and_shutdown_abandons_wedged_worker() {
+        // A wedged worker (never reads its mailbox): try_route must report
+        // MailboxFull instead of hanging, and shutdown(deadline) must
+        // return;  worker threads are detached, so the runtime must then
+        // drop without waiting on the stuck thread (the regression this
+        // test pins: spawn_blocking-based panic watchers hung runtime
+        // drop; watchers are gone entirely now, panics are caught
+        // in-thread).
+        let cfg = TestConfig {
+            stall: true,
+            ..default_test_config()
+        };
+        let (mut sup, _cfg) = test_supervisor_with(cfg, 1, 1, 3);
+        let admin = sup.admin_handle();
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+        let supervise = tokio::spawn(async move {
+            let _ = sup.supervise(&mut shutdown_rx).await;
+            sup
+        });
+
+        // Capacity 1: the first command parks in the mailbox forever, the
+        // second must fail fast.
+        admin
+            .try_route(WorkerIndex::new(0), ())
+            .expect("first command fits the mailbox");
+        assert!(matches!(
+            admin.try_route(WorkerIndex::new(0), ()),
+            Err(RouteError::MailboxFull(_))
+        ));
+        assert!(matches!(
+            admin.try_route(WorkerIndex::new(9), ()),
+            Err(RouteError::UnknownWorker(_))
+        ));
+
+        let _ = shutdown_tx.send(true);
+        let sup = supervise.await.expect("supervise task");
+        // Must return at the deadline despite the wedged worker; the test
+        // process exiting afterward proves runtime drop doesn't wait on
+        // the detached watcher.
+        let start = Instant::now();
+        sup.shutdown(Duration::from_millis(300)).await;
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "shutdown did not respect its deadline"
+        );
+    }
+}

--- a/crates/service-core/src/worker.rs
+++ b/crates/service-core/src/worker.rs
@@ -1,0 +1,134 @@
+// Copyright (C) 2022-present The NetGauze Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::affinity::CoreId;
+use opentelemetry::metrics::Meter;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+/// Worker index slot identity: used to, e.g., route, respawn, labels
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct WorkerIndex(usize);
+
+impl WorkerIndex {
+    pub const fn new(index: usize) -> Self {
+        Self(index)
+    }
+    pub const fn get(&self) -> usize {
+        self.0
+    }
+}
+
+impl std::fmt::Display for WorkerIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub trait Worker: Sized + 'static {
+    /// Admin commands. Must be `Send`: crosses from the control-plane
+    /// runtime into this core's thread.
+    type Command: Send + 'static;
+
+    /// User provided configuration that moved into the thread, one clone per
+    /// core.
+    type Config: Clone + Send + 'static;
+
+    /// Per-slot metrics state: created once by [`Worker::build_stats`],
+    /// shared with the OTel observable callbacks, and REUSED by every
+    /// respawn of the slot; even in case of panics. It
+    /// therefore crosses the supervisor's `catch_unwind` boundary and
+    /// MUST be panic-tolerant: lock-free atomics / `ArcSwap` mirrors,
+    /// never a poisoning `std::sync::Mutex` (a panic while holding one
+    /// would make every subsequent incarnation fail on lock()).
+    type Stats: Send + Sync + 'static;
+
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// For thread names, log fields and metric attributes.
+    const NAME: &'static str;
+
+    /// Called ONCE per worker slot, on the control-plane runtime thread,
+    /// at supervisor start; never again on respawn.
+    /// Creates the atomics for metrics AND registers every observable callback
+    /// over them.
+    fn build_stats(
+        worker_index: WorkerIndex,
+        config: &Self::Config,
+        meter: &Meter,
+    ) -> Arc<Self::Stats>;
+
+    /// Called on the pinned thread *after* affinity is set, so first-touch
+    /// NUMA allocation (if configured) lands on this core's node.
+    /// `stats` is the per-slot instance from `build_stats`: the same one
+    /// across every respawn of this slot, so WORKER-SCOPED monotonic
+    /// counters (fields directly on the stats struct) continue rather
+    /// than resetting.
+    ///
+    /// Continuity does NOT extend to RCU mirrors of
+    /// per-entity handles (peers, pipelines) an implementation may hold
+    /// inside its stats: a respawned worker typically resets and
+    /// repopulates those with fresh atomics, and backends see an
+    /// ordinary counter restart for the affected series: that is
+    /// implementation-defined, not forbidden by this contract.
+    fn build(
+        ctx: &WorkerContext,
+        config: Self::Config,
+        stats: Arc<Self::Stats>,
+    ) -> Result<Self, Self::Error>;
+
+    /// Runs until the command channel closes or a fatal error occurs.
+    /// Deliberately `impl Future` without a `Send` bound — this future is
+    /// driven by a `current_thread` runtime and never migrates.
+    fn run(
+        self,
+        cmd_rx: mpsc::Receiver<Self::Command>,
+    ) -> impl Future<Output = Result<(), Self::Error>>;
+}
+
+pub struct WorkerContext {
+    worker_index: WorkerIndex,
+    core_id: Option<CoreId>,
+    meter: Meter,
+}
+
+impl WorkerContext {
+    pub const fn new(worker_index: WorkerIndex, core_id: Option<CoreId>, meter: Meter) -> Self {
+        Self {
+            worker_index,
+            core_id,
+            meter,
+        }
+    }
+
+    /// This worker's position in `CoreAssignment`'s list (0..worker_count).
+    /// Distinct from `core_id` because `CoreAssignment::explicit` may list
+    /// non-contiguous physical cores: `worker_index` is what admin surfaces
+    /// like `CollectionSupervisor::route(worker_index, ..)` address by;
+    /// `core_id` is what respawn-on-the-same-core and metric labels use
+    pub const fn worker_index(&self) -> WorkerIndex {
+        self.worker_index
+    }
+
+    /// The physical core this thread is pinned to if it's pinned according to
+    /// the `AffinityConfig`.
+    pub const fn core_id(&self) -> Option<CoreId> {
+        self.core_id
+    }
+
+    pub const fn meter(&self) -> &Meter {
+        &self.meter
+    }
+}


### PR DESCRIPTION
Introduce netgauze-service-core, the thread-per-core scaffolding shared by the upcoming protocol services (flow, BMP, UDP-Notif):
 - Worker trait: build_stats() once per slot (OTel callbacks registered exactly once; the SDK never unregisters), build()/run() per incarnation on a pinned OS thread with its own current-thread runtime.
 - CollectionSupervisor: detached worker threads with in-thread panic capture (catch_unwind, no watcher threads), budgeted respawn (validated RestartPolicy: rolling window + backoff, selected against shutdown), typed start errors, and a min_live_workers valve so supervise() tells the embedder to fail the whole site (anycast failover) instead of limping at partial capacity.
 - AdminHandle: cloneable admin plane valid while supervise() runs; route/try_route and a concurrent fan_out (per-worker timeout, replies collected per worker; results are confirmations, not proof of execution), failed/done slot mirrors, and per-slot last-exit records (kind/message/timestamp) for readiness triage.
 - CPU affinity strategies (PinOutcome distinguishes unpinned from failed pins) with environment auto-detection, NUMA-aware physical-core assignment via hwloc, and shared drain-loop batch knobs.