### PR TITLE
netconf-proto: upgrade to quick-xml 0.42 and fix four XML parsing defects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,9 +4099,9 @@ checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ smallvec = { version = "1.15" }
 rustc-hash = { version = "2.1" }
 yang5 = { version = "0.3", features = ["bundled"] }
 tempfile = { version = "3.27" }
-quick-xml = { version = "0.41" }
+quick-xml = { version = "0.42" }
 russh = { version = "0.62" }
 secrecy = { version = "0.10" }
 notify = { version = "8.2" }

--- a/crates/netconf-proto/src/lib.rs
+++ b/crates/netconf-proto/src/lib.rs
@@ -35,17 +35,16 @@ pub mod yanglib;
 pub mod yangparser;
 
 pub(crate) const NETCONF_NS_STR: &str = "urn:ietf:params:xml:ns:netconf:base:1.0";
-pub(crate) const NETCONF_NS: Namespace<'static> = Namespace(NETCONF_NS_STR.as_bytes());
+pub(crate) const NETCONF_NS: Namespace<'static> = Namespace(NETCONF_NS_STR);
 pub(crate) const NETCONF_MONITORING_NS_STR: &str =
     "urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring";
-pub(crate) const NETCONF_MONITORING_NS: Namespace<'static> =
-    Namespace(NETCONF_MONITORING_NS_STR.as_bytes());
+pub(crate) const NETCONF_MONITORING_NS: Namespace<'static> = Namespace(NETCONF_MONITORING_NS_STR);
 pub(crate) const YANG_LIBRARY_NS_STR: &str = "urn:ietf:params:xml:ns:yang:ietf-yang-library";
-pub(crate) const YANG_LIBRARY_NS: Namespace<'static> = Namespace(YANG_LIBRARY_NS_STR.as_bytes());
+pub(crate) const YANG_LIBRARY_NS: Namespace<'static> = Namespace(YANG_LIBRARY_NS_STR);
 pub(crate) const YANG_LIBRARY_AUGMENTED_BY_NS_STR: &str =
     "urn:ietf:params:xml:ns:yang:ietf-yang-library-augmentedby";
 pub(crate) const YANG_LIBRARY_AUGMENTED_BY_NS: Namespace<'static> =
-    Namespace(YANG_LIBRARY_AUGMENTED_BY_NS_STR.as_bytes());
+    Namespace(YANG_LIBRARY_AUGMENTED_BY_NS_STR);
 pub(crate) const YANG_DATASTORES_NS_STR: &str = "urn:ietf:params:xml:ns:yang:ietf-datastores";
 
 #[cfg(test)]

--- a/crates/netconf-proto/src/protocol.rs
+++ b/crates/netconf-proto/src/protocol.rs
@@ -60,12 +60,12 @@ impl<'a> XmlDeserialize<'a, NetConfMessage> for NetConfMessage {
         parser.skip_text()?;
         match parser.peek() {
             Event::Start(a) => match a.local_name().into_inner() {
-                b"hello" => Ok(NetConfMessage::Hello(Hello::xml_deserialize(parser)?)),
-                b"rpc" => Ok(NetConfMessage::Rpc(Rpc::xml_deserialize(parser)?)),
-                b"rpc-reply" => Ok(NetConfMessage::RpcReply(RpcReply::xml_deserialize(parser)?)),
+                "hello" => Ok(NetConfMessage::Hello(Hello::xml_deserialize(parser)?)),
+                "rpc" => Ok(NetConfMessage::Rpc(Rpc::xml_deserialize(parser)?)),
+                "rpc-reply" => Ok(NetConfMessage::RpcReply(RpcReply::xml_deserialize(parser)?)),
                 _ => Err(ParsingError::InvalidValue(format!(
                     "invalid start value: {}",
-                    std::str::from_utf8(a.local_name().into_inner())?
+                    a.local_name().into_inner()
                 ))),
             },
             token => Err(ParsingError::WrongToken {
@@ -232,7 +232,7 @@ pub enum RpcOperation {
     WellKnown(WellKnownOperation),
 }
 
-fn extract_attribute(bytes_start: &BytesStart<'_>, attribute_name: &[u8]) -> Option<Box<str>> {
+fn extract_attribute(bytes_start: &BytesStart<'_>, attribute_name: &str) -> Option<Box<str>> {
     bytes_start
         .attributes()
         .map(|attr| match attr {
@@ -264,7 +264,7 @@ fn extract_attribute(bytes_start: &BytesStart<'_>, attribute_name: &[u8]) -> Opt
 /// </xs:simpleType>
 /// ```
 fn extract_message_id(open: &BytesStart<'_>) -> Result<Option<Box<str>>, ParsingError> {
-    let msg_id_attr = extract_attribute(open, b"message-id");
+    let msg_id_attr = extract_attribute(open, "message-id");
     if let Some(msg_id) = &msg_id_attr
         && msg_id.len() > 4095
     {
@@ -289,7 +289,7 @@ impl<'a> XmlDeserialize<'a, Rpc> for Rpc {
         let operation = match WellKnownOperation::xml_deserialize(parser) {
             Ok(operation) => RpcOperation::WellKnown(operation),
             Err(ParsingError::Recoverable) => {
-                let operation = parser.copy_buffer_till(b"rpc")?;
+                let operation = parser.copy_buffer_till("rpc")?;
                 RpcOperation::Raw(operation)
             }
             Err(e) => return Err(e),
@@ -692,14 +692,14 @@ impl<'a> XmlDeserialize<'a, Filter> for Filter {
     fn xml_deserialize(parser: &mut XmlParser<'a, impl io::BufRead>) -> Result<Self, ParsingError> {
         parser.skip_text()?;
         let filter_start = parser.open(Some(NETCONF_NS), "filter")?;
-        let filter_type = extract_attribute(&filter_start, b"type").unwrap_or("subtree".into());
+        let filter_type = extract_attribute(&filter_start, "type").unwrap_or("subtree".into());
         let filter = match filter_type.as_ref() {
             "subtree" => {
-                let value = parser.copy_buffer_till(b"filter")?;
+                let value = parser.copy_buffer_till("filter")?;
                 Filter::Subtree(value)
             }
             "xpath" => {
-                let select = extract_attribute(&filter_start, b"select")
+                let select = extract_attribute(&filter_start, "select")
                     .ok_or(ParsingError::MissingAttribute("select".into()))?;
                 Filter::XPath(select)
             }
@@ -759,7 +759,7 @@ impl<'a> XmlDeserialize<'a, EditConfig> for EditConfig {
             parser.close()?;
             EditConfig::Url(url)
         } else if parser.maybe_open(Some(NETCONF_NS), "config")?.is_some() {
-            let value = parser.copy_buffer_till(b"config")?;
+            let value = parser.copy_buffer_till("config")?;
             parser.close()?;
             EditConfig::Config(value)
         } else {
@@ -1181,11 +1181,11 @@ impl<'a> XmlDeserialize<'a, RpcReply> for RpcReply {
             });
         }
         let errors: Vec<RpcError> =
-            parser.collect_xml_sequence_with_tag(Some(NETCONF_NS), b"rpc-error")?;
+            parser.collect_xml_sequence_with_tag(Some(NETCONF_NS), "rpc-error")?;
         let responses = match WellKnownRpcResponse::xml_deserialize(parser) {
             Ok(response) => RpcResponse::WellKnown(response),
             Err(ParsingError::Recoverable) => {
-                let responses = parser.copy_buffer_till(b"rpc-reply")?;
+                let responses = parser.copy_buffer_till("rpc-reply")?;
                 RpcResponse::Raw(responses)
             }
             Err(e) => return Err(e),
@@ -1346,7 +1346,7 @@ impl<'a> XmlDeserialize<'a, WellKnownRpcResponse> for WellKnownRpcResponse {
                 let yang_lib = YangLibrary::xml_deserialize(parser)?;
                 return Ok(Self::YangLibrary(Arc::new(yang_lib)));
             }
-            let data = parser.copy_buffer_till(b"data")?;
+            let data = parser.copy_buffer_till("data")?;
             // close data
             parser.close()?;
             return Ok(Self::Data(data));
@@ -1884,7 +1884,7 @@ impl<'a> XmlDeserialize<'a, ErrorInfo> for ErrorInfo {
         loop {
             if let Event::End(end) = parser.peek() {
                 let (ns, local) = parser.ns_reader().resolver().resolve(end.name(), true);
-                if ns == ResolveResult::Bound(NETCONF_NS) && local.into_inner() == b"error-info" {
+                if ns == ResolveResult::Bound(NETCONF_NS) && local.into_inner() == "error-info" {
                     break;
                 } else {
                     parser.skip()?;

--- a/crates/netconf-proto/src/xml_utils.rs
+++ b/crates/netconf-proto/src/xml_utils.rs
@@ -550,10 +550,15 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
         }
     }
 
-    /// Copy buffer content until a specific end tag is reached.
+    /// Copy the raw XML content of the element most recently [`Self::open`]ed,
+    /// up to (but not including) its closing tag.
     ///
-    /// This method reads and copies all XML events to a string buffer until it
-    /// encounters an end tag matching the provided `tag` parameter.
+    /// Termination is by NESTING DEPTH, not by tag name: the copy ends at the
+    /// first end tag seen at depth zero, which XML well-formedness guarantees
+    /// is the opened element's own. A payload that nests an element sharing
+    /// the container's name (`<config>` inside a `<config>` subtree) is
+    /// therefore copied whole. A self-closing container (`<data/>`) yields an
+    /// empty string.
     ///
     /// # Namespace Handling
     ///
@@ -572,6 +577,9 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
     /// - The namespace resolution only occurs once (on the first start tag) to
     ///   minimize overhead
     pub fn copy_buffer_till(&mut self, tag: &'_ str) -> Result<Box<str>, ParsingError> {
+        if !self.parent_has_child() {
+            return Ok("".into());
+        }
         let cursor = io::Cursor::new(vec![]);
         let mut writer = quick_xml::writer::Writer::new(cursor);
         let mut wrote_ns = false;
@@ -631,8 +639,9 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
         Ok(ret.into())
     }
 
-    /// Copy every event between the current position and the end tag whose
-    /// local name matches `tag`, recording which namespace prefixes are
+    /// Copy every event between the current position and the closing tag of
+    /// the element most recently [`Self::open`]ed (found by nesting depth; see
+    /// [`Self::copy_buffer_till`]), recording which namespace prefixes are
     /// actually referenced inside.
     ///
     /// Unlike naive text extraction, this resolves each element and attribute
@@ -647,9 +656,15 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
         &mut self,
         tag: &'_ str,
     ) -> Result<CopiedSubtree, ParsingError> {
+        if !self.parent_has_child() {
+            return Ok(CopiedSubtree {
+                xml: "".into(),
+                namespaces: IndexMap::new(),
+            });
+        }
         let mut writer = quick_xml::writer::Writer::new(io::Cursor::new(Vec::new()));
         let mut namespaces: IndexMap<String, String> = IndexMap::new();
-        // See `copy_buffer_till` for why this depth counter is required.
+        // Depth-based termination; see `copy_buffer_till`.
         let mut depth: usize = 0;
         loop {
             match self.peek() {
@@ -1847,5 +1862,142 @@ mod tests {
             r#"<a xmlns="urn:x"><filter>deep</filter></a>"#
         );
         parser.close().expect("close consumes the outer </filter>");
+    }
+
+    #[test]
+    fn test_copy_buffer_till_empty_container_leaves_siblings_readable() {
+        for envelope in [
+            r#"<rpc-reply><data/><ok/></rpc-reply>"#,
+            r#"<rpc-reply><data></data><ok/></rpc-reply>"#,
+        ] {
+            let mut parser = create_parser(envelope);
+            parser.open(None, "rpc-reply").expect("open rpc-reply");
+            parser.open(None, "data").expect("open data");
+
+            let copied = parser.copy_buffer_till("data").expect("copy empty data");
+            assert!(
+                copied.is_empty(),
+                "{envelope}: expected no content, got `{copied}`"
+            );
+
+            parser.close().expect("close data");
+            // The sibling after the empty container must still be there.
+            assert!(
+                parser.is_tag(None, "ok"),
+                "{envelope}: sibling after the empty container was consumed"
+            );
+            parser.open(None, "ok").expect("open ok");
+            parser.close().expect("close ok");
+            parser.close().expect("close rpc-reply");
+        }
+    }
+
+    #[test]
+    fn test_copy_buffer_till_container_vs_same_named_payload() {
+        let xml = r#"<config><config/><peer>1</peer></config>"#;
+        let mut parser = create_parser(xml);
+        parser.open(None, "config").expect("open outer config");
+
+        let copied = parser.copy_buffer_till("config").expect("copy payload");
+        assert!(
+            copied.contains("<peer>1</peer>"),
+            "payload after the same-named self-closing element was lost: `{copied}`"
+        );
+        assert!(
+            !copied.is_empty(),
+            "self-closing payload element was mistaken for an empty container"
+        );
+        parser
+            .close()
+            .expect("outer </config> still pending after the copy");
+    }
+
+    #[test]
+    fn test_copy_buffer_till_spans_repeated_container_name() {
+        let xml = r#"<filter><a><filter><filter>deep</filter></filter></a></filter>"#;
+        let mut parser = create_parser(xml);
+        parser.open(None, "filter").expect("open outer filter");
+
+        let copied = parser
+            .copy_buffer_till("filter")
+            .expect("copy nested payload");
+        assert_eq!(
+            copied.as_ref(),
+            r#"<a><filter><filter>deep</filter></filter></a>"#
+        );
+        parser
+            .close()
+            .expect("outer </filter> still pending after the copy");
+    }
+
+    #[test]
+    fn test_copy_buffer_till_with_namespaces_empty_container_records_nothing() {
+        let xml = r#"<top xmlns:unused="urn:never:referenced"><subtree/><next>x</next></top>"#;
+        let mut parser = create_parser(xml);
+        parser.open(None, "top").expect("open top");
+        parser.open(None, "subtree").expect("open subtree");
+
+        let copied = parser
+            .copy_buffer_till_with_namespaces("subtree")
+            .expect("copy empty subtree");
+        assert!(
+            copied.xml.is_empty(),
+            "expected no XML, got `{}`",
+            copied.xml
+        );
+        assert!(
+            copied.namespaces.is_empty(),
+            "an in-scope but unreferenced binding was recorded: {:?}",
+            copied.namespaces
+        );
+
+        parser.close().expect("close subtree");
+        assert!(parser.is_tag(None, "next"), "sibling was consumed");
+    }
+
+    #[test]
+    fn test_copy_buffer_till_with_namespaces_spans_repeated_name() {
+        let xml = r#"<subtree xmlns:if="urn:example:if" xmlns:unused="urn:never">"#.to_string()
+            + r#"<if:port><subtree>inner</subtree></if:port></subtree>"#;
+        let mut parser = create_parser(&xml);
+        parser.open(None, "subtree").expect("open outer subtree");
+
+        let copied = parser
+            .copy_buffer_till_with_namespaces("subtree")
+            .expect("copy nested payload");
+        assert_eq!(
+            copied.xml.as_ref(),
+            r#"<if:port><subtree>inner</subtree></if:port>"#
+        );
+        assert_eq!(
+            copied.namespaces.get("if").map(String::as_str),
+            Some("urn:example:if"),
+            "the prefix used inside must be recorded: {:?}",
+            copied.namespaces
+        );
+        assert!(
+            !copied.namespaces.contains_key("unused"),
+            "an unreferenced binding was recorded: {:?}",
+            copied.namespaces
+        );
+        parser
+            .close()
+            .expect("outer </subtree> still pending after the copy");
+    }
+
+    /// The empty-container guard MUST key on the PARENT, not on the current
+    /// event: after open() the current event may be a self-closing element
+    /// with the SAME local name as the container, but it is CONTENT.
+    /// Guarding on `current` would silently drop it.
+    #[test]
+    fn test_copy_buffer_till_keeps_self_closing_child_of_same_name() {
+        let xml = r#"<config><config/></config>"#;
+        let mut parser = create_parser(xml);
+        parser.open(None, "config").expect("open outer config");
+        let copied = parser
+            .copy_buffer_till("config")
+            .expect("copy till outer </config>");
+        assert_eq!(copied.as_ref(), "<config/>");
+        parser.close().expect("close consumes the outer </config>");
     }
 }

--- a/crates/netconf-proto/src/xml_utils.rs
+++ b/crates/netconf-proto/src/xml_utils.rs
@@ -49,11 +49,11 @@ impl From<XmlWriterError> for quick_xml::Error {
     fn from(value: XmlWriterError) -> Self {
         match value {
             XmlWriterError::UndefinedNamespace(ns) => {
-                quick_xml::Error::Namespace(NamespaceError::UnknownPrefix(ns.as_bytes().to_vec()))
+                quick_xml::Error::Namespace(NamespaceError::UnknownPrefix(ns))
             }
-            XmlWriterError::DuplicateNamespacePrefix(prefix) => quick_xml::Error::Namespace(
-                NamespaceError::InvalidPrefixForXmlns(prefix.as_bytes().to_vec()),
-            ),
+            XmlWriterError::DuplicateNamespacePrefix(prefix) => {
+                quick_xml::Error::Namespace(NamespaceError::InvalidPrefixForXmlns(prefix))
+            }
         }
     }
 }
@@ -62,7 +62,7 @@ impl From<XmlWriterError> for quick_xml::Error {
 pub struct XmlWriter<T: io::Write> {
     inner: quick_xml::writer::Writer<T>,
     // Stack of multiple namespace bindings since XML allows to overwrite the bindings
-    namespace_bindings: Vec<IndexMap<Cow<'static, [u8]>, String>>,
+    namespace_bindings: Vec<IndexMap<Cow<'static, str>, String>>,
     // Namespaces has been appended to the xml element
     ns_applied: bool,
 }
@@ -89,7 +89,7 @@ impl<T: io::Write> XmlWriter<T> {
         let ns_applied = false;
         let mut cow_ns = IndexMap::with_capacity(namespace_binding.len());
         for (ns, prefix) in namespace_binding {
-            cow_ns.insert(Cow::Owned(ns.as_ref().to_vec()), prefix);
+            cow_ns.insert(ns.into_inner().to_owned().into(), prefix);
         }
         let namespace_bindings = vec![cow_ns];
         Ok(Self {
@@ -129,7 +129,7 @@ impl<T: io::Write> XmlWriter<T> {
             prefix
         } else {
             return Err(XmlWriterError::UndefinedNamespace(
-                String::from_utf8(ns.into_inner().to_vec()).unwrap_or("UNKNOWN".to_string()),
+                ns.into_inner().to_string(),
             ));
         };
         let mut start = if prefix.is_empty() {
@@ -149,13 +149,13 @@ impl<T: io::Write> XmlWriter<T> {
         self.ns_applied = false;
         let mut cow_ns = IndexMap::with_capacity(namespace_binding.len());
         for (ns, prefix) in namespace_binding {
-            cow_ns.insert(Cow::Owned(ns.as_ref().to_vec()), prefix);
+            cow_ns.insert(ns.into_inner().to_owned().into(), prefix);
         }
         self.namespace_bindings.push(cow_ns);
         Ok(())
     }
 
-    pub fn pop_namespace_binding(&mut self) -> Option<IndexMap<Cow<'static, [u8]>, String>> {
+    pub fn pop_namespace_binding(&mut self) -> Option<IndexMap<Cow<'static, str>, String>> {
         self.namespace_bindings.pop()
     }
 
@@ -176,10 +176,10 @@ impl<T: io::Write> XmlWriter<T> {
             if let Some(bindings) = self.namespace_bindings.last() {
                 for (namespace, prefix) in bindings {
                     if prefix.is_empty() {
-                        start.push_attribute(("xmlns".as_bytes(), namespace.as_ref()));
+                        start.push_attribute(("xmlns", namespace.as_ref()));
                     } else {
                         start.push_attribute((
-                            format!("xmlns:{prefix}").as_bytes(),
+                            format!("xmlns:{prefix}").as_str(),
                             namespace.as_ref(),
                         ));
                     }
@@ -378,7 +378,7 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
             }
             Event::End(e) => Err(ParsingError::SkipError(format!(
                 "Cannot skip a closing tag, call close() to close </{}>",
-                std::str::from_utf8(e.name().local_name().into_inner())?
+                e.name().local_name().into_inner()
             ))),
             Event::Eof => Err(ParsingError::Eof),
             _ => self.next_event(),
@@ -401,7 +401,7 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
         };
 
         let (resolved, local) = self.ns_reader.resolver().resolve_element(qname);
-        if local.into_inner() != key.as_bytes() {
+        if local.into_inner() != key {
             return false;
         }
         let expected = match ns {
@@ -468,24 +468,21 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
         loop {
             match self.peek() {
                 Event::CData(unescaped) => {
-                    let decoded = unescaped.decode()?;
-                    accumulator.push_str(decoded.as_ref());
+                    accumulator.push_str(unescaped.as_ref());
                     self.next_event()?
                 }
                 Event::Text(escaped) => {
-                    let decoded = escaped.decode()?;
-                    accumulator.push_str(decoded.as_ref());
+                    accumulator.push_str(escaped.as_ref());
                     self.next_event()?
                 }
                 Event::GeneralRef(general_ref) => {
-                    let decoded = general_ref.decode()?;
-                    let replaced = match decoded.as_ref() {
+                    let replaced = match general_ref.as_ref() {
                         "quot" => "\"",
                         "apos" => "'",
                         "amp" => "&",
                         "lt" => "<",
                         "gt" => ">",
-                        _ => decoded.as_ref(),
+                        _ => general_ref.as_ref(),
                     };
                     accumulator.push_str(replaced);
                     self.next_event()?
@@ -515,17 +512,14 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
     /// Fails with [`ParsingError::InvalidValue`] if the prefix cannot be
     /// resolved.
     pub fn resolve_identity_ref(&self, raw: &str) -> Result<(String, String), ParsingError> {
-        let (resolved_ns, local) = self
-            .ns_reader
-            .resolver()
-            .resolve(QName(raw.trim().as_bytes()), true);
+        let (resolved_ns, local) = self.ns_reader.resolver().resolve(QName(raw.trim()), true);
         let ns_uri = match resolved_ns {
-            ResolveResult::Bound(ns) => std::str::from_utf8(ns.into_inner())?.to_owned(),
+            ResolveResult::Bound(ns) => ns.into_inner().to_string(),
             _ => {
                 return Err(ParsingError::InvalidValue(raw.to_string()));
             }
         };
-        let local_name = std::str::from_utf8(local.into_inner())?.to_owned();
+        let local_name = local.into_inner().to_string();
         Ok((ns_uri, local_name))
     }
 
@@ -574,7 +568,7 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
     /// - Performs UTF-8 conversion which may fail on invalid sequences
     /// - The namespace resolution only occurs once (on the first start tag) to
     ///   minimize overhead
-    pub fn copy_buffer_till(&mut self, tag: &'_ [u8]) -> Result<Box<str>, ParsingError> {
+    pub fn copy_buffer_till(&mut self, tag: &'_ str) -> Result<Box<str>, ParsingError> {
         let cursor = io::Cursor::new(vec![]);
         let mut writer = quick_xml::writer::Writer::new(cursor);
         let mut wrote_ns = false;
@@ -594,17 +588,15 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
                         .flatten()
                         .map(|x| {
                             (
-                                std::str::from_utf8(x.key.local_name().into_inner())
-                                    .unwrap()
-                                    .to_string(),
-                                std::str::from_utf8(&x.value).unwrap().to_string(),
+                                x.key.local_name().into_inner().to_string(),
+                                x.value.to_string(),
                             )
                         })
                         .collect::<HashMap<_, _>>();
                     if !attrs.contains_key("xmlns") {
                         let (ns, _) = self.ns_reader.resolver().resolve(a.name(), true);
                         if let ResolveResult::Bound(ns) = ns {
-                            a.push_attribute((&b"xmlns"[..], ns.0));
+                            a.push_attribute(("xmlns", ns.0));
                         }
                     }
                     wrote_ns = true;
@@ -635,7 +627,7 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
     /// [`CopiedSubtree::namespaces`].
     pub fn copy_buffer_till_with_namespaces(
         &mut self,
-        tag: &'_ [u8],
+        tag: &'_ str,
     ) -> Result<CopiedSubtree, ParsingError> {
         let mut writer = quick_xml::writer::Writer::new(io::Cursor::new(Vec::new()));
         let mut namespaces: IndexMap<String, String> = IndexMap::new();
@@ -702,7 +694,7 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
     >(
         &mut self,
         ns: Option<Namespace<'_>>,
-        tag: &'_ [u8],
+        tag: &'_ str,
     ) -> Result<Vec<N>, ParsingError> {
         let mut acc = Vec::new();
         let resolved_ns = if let Some(ns) = ns {
@@ -745,9 +737,9 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
         for (decl, Namespace(ns)) in self.ns_reader().resolver().bindings() {
             let prefix = match decl {
                 PrefixDeclaration::Default => String::from(""),
-                PrefixDeclaration::Named(p) => String::from_utf8_lossy(p).into_owned(),
+                PrefixDeclaration::Named(p) => p.to_string(),
             };
-            all_namespaces.insert(prefix, String::from_utf8_lossy(ns).into_owned());
+            all_namespaces.insert(prefix, ns.to_string());
         }
         let path = self.tag_string()?;
         let used_namespaces = Self::find_xpath_prefixes(&path);
@@ -767,32 +759,32 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
 
         // Element QName: prefix (or empty for default namespace).
         let prefix = match e.name().prefix() {
-            Some(p) => String::from_utf8_lossy(p.as_ref()).into_owned(),
+            Some(p) => p.into_inner().to_string(),
             None => String::new(),
         };
         if !out.contains_key(&prefix)
             && let (ResolveResult::Bound(Namespace(uri)), _) =
                 ns_reader.resolver().resolve_element(e.name())
         {
-            out.insert(prefix, String::from_utf8_lossy(uri).into_owned());
+            out.insert(prefix, uri.to_string());
         }
 
         // Attributes: only prefixed ones carry a namespace; xmlns* are bindings,
         // not usages, so skip them.
         for attr in e.attributes().flatten() {
             let key = attr.key.as_ref();
-            if key == b"xmlns" || key.starts_with(b"xmlns:") {
+            if key == "xmlns" || key.starts_with("xmlns:") {
                 continue;
             }
             if let Some(p) = attr.key.prefix() {
-                let prefix = String::from_utf8_lossy(p.as_ref()).into_owned();
+                let prefix = p.into_inner().to_string();
                 if out.contains_key(&prefix) {
                     continue;
                 }
                 if let (ResolveResult::Bound(Namespace(uri)), _) =
                     ns_reader.resolver().resolve_attribute(attr.key)
                 {
-                    out.insert(prefix, String::from_utf8_lossy(uri).into_owned());
+                    out.insert(prefix, uri.to_string());
                 }
             }
         }
@@ -951,7 +943,7 @@ mod tests {
 
         // open root element, and arrive at child1
         parser
-            .open(Some(Namespace(b"urn:ietf:example")), "root")
+            .open(Some(Namespace("urn:ietf:example")), "root")
             .expect("failed to open root");
         assert_eq!(parser.peek(), &Event::Start(BytesStart::new("child1")));
 
@@ -990,7 +982,7 @@ mod tests {
 
         // open root element, and arrive at text
         parser
-            .open(Some(Namespace(b"urn:ietf:example")), "root")
+            .open(Some(Namespace("urn:ietf:example")), "root")
             .expect("failed to open root");
         assert_eq!(
             parser.peek(),
@@ -1011,13 +1003,13 @@ mod tests {
         assert!(is_match);
 
         parser.open(None, "root").expect("failed to open root");
-        let is_match = parser.is_tag(Some(Namespace(b"https://example.com")), "child");
+        let is_match = parser.is_tag(Some(Namespace("https://example.com")), "child");
         assert!(is_match);
 
-        let is_not_match = parser.is_tag(Some(Namespace(b"https://wrong.com")), "child");
+        let is_not_match = parser.is_tag(Some(Namespace("https://wrong.com")), "child");
         assert!(!is_not_match);
 
-        let is_not_match = parser.is_tag(Some(Namespace(b"https://example.com")), "wrong");
+        let is_not_match = parser.is_tag(Some(Namespace("https://example.com")), "wrong");
         assert!(!is_not_match);
     }
 
@@ -1040,14 +1032,14 @@ mod tests {
         assert_eq!(parser.previous(), &Event::Eof);
 
         // Open root
-        let result_root = parser.open(Some(Namespace(b"https://example.com")), "root");
+        let result_root = parser.open(Some(Namespace("https://example.com")), "root");
         let expected_root = BytesStart::from_content("root xmlns=\"https://example.com\"", 4);
         assert_eq!(result_root, Ok(expected_root.clone()));
         assert_eq!(parser.parents, vec![Event::Start(expected_root.clone())]);
         assert_eq!(parser.previous(), &Event::Start(expected_root.clone()));
 
         // Open child
-        let result_child = parser.open(Some(Namespace(b"https://example.com")), "child");
+        let result_child = parser.open(Some(Namespace("https://example.com")), "child");
         let expected_child = BytesStart::new("child");
         assert_eq!(result_child, Ok(expected_child.clone()));
         assert_eq!(
@@ -1075,7 +1067,7 @@ mod tests {
         let xml = r#"<root xmlns="https://example.com"><child/></root>"#;
         let mut parser = create_parser(xml);
 
-        let result = parser.open(Some(Namespace(b"https://example.com")), "wrong");
+        let result = parser.open(Some(Namespace("https://example.com")), "wrong");
         assert_eq!(
             result,
             Err(ParsingError::WrongToken {
@@ -1103,7 +1095,7 @@ mod tests {
             BytesStart::from_content("root xmlns=\"https://example.com\"", 4).into_owned(),
         ));
 
-        let result = parser.maybe_open(Some(Namespace(b"https://example.com")), "root");
+        let result = parser.maybe_open(Some(Namespace("https://example.com")), "root");
         assert_eq!(result, expected);
         // check pointer did move after the `maybe_open` succeeded
         assert_eq!(
@@ -1117,7 +1109,7 @@ mod tests {
         let xml = r#"<root xmlns="https://example.com"><child/></root>"#;
         let mut parser = create_parser(xml);
         let expected = Ok(None);
-        let result = parser.maybe_open(Some(Namespace(b"https://example.com")), "wrong");
+        let result = parser.maybe_open(Some(Namespace("https://example.com")), "wrong");
         assert_eq!(result, expected);
 
         // check pointer didn't move after the `maybe_open` didn't return anything
@@ -1231,12 +1223,8 @@ mod tests {
     fn test_writer_creation() {
         let mut buffer = Vec::new();
         let writer = quick_xml::writer::Writer::new(&mut buffer);
-        let ns_to_apply =
-            IndexMap::from([(Namespace(b"https://example.com"), "xmlns".to_string())]);
-        let cow_bindings = IndexMap::from([(
-            Cow::Owned(b"https://example.com".to_vec()),
-            "xmlns".to_string(),
-        )]);
+        let ns_to_apply = IndexMap::from([(Namespace("https://example.com"), "xmlns".to_string())]);
+        let cow_bindings = IndexMap::from([("https://example.com".into(), "xmlns".to_string())]);
         let xml_writer = XmlWriter::new_with_custom_namespaces(writer, ns_to_apply.clone())
             .expect("failed creating writer");
         assert_eq!(xml_writer.namespace_bindings, vec![cow_bindings]);
@@ -1251,7 +1239,7 @@ mod tests {
             .expect("failed creating writer");
 
         let element = xml_writer.create_element("root");
-        assert_eq!(element.name().as_ref(), b"root");
+        assert_eq!(element.name().into_inner(), "root");
         assert!(xml_writer.ns_applied);
     }
 
@@ -1261,27 +1249,27 @@ mod tests {
         let mut buffer = Vec::new();
         let writer = quick_xml::writer::Writer::new(&mut buffer);
         let ns_to_apply = IndexMap::from([
-            (Namespace(b"https://example.com"), "".to_string()),
-            (Namespace(b"https://custom.com"), "ns".to_string()),
+            (Namespace("https://example.com"), "".to_string()),
+            (Namespace("https://custom.com"), "ns".to_string()),
         ]);
         let mut xml_writer = XmlWriter::new_with_custom_namespaces(writer, ns_to_apply)
             .expect("failed creating writer");
 
         let element = xml_writer.create_element("root");
-        assert_eq!(element.name().as_ref(), b"root");
+        assert_eq!(element.name().as_ref(), "root");
         // Namespaces should be cleared after creating element
         assert!(xml_writer.ns_applied);
 
         // Check attributes were added
-        let mut attrs: Vec<(Box<[u8]>, Box<[u8]>)> = element
+        let mut attrs: Vec<(String, String)> = element
             .attributes()
             .map(|x| x.expect("failed to decode attribute"))
-            .map(|x| (x.key.as_ref().into(), x.value.as_ref().into()))
+            .map(|x| (x.key.into_inner().to_string(), x.value.as_ref().to_owned()))
             .collect();
         attrs.sort_by(|x, y| x.0.cmp(&y.0));
-        let expected: Vec<(Box<[u8]>, Box<[u8]>)> = vec![
-            ((*b"xmlns").into(), (*b"https://example.com").into()),
-            ((*b"xmlns:ns").into(), (*b"https://custom.com").into()),
+        let expected: Vec<(String, String)> = vec![
+            ("xmlns".to_string(), "https://example.com".to_string()),
+            ("xmlns:ns".to_string(), "https://custom.com".to_string()),
         ];
         assert_eq!(attrs, expected);
     }
@@ -1294,7 +1282,7 @@ mod tests {
         let mut xml_writer = XmlWriter::new_with_custom_namespaces(writer, ns_to_apply)
             .expect("failed creating writer");
 
-        let element = xml_writer.create_ns_element(Namespace(b"ns"), "child");
+        let element = xml_writer.create_ns_element(Namespace("ns"), "child");
         assert!(element.is_err());
         assert!(!xml_writer.ns_applied);
     }
@@ -1303,7 +1291,7 @@ mod tests {
     fn test_create_ns_element_with_namespace() {
         let mut buffer = Vec::new();
         let writer = quick_xml::writer::Writer::new(&mut buffer);
-        let ns = Namespace(b"https://custom.com");
+        let ns = Namespace("https://custom.com");
         let ns_to_apply = IndexMap::from([(ns, "ns".to_string())]);
         let mut xml_writer = XmlWriter::new_with_custom_namespaces(writer, ns_to_apply)
             .expect("failed creating writer");
@@ -1311,15 +1299,15 @@ mod tests {
         let element = xml_writer
             .create_ns_element(ns, "child")
             .expect("failed to create an xml element with namespace prefix");
-        assert_eq!(element.name().as_ref(), b"ns:child");
+        assert_eq!(element.name().as_ref(), "ns:child");
         // Namespaces should be cleared after creating element
         assert!(xml_writer.ns_applied);
 
         // Check attributes were added
         let mut attrs = element.attributes();
         let attr = attrs.next().unwrap().unwrap();
-        assert_eq!(attr.key.as_ref(), b"xmlns:ns");
-        assert_eq!(attr.value.as_ref(), b"https://custom.com");
+        assert_eq!(attr.key.as_ref(), "xmlns:ns");
+        assert_eq!(attr.value.as_ref(), "https://custom.com");
     }
 
     #[test]
@@ -1364,7 +1352,7 @@ mod tests {
         root.push_attribute(("xmlns", "https://example.com"));
         xml_writer.write_event(Event::Start(root)).unwrap();
 
-        let ns = Namespace(b"https://example2.com");
+        let ns = Namespace("https://example2.com");
         xml_writer
             .push_namespace_binding(IndexMap::from([(ns, "ns".to_string())]))
             .expect("failed adding namespace binding");
@@ -1399,8 +1387,8 @@ mod tests {
         let mut buffer = Vec::new();
         let writer = quick_xml::writer::Writer::new(&mut buffer);
         let ns_to_apply = IndexMap::from([
-            (Namespace(b"https://example.com"), "".to_string()),
-            (Namespace(b"https://custom.com"), "ns".to_string()),
+            (Namespace("https://example.com"), "".to_string()),
+            (Namespace("https://custom.com"), "ns".to_string()),
         ]);
         let mut xml_writer = XmlWriter::new_with_custom_namespaces(writer, ns_to_apply)
             .expect("failed creating writer");
@@ -1599,7 +1587,7 @@ mod tests {
         parser
             .open(
                 Some(Namespace(
-                    b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
                 )),
                 "datastore-xpath-filter",
             )
@@ -1629,7 +1617,7 @@ mod tests {
         parser
             .open(
                 Some(Namespace(
-                    b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
                 )),
                 "datastore-xpath-filter",
             )
@@ -1659,7 +1647,7 @@ mod tests {
         parser
             .open(
                 Some(Namespace(
-                    b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
                 )),
                 "filters",
             )
@@ -1668,7 +1656,7 @@ mod tests {
         parser
             .open(
                 Some(Namespace(
-                    b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
                 )),
                 "datastore-xpath-filter",
             )
@@ -1699,7 +1687,7 @@ mod tests {
         parser
             .open(
                 Some(Namespace(
-                    b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
                 )),
                 "datastore-xpath-filter",
             )
@@ -1729,7 +1717,7 @@ mod tests {
         parser
             .open(
                 Some(Namespace(
-                    b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
                 )),
                 "datastore-xpath-filter",
             )
@@ -1747,7 +1735,7 @@ mod tests {
         // identityref values inside string literals. The `t:` token appears
         // only inside quotes, so even though it's declared, it shouldn't end
         // up in the namespace map (find_xpath_prefixes correctly skips it).
-        // Conversely `if:` is live and must be kept.
+        // Conversely, `if:` is live and must be kept.
         let xml = r#"<datastore-xpath-filter
         xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications"
         xmlns:if="urn:example:interfaces"
@@ -1756,7 +1744,7 @@ mod tests {
         parser
             .open(
                 Some(Namespace(
-                    b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
+                    "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications",
                 )),
                 "datastore-xpath-filter",
             )

--- a/crates/netconf-proto/src/xml_utils.rs
+++ b/crates/netconf-proto/src/xml_utils.rs
@@ -18,6 +18,7 @@
 use crate::NETCONF_NS;
 use chrono::{DateTime, Datelike, Timelike, Utc};
 use indexmap::IndexMap;
+use quick_xml::escape::resolve_predefined_entity;
 use quick_xml::events::{BytesStart, BytesText, Event};
 use quick_xml::name::{Namespace, NamespaceError, PrefixDeclaration, QName, ResolveResult};
 use quick_xml::reader::NsReader;
@@ -476,15 +477,16 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
                     self.next_event()?
                 }
                 Event::GeneralRef(general_ref) => {
-                    let replaced = match general_ref.as_ref() {
-                        "quot" => "\"",
-                        "apos" => "'",
-                        "amp" => "&",
-                        "lt" => "<",
-                        "gt" => ">",
-                        _ => general_ref.as_ref(),
-                    };
-                    accumulator.push_str(replaced);
+                    if let Some(ch) = general_ref.resolve_char_ref()? {
+                        // &#10; &#x41; ...
+                        accumulator.push(ch);
+                    } else if let Some(s) = resolve_predefined_entity(general_ref.as_ref()) {
+                        // quot/apos/amp/lt/gt
+                        accumulator.push_str(s);
+                    } else {
+                        // unknown: unchanged
+                        accumulator.push_str(general_ref.as_ref());
+                    }
                     self.next_event()?
                 }
                 Event::End(_) => {
@@ -1760,5 +1762,13 @@ mod tests {
             namespaces,
             IndexMap::from([("if".to_string(), "urn:example:interfaces".to_string())]),
         );
+    }
+
+    #[test]
+    fn test_numeric_char_ref() {
+        let xml = "<root>line1&#10;line2</root>";
+        let mut parser = create_parser(xml);
+        parser.open(None, "root").expect("open root");
+        assert_eq!(parser.tag_string().unwrap().as_ref(), "line1\nline2");
     }
 }

--- a/crates/netconf-proto/src/xml_utils.rs
+++ b/crates/netconf-proto/src/xml_utils.rs
@@ -502,6 +502,7 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
                     }
                     return Ok(accumulator.into());
                 }
+                Event::Eof => return Err(ParsingError::Eof),
                 _ => self.next_event()?,
             };
         }
@@ -1186,6 +1187,27 @@ mod tests {
         );
 
         parser.close().expect("failed to close root");
+    }
+
+    #[test]
+    fn test_tag_string_errors_on_unclosed_element_at_eof() {
+        // A framed-but-malformed inner document: a text leaf never closed
+        // before the stream ends. quick-xml returns Eof FOREVER once the
+        // reader is done (it does not error on unclosed elements), so
+        // without an explicit Eof arm this loop never terminates.
+        // Threaded with a timeout so a regression fails the test instead
+        // of hanging the test runner.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let xml = r#"<identifier>foo"#; // no </identifier>, no more tags
+            let mut parser = create_parser(xml);
+            parser.open(None, "identifier").expect("open identifier");
+            let _ = tx.send(parser.tag_string());
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(result) => assert_eq!(result, Err(ParsingError::Eof)),
+            Err(_) => panic!("tag_string() did not return which is a infinite loop on Eof"),
+        }
     }
 
     #[test]

--- a/crates/netconf-proto/src/xml_utils.rs
+++ b/crates/netconf-proto/src/xml_utils.rs
@@ -574,14 +574,29 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
         let cursor = io::Cursor::new(vec![]);
         let mut writer = quick_xml::writer::Writer::new(cursor);
         let mut wrote_ns = false;
+        // Depth of nested elements sharing the terminator's local name.
+        // Without it the FIRST inner `</tag>` (e.g. a `<config>` nested
+        // inside a `<config>` payload) ends the copy early, truncating
+        // the subtree and desyncing the parser for the rest of the
+        // message. Local-name counting is self-balancing: every
+        // same-named Start increments and its End decrements, regardless
+        // of namespace; quick-xml guarantees well-formedness, so opens
+        // and closes are matched. A self-closing `<tag/>` (Empty) opens
+        // and closes at once and needs no adjustment.
+        let mut depth: usize = 0;
         loop {
-            if let Event::End(b) = self.peek()
-                && b.local_name().into_inner() == tag
-            {
-                break;
-            }
-            if let Event::Eof = self.peek() {
-                return Err(ParsingError::Eof);
+            match self.peek() {
+                Event::End(b) if b.local_name().into_inner() == tag => {
+                    if depth == 0 {
+                        break;
+                    }
+                    depth -= 1;
+                }
+                Event::Start(b) if b.local_name().into_inner() == tag => {
+                    depth += 1;
+                }
+                Event::Eof => return Err(ParsingError::Eof),
+                _ => {}
             }
             if !wrote_ns {
                 if let Event::Start(a) = &mut self.current {
@@ -633,15 +648,21 @@ impl<'a, R: io::BufRead> XmlParser<'a, R> {
     ) -> Result<CopiedSubtree, ParsingError> {
         let mut writer = quick_xml::writer::Writer::new(io::Cursor::new(Vec::new()));
         let mut namespaces: IndexMap<String, String> = IndexMap::new();
-
+        // See `copy_buffer_till` for why this depth counter is required.
+        let mut depth: usize = 0;
         loop {
-            if let Event::End(b) = self.peek()
-                && b.local_name().into_inner() == tag
-            {
-                break;
-            }
-            if let Event::Eof = self.peek() {
-                return Err(ParsingError::Eof);
+            match self.peek() {
+                Event::End(b) if b.local_name().into_inner() == tag => {
+                    if depth == 0 {
+                        break;
+                    }
+                    depth -= 1;
+                }
+                Event::Start(b) if b.local_name().into_inner() == tag => {
+                    depth += 1;
+                }
+                Event::Eof => return Err(ParsingError::Eof),
+                _ => {}
             }
 
             // Record prefix usage on Start/Empty. We resolve NOW so that bindings
@@ -1770,5 +1791,39 @@ mod tests {
         let mut parser = create_parser(xml);
         parser.open(None, "root").expect("open root");
         assert_eq!(parser.tag_string().unwrap().as_ref(), "line1\nline2");
+    }
+
+    #[test]
+    fn test_copy_buffer_till_handles_nested_same_name() {
+        // A subtree whose payload legitimately nests an element with the
+        // SAME local name as the terminator (e.g., <config> inside <config>).
+        let xml = r#"<config><top xmlns="urn:x"><config>inner</config></top></config>"#;
+        let mut parser = create_parser(xml);
+        parser.open(None, "config").expect("open outer config");
+        let copied = parser
+            .copy_buffer_till("config")
+            .expect("copy till outer </config>");
+        assert_eq!(
+            copied.as_ref(),
+            r#"<top xmlns="urn:x"><config>inner</config></top>"#
+        );
+        // The parser must now be positioned on the OUTER </config>, not
+        // desynced: close() consumes it cleanly.
+        parser.close().expect("close consumes the outer </config>");
+    }
+
+    #[test]
+    fn test_copy_buffer_till_with_namespaces_handles_nested_same_name() {
+        let xml = r#"<filter><a xmlns="urn:x"><filter>deep</filter></a></filter>"#;
+        let mut parser = create_parser(xml);
+        parser.open(None, "filter").expect("open outer filter");
+        let subtree = parser
+            .copy_buffer_till_with_namespaces("filter")
+            .expect("copy till outer </filter>");
+        assert_eq!(
+            subtree.xml.as_ref(),
+            r#"<a xmlns="urn:x"><filter>deep</filter></a>"#
+        );
+        parser.close().expect("close consumes the outer </filter>");
     }
 }

--- a/crates/netconf-proto/src/yang_push/filters.rs
+++ b/crates/netconf-proto/src/yang_push/filters.rs
@@ -362,7 +362,7 @@ impl XmlSerialize for DatastoreXPathFilter {
         let mut new_namespaces: IndexMap<Namespace<'_>, String> =
             IndexMap::with_capacity(self.namespaces.len() + 1);
         for (prefix, namespace) in &self.namespaces {
-            let ns = Namespace(namespace.as_bytes());
+            let ns = Namespace(namespace);
             new_namespaces.insert(ns, prefix.clone().into());
         }
         if writer.get_namespace_prefix(YANG_PUSH_NS).is_none()
@@ -425,7 +425,7 @@ impl XmlSerialize for DatastoreSubtreeFilter {
         let mut new_namespaces: IndexMap<Namespace<'_>, String> =
             IndexMap::with_capacity(self.namespaces.len() + 1);
         for (prefix, namespace) in &self.namespaces {
-            let ns = Namespace(namespace.as_bytes());
+            let ns = Namespace(namespace);
             new_namespaces.insert(ns, prefix.clone().into());
         }
         if writer.get_namespace_prefix(YANG_PUSH_NS).is_none()
@@ -459,7 +459,7 @@ impl<'a> XmlDeserialize<'a, DatastoreSubtreeFilter> for DatastoreSubtreeFilter {
                 expecting: "<datastore-subtree-filter>".to_string(),
                 found: parser.peek().clone().into_owned(),
             })??;
-        let subtree = parser.copy_buffer_till_with_namespaces(b"datastore-subtree-filter")?;
+        let subtree = parser.copy_buffer_till_with_namespaces("datastore-subtree-filter")?;
 
         parser.close()?;
         Ok(Self {
@@ -548,7 +548,7 @@ impl XmlSerialize for StreamXPathFilter {
         let mut new_namespaces: IndexMap<Namespace<'_>, String> =
             IndexMap::with_capacity(self.namespaces.len() + 1);
         for (prefix, namespace) in &self.namespaces {
-            let ns = Namespace(namespace.as_bytes());
+            let ns = Namespace(namespace);
             new_namespaces.insert(ns, prefix.clone().into());
         }
         if writer
@@ -613,7 +613,7 @@ impl XmlSerialize for StreamSubtreeFilter {
         let mut new_namespaces: IndexMap<Namespace<'_>, String> =
             IndexMap::with_capacity(self.namespaces.len() + 1);
         for (prefix, namespace) in &self.namespaces {
-            let ns = Namespace(namespace.as_bytes());
+            let ns = Namespace(namespace);
             new_namespaces.insert(ns, prefix.clone().into());
         }
         if writer
@@ -650,7 +650,7 @@ impl<'a> XmlDeserialize<'a, StreamSubtreeFilter> for StreamSubtreeFilter {
                 expecting: "<stream-subtree-filter>".to_string(),
                 found: parser.peek().clone().into_owned(),
             })??;
-        let subtree = parser.copy_buffer_till_with_namespaces(b"stream-subtree-filter")?;
+        let subtree = parser.copy_buffer_till_with_namespaces("stream-subtree-filter")?;
 
         parser.close()?;
         Ok(Self {

--- a/crates/netconf-proto/src/yang_push/mod.rs
+++ b/crates/netconf-proto/src/yang_push/mod.rs
@@ -42,11 +42,11 @@ mod tests;
 pub mod types;
 
 pub const YANG_PUSH_NS: Namespace<'static> =
-    Namespace(b"urn:ietf:params:xml:ns:yang:ietf-yang-push");
+    Namespace("urn:ietf:params:xml:ns:yang:ietf-yang-push");
 pub const SUBSCRIBED_NOTIFICATIONS_NS: Namespace<'static> =
-    Namespace(b"urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications");
+    Namespace("urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications");
 pub const DISTRIBUTED_NOTIF_NS: Namespace<'static> =
-    Namespace(b"urn:ietf:params:xml:ns:yang:ietf-distributed-notif");
+    Namespace("urn:ietf:params:xml:ns:yang:ietf-distributed-notif");
 
 pub const YANG_PUSH_REVISION: Namespace<'static> =
-    Namespace(b"urn:ietf:params:xml:ns:yang:ietf-yang-push-revision");
+    Namespace("urn:ietf:params:xml:ns:yang:ietf-yang-push-revision");


### PR DESCRIPTION
Upgrades `quick-xml` to 0.42 and fixes four defects in the XML parsing primitives that the upgrade work surfaced.